### PR TITLE
fix: correct invalid expose syntax in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - API_PORT=8000
       - API_WORKERS=${API_WORKERS:-4} # 服务器生产环境默认 4 workers
     expose:
-      - "8000:8000"
+      - "8000"
     volumes:
       - ./uploads:/app/uploads
       - ./migrations:/app/migrations


### PR DESCRIPTION
## 修复描述 (Description)

**问题背景：**
在 Windows 环境下使用 Docker Desktop 启动项目时，执行 `docker compose up -d` 会触发 Go 语言底层的解析错误：
`Error response from daemon: strconv.ParseUint: parsing "8000:8000": invalid syntax`
这导致 `sag_api` 容器无法正常创建和启动。
<img width="1267" height="88" alt="image" src="https://github.com/user-attachments/assets/30582336-16f6-48ab-b702-607efb21a424" />
**错误原因：**
在 `docker-compose.yml` 中，`expose` 字段仅用于声明容器间内部通信的端口，其语法仅接受单个端口数字或列表，而不支持 `宿主机:容器` 的映射格式（该格式仅适用于 `ports` 字段）。

**解决方案：**
将 `api` 服务下的 `expose: - "8000:8000"` 修正为标准的 `expose: - "8000"`。

**验证情况：**
已经在 Windows 11 环境下进行了本地验证，修改后容器可以顺利通过编译并正常启动，不再报语法解析错误。

