### PR TITLE
feat: 支持自定义 rerank endpoint

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -225,7 +225,10 @@ API Key 只会显示“已配置 / 未配置”，不会在界面和接口响应
 ```env
 EMBEDDING_API_KEY=你的_embedding_key
 LLM_API_KEY=你的_llm_key
+RERANK_BASE_URL=https://api.your-provider.com/v1/rerank
 ```
+
+默认情况下，重排序请求会基于 `LLM_BASE_URL` 追加 `/reranks`，例如 `https://api.302ai.cn/v1/reranks`。只有当平台需要 `/v1/rerank` 等不同完整 endpoint 时，才配置 `RERANK_BASE_URL`。
 
 如果没有配置 API Key，系统会使用本地 deterministic fallback，方便跑测试和看界面；真实检索效果请配置远程模型。
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,10 @@ API keys only show as "Configured / Not configured". Plaintext keys are not echo
 ```env
 EMBEDDING_API_KEY=your_embedding_key
 LLM_API_KEY=your_llm_key
+RERANK_BASE_URL=https://api.your-provider.com/v1/rerank
 ```
+
+By default, rerank requests use `LLM_BASE_URL` and append `/reranks`, for example `https://api.302ai.cn/v1/reranks`. Set `RERANK_BASE_URL` only when your provider needs a different full endpoint such as `/v1/rerank`.
 
 If no API key is configured, the system uses a local deterministic fallback. This is useful for tests and UI inspection, but real retrieval quality requires remote models.
 

--- a/src/ai/rerank-client.ts
+++ b/src/ai/rerank-client.ts
@@ -45,7 +45,7 @@ export class QwenRerankClient implements RerankClient {
     candidates: EventRecord[];
     topK: number;
   }): Promise<string[]> {
-    const url = buildRerankUrl(settings.llmBaseUrl);
+    const url = buildRerankUrl(config.RERANK_BASE_URL ?? settings.llmBaseUrl);
     const documents = input.candidates.map((candidate) => eventToRerankDocument(candidate, input.candidates.length));
     const body = {
       model: config.RERANK_MODEL,
@@ -129,12 +129,12 @@ export class QwenRerankClient implements RerankClient {
   }
 }
 
-function buildRerankUrl(baseUrl: string): string {
+export function buildRerankUrl(baseUrl: string): string {
   const base = baseUrl.replace(/\/$/, "");
   if (base.endsWith("/v1")) {
     return `${base}/reranks`;
   }
-  if (base.endsWith("/reranks")) {
+  if (base.endsWith("/rerank") || base.endsWith("/reranks")) {
     return base;
   }
   return `${base}/v1/reranks`;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -22,6 +22,7 @@ const envSchema = z.object({
   LLM_BASE_URL: z.string().url().default(DEFAULT_302AI_BASE_URL),
   LLM_TIMEOUT_MS: z.coerce.number().int().positive().default(60_000),
   LLM_MAX_RETRIES: z.coerce.number().int().min(0).default(2),
+  RERANK_BASE_URL: z.string().url().optional(),
   RERANK_MODEL: z.string().min(1).default("qwen3-rerank"),
   RERANK_INSTRUCT: z.string().min(1).default("Given a user question, rank SAG event candidates by relevance and usefulness for retrieval-augmented question answering."),
   DEFAULT_SEARCH_MODE: z.enum(["standard", "fast"]).default("fast"),

--- a/test/rerank-client.test.ts
+++ b/test/rerank-client.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { buildRerankUrl } from "../src/ai/rerank-client.js";
+
+describe("buildRerankUrl", () => {
+  it("keeps the existing plural /v1/reranks default for provider base URLs", () => {
+    expect(buildRerankUrl("https://api.example.com")).toBe("https://api.example.com/v1/reranks");
+    expect(buildRerankUrl("https://api.example.com/")).toBe("https://api.example.com/v1/reranks");
+    expect(buildRerankUrl("https://api.example.com/v1")).toBe("https://api.example.com/v1/reranks");
+  });
+
+  it("keeps explicit rerank endpoints unchanged", () => {
+    expect(buildRerankUrl("https://api.example.com/v1/rerank")).toBe("https://api.example.com/v1/rerank");
+    expect(buildRerankUrl("https://api.example.com/v1/reranks")).toBe("https://api.example.com/v1/reranks");
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional `RERANK_BASE_URL` to let providers use a custom rerank endpoint
- Keep the existing default `/v1/reranks` behavior when no override is configured
- Document the override and cover URL construction with tests

## Tests
- `npm test -- rerank-client`
- `npm run typecheck`