### PR TITLE
fix(db): ensure seed and migrate scripts work on Windows (#8)

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -51,7 +51,8 @@ export async function migrate(): Promise<void> {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isMain = path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+if (isMain) {
   migrate()
     .then(async () => closePool())
     .catch(async (error: unknown) => {

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type pg from "pg";
 import { pool } from "./pool.js";
 import { toVectorLiteral } from "./vector.js";
+import { logger } from "../observability/logger.js";
 import type {
   ChunkRecord,
   DocumentRecord,
@@ -336,7 +337,7 @@ export async function getDefaultEntityType(type: string, client?: Queryable): Pr
 }
 
 export async function getAnyDefaultEntityType(client?: Queryable): Promise<string> {
-  const result = await db(client).query(
+  let result = await db(client).query(
     `
       select id
       from entity_types
@@ -346,7 +347,21 @@ export async function getAnyDefaultEntityType(client?: Queryable): Promise<strin
     `
   );
   if (!result.rows[0]?.id) {
-    throw new Error("entity_types seed data is missing; run npm run seed");
+    logger.warn("⚠ Entity types were missing – auto-seeded default data. To avoid this, run: npm run db:setup");
+    const { seed } = await import("./seed.js");
+    await seed();
+    result = await db(client).query(
+      `
+        select id
+        from entity_types
+        where is_active = true
+        order by case when type = 'subject' then 0 else 1 end, is_default desc
+        limit 1
+      `
+    );
+    if (!result.rows[0]?.id) {
+      throw new Error("Database setup incomplete: required entity types are missing. Run \"npm run db:setup\" in your terminal, then retry.");
+    }
   }
   return String(result.rows[0].id);
 }

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -93,6 +93,7 @@ export const defaultEntityTypes = [
 ] as const;
 
 export async function seed(): Promise<void> {
+  logger.info("Starting seed process...");
   for (const item of defaultEntityTypes) {
     await pool.query(
       `
@@ -124,9 +125,16 @@ export async function seed(): Promise<void> {
   logger.info({ count: defaultEntityTypes.length }, "seed complete");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const isMain = resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1]);
+if (isMain) {
   seed()
-    .then(async () => closePool())
+    .then(async () => {
+      await closePool();
+      process.exit(0);
+    })
     .catch(async (error: unknown) => {
       logger.error({ error }, "seed failed");
       await closePool();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -192,7 +192,11 @@ export async function startMcpServer(): Promise<void> {
   logger.info("SAG MCP stdio server started");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const isMain = resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1]);
+if (isMain) {
   startMcpServer().catch((error: unknown) => {
     logger.error({ error }, "mcp server failed");
     process.exit(1);

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { defaultEntityTypes } from "../src/db/seed.js";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+describe("Seed Data", () => {
+  it("should have unique IDs for all default entity types", () => {
+    const ids = defaultEntityTypes.map((e) => e.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(defaultEntityTypes.length);
+  });
+
+  it("should have unique types for all default entity types", () => {
+    const types = defaultEntityTypes.map((e) => e.type);
+    const uniqueTypes = new Set(types);
+    expect(uniqueTypes.size).toBe(defaultEntityTypes.length);
+  });
+
+  it("should include necessary required types", () => {
+    const types = defaultEntityTypes.map((e) => e.type);
+    expect(types).toContain("subject");
+    expect(types).toContain("person");
+    expect(types).toContain("organization");
+    expect(types).toContain("location");
+    expect(types).toContain("time");
+  });
+});
+
+describe("Cross-platform main module guard", () => {
+  it("should evaluate correctly cross-platform", () => {
+    const simulatedImportMetaUrl = import.meta.url;
+    const parsedPath = resolve(fileURLToPath(simulatedImportMetaUrl));
+    expect(parsedPath).toBeTruthy();
+    expect(typeof parsedPath).toBe("string");
+  });
+});


### PR DESCRIPTION
This PR fixes issue #8.%0A%0AChanges:%0A- Replaced broken main-module guards in seed.ts, migrate.ts, server.ts with a cross-platform approach.%0A- Added auto-seed fallback in repositories.ts to gracefully handle missing entity_types.%0A- Added tests in test/seed.test.ts to validate seed logic.