### PR TITLE
feat: add Dify external knowledge integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ SAG_SAG_LANGUAGE=zh
 # 本地 dev 留空时，Compose 会使用只适合本机的开发密钥。
 SAG_SECRET_KEY=
 
+# ── Dify 外部知识库（可选）────────────────────────────
+# 仅在需要接入 Dify 时执行 `make setup-dify` 自动生成；不要提交真实密钥。
+SAG_DIFY_API_KEY=
+
 # 浏览器访问后端的地址（构建期内联；修改后需重建 web 镜像）。
 NEXT_PUBLIC_API_BASE=http://localhost:8000
 # Web 默认开启页内窗口缩放；桌面客户端构建时设为 false。

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help dev api web install install-api install-web test build release release-dry-run compose-config compose-up compose-ps compose-logs compose-down compose-up-postgres compose-down-postgres
+.PHONY: help dev api web install install-api install-web test build setup-dify release release-dry-run compose-config compose-up compose-ps compose-logs compose-down compose-up-postgres compose-down-postgres
 
 help: ## 显示可用命令
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
@@ -27,6 +27,9 @@ test: ## 运行后端与 Agent Core 测试
 
 build: ## 构建前端产物
 	cd apps/web && npm run build
+
+setup-dify: ## 生成并保存可选的 Dify 外部知识库 API Key
+	python3 scripts/setup_dify.py
 
 release: ## 为已审核的 public/main 创建并推送稳定版 tag
 	@test -n "$(VERSION)" || (echo "VERSION 必填，例如：make release VERSION=1.4.0" && exit 1)

--- a/README-CN.md
+++ b/README-CN.md
@@ -276,6 +276,12 @@ curl -s http://localhost:8000/api/v1/openai/<AGENT_ID>/chat/completions \
 
 返回标准 `chat.completion`，并额外提供 `sag.citations` 引用字段；标准客户端会忽略未知字段。设置 `"stream": true` 后以 SSE 分块返回。
 
+### 作为 Dify 外部知识库
+
+SAG 可以通过专用兼容端点接入 Dify 的“连接外部知识库”，无需修改 Dify
+源码。密钥、Docker 网络、Source ID 与控制台配置步骤见
+[`docs/dify-integration.md`](docs/dify-integration.md)。
+
 ### 运行与更新
 
 ```bash

--- a/apps/api/sag_api/api/v1/__init__.py
+++ b/apps/api/sag_api/api/v1/__init__.py
@@ -5,6 +5,7 @@ from sag_api.api.v1 import (
     agents,
     attachments,
     auth,
+    dify,
     documents,
     insights,
     jobs,
@@ -18,6 +19,7 @@ from sag_api.api.v1 import (
 api_router = APIRouter(prefix="/api/v1")
 for _module in (
     auth,
+    dify,
     sources,
     documents,
     insights,

--- a/apps/api/sag_api/api/v1/dify.py
+++ b/apps/api/sag_api/api/v1/dify.py
@@ -1,0 +1,100 @@
+"""Dify 外部知识库兼容层。"""
+
+from __future__ import annotations
+
+from secrets import compare_digest
+
+from fastapi import APIRouter, Depends, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sag_api.core.config import settings
+from sag_api.core.db import get_session
+from sag_api.core.deps import get_engine_manager
+from sag_api.core.errors import (
+    ForbiddenError,
+    ServiceUnavailableError,
+    ValidationError,
+)
+from sag_api.sag import EngineManager
+from sag_api.schemas.dify import (
+    DifyRetrievalRecord,
+    DifyRetrievalRequest,
+    DifyRetrievalResponse,
+)
+from sag_api.services.retrieval_service import retrieve_relevant_sections
+from sag_api.services.source_service import get_source
+
+router = APIRouter(prefix="/dify", tags=["dify"])
+
+
+def _require_dify_api_key(
+    authorization: str | None = Header(default=None),
+) -> None:
+    expected = settings.dify_api_key
+    if not expected:
+        raise ServiceUnavailableError("Dify integration is not configured")
+    scheme, _, supplied = (authorization or "").partition(" ")
+    if (
+        scheme.lower() != "bearer"
+        or not supplied
+        or not compare_digest(supplied, expected)
+    ):
+        raise ForbiddenError("Invalid Dify API key")
+
+
+def _section_title(source_name: str, heading: str) -> str:
+    heading = heading.strip()
+    return f"{source_name} — {heading}" if heading else source_name
+
+
+@router.post("/retrieval", response_model=DifyRetrievalResponse)
+async def retrieval(
+    body: DifyRetrievalRequest,
+    _authorized: None = Depends(_require_dify_api_key),
+    session: AsyncSession = Depends(get_session),
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> DifyRetrievalResponse:
+    """Adapt one SAG source to Dify's external knowledge retrieval contract."""
+
+    knowledge_id = body.knowledge_id.strip()
+    query = body.query.strip()
+    if not knowledge_id and not query:
+        return DifyRetrievalResponse()
+    if not knowledge_id or not query:
+        raise ValidationError(
+            "knowledge_id and query are required for retrieval"
+        )
+    if body.metadata_condition is not None:
+        raise ValidationError(
+            "metadata_condition is not supported by the SAG Dify integration"
+        )
+
+    source = await get_source(session, knowledge_id)
+    outcome = await retrieve_relevant_sections(
+        engine_manager,
+        [source],
+        query,
+        strategy="multi",
+        top_k=body.retrieval_setting.top_k,
+    )
+    records = [
+        DifyRetrievalRecord(
+            content=section.content,
+            title=_section_title(source.name, section.heading),
+            score=section.score,
+            metadata={
+                "document_id": (
+                    f"{source.id}:{section.chunk_id}"
+                    if section.chunk_id
+                    else source.id
+                ),
+                "source_id": source.id,
+                "source_name": source.name,
+                "chunk_id": section.chunk_id or "",
+                "heading": section.heading,
+            },
+        )
+        for section in outcome.sections
+        if section.score >= body.retrieval_setting.score_threshold
+    ]
+    return DifyRetrievalResponse(records=records)

--- a/apps/api/sag_api/core/config.py
+++ b/apps/api/sag_api/core/config.py
@@ -47,6 +47,8 @@ class Settings(BaseSettings):
     cors_origins: Annotated[list[str], NoDecode] = Field(default_factory=lambda: ["http://localhost:3000"])
     # 关闭后仅允许首个用户注册（部署引导），其余返回 403
     allow_registration: bool = True
+    # Dify 外部知识库调用的专用服务密钥；未配置时兼容端点拒绝服务。
+    dify_api_key: str | None = None
 
     # ── sag 元数据库 ───────────────────────────────────────────────────
     database_url: str = "sqlite+aiosqlite:///./.data/sag.db"

--- a/apps/api/sag_api/schemas/dify.py
+++ b/apps/api/sag_api/schemas/dify.py
@@ -1,0 +1,32 @@
+"""Dify 外部知识库检索协议。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DifyRetrievalSetting(BaseModel):
+    top_k: int = Field(default=4, ge=1, le=50)
+    score_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class DifyRetrievalRequest(BaseModel):
+    knowledge_id: str = Field(default="", max_length=64)
+    query: str = Field(default="", max_length=4000)
+    retrieval_setting: DifyRetrievalSetting = Field(
+        default_factory=DifyRetrievalSetting
+    )
+    metadata_condition: dict[str, Any] | None = None
+
+
+class DifyRetrievalRecord(BaseModel):
+    content: str
+    title: str
+    score: float
+    metadata: dict[str, Any]
+
+
+class DifyRetrievalResponse(BaseModel):
+    records: list[DifyRetrievalRecord] = Field(default_factory=list)

--- a/apps/api/tests/test_dify_retrieval.py
+++ b/apps/api/tests/test_dify_retrieval.py
@@ -1,0 +1,198 @@
+"""Dify 外部知识库兼容检索的 HTTP 契约。"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+
+def _set_dify_key(monkeypatch, settings, value: str | None) -> None:
+    """Allow the contract tests to describe the setting before it exists."""
+
+    monkeypatch.setitem(settings.__dict__, "dify_api_key", value)
+
+
+@pytest.mark.asyncio
+async def test_dify_retrieval_maps_one_source_to_traceable_records(monkeypatch):
+    from sag_api.core.config import settings
+    from sag_api.core.deps import get_engine_manager
+    from sag_api.main import app
+    from sag_api.sag.dto import RetrievedSection, SearchOutcome
+
+    class RecordingEngine:
+        strategy: str | None = None
+        top_k: int | None = None
+        source_id: str | None = None
+
+        async def provision(self, *_args):
+            return None
+
+        async def search_many(self, targets, query, *, strategy=None, top_k=None):
+            assert len(targets) == 1
+            source_config_id, source = targets[0]
+            self.strategy = strategy
+            self.top_k = top_k
+            self.source_id = source.id
+            return SearchOutcome(
+                query=query,
+                sections=[
+                    RetrievedSection(
+                        chunk_id="chunk-123",
+                        heading="关键章节",
+                        content="星河计划的内部识别码是 SAG-TRACE-7291。",
+                        score=0.91,
+                        source_config_id=source_config_id,
+                    ),
+                    RetrievedSection(
+                        chunk_id="chunk-low",
+                        heading="低分章节",
+                        content="这条记录应被 Dify 的阈值过滤。",
+                        score=0.55,
+                        source_config_id=source_config_id,
+                    ),
+                ],
+            )
+
+    engine = RecordingEngine()
+    _set_dify_key(monkeypatch, settings, "dify-secret")
+    app.dependency_overrides[get_engine_manager] = lambda: engine
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+                registered = await client.post(
+                    "/api/v1/auth/register",
+                    json={
+                        "email": f"dify-{uuid.uuid4().hex}@t.com",
+                        "password": "password123",
+                    },
+                )
+                assert registered.status_code == 201, registered.text
+                user_headers = {
+                    "Authorization": f"Bearer {registered.json()['access_token']}"
+                }
+                source = await client.post(
+                    "/api/v1/sources",
+                    headers=user_headers,
+                    json={"name": "Dify 接入测试源"},
+                )
+                assert source.status_code == 201, source.text
+
+                response = await client.post(
+                    "/api/v1/dify/retrieval",
+                    headers={"Authorization": "Bearer dify-secret"},
+                    json={
+                        "knowledge_id": source.json()["id"],
+                        "query": "星河计划的识别码是什么",
+                        "retrieval_setting": {
+                            "top_k": 3,
+                            "score_threshold": 0.6,
+                        },
+                    },
+                )
+
+        assert response.status_code == 200, response.text
+        assert engine.strategy == "multi"
+        assert engine.top_k == 11
+        assert engine.source_id == source.json()["id"]
+        assert response.json() == {
+            "records": [
+                {
+                    "content": "星河计划的内部识别码是 SAG-TRACE-7291。",
+                    "title": "Dify 接入测试源 — 关键章节",
+                    "score": 0.655,
+                    "metadata": {
+                        "document_id": f"{source.json()['id']}:chunk-123",
+                        "source_id": source.json()["id"],
+                        "source_name": "Dify 接入测试源",
+                        "chunk_id": "chunk-123",
+                        "heading": "关键章节",
+                    },
+                }
+            ]
+        }
+    finally:
+        app.dependency_overrides.pop(get_engine_manager, None)
+
+
+@pytest.mark.asyncio
+async def test_dify_retrieval_handles_auth_probe_and_invalid_requests(
+    monkeypatch,
+):
+    from sag_api.core.config import settings
+    from sag_api.main import app
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+            _set_dify_key(monkeypatch, settings, None)
+            disabled = await client.post("/api/v1/dify/retrieval", json={})
+            assert disabled.status_code == 503
+
+            _set_dify_key(monkeypatch, settings, "dify-secret")
+            missing = await client.post("/api/v1/dify/retrieval", json={})
+            assert missing.status_code == 403
+            wrong = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer wrong"},
+                json={},
+            )
+            assert wrong.status_code == 403
+
+            probe = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer dify-secret"},
+                json={
+                    "knowledge_id": "",
+                    "query": "",
+                    "retrieval_setting": {"top_k": 1, "score_threshold": 0},
+                },
+            )
+            assert probe.status_code == 200
+            assert probe.json() == {"records": []}
+
+            partial = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer dify-secret"},
+                json={"knowledge_id": "source-id", "query": ""},
+            )
+            assert partial.status_code == 422
+            assert partial.json()["error"]["code"] == "validation_error"
+
+            metadata_filter = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer dify-secret"},
+                json={
+                    "knowledge_id": "source-id",
+                    "query": "metadata",
+                    "metadata_condition": {
+                        "logical_operator": "and",
+                        "conditions": [],
+                    },
+                },
+            )
+            assert metadata_filter.status_code == 422
+            assert metadata_filter.json()["error"]["code"] == "validation_error"
+
+            invalid_settings = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer dify-secret"},
+                json={
+                    "knowledge_id": "source-id",
+                    "query": "invalid",
+                    "retrieval_setting": {
+                        "top_k": 0,
+                        "score_threshold": 1.1,
+                    },
+                },
+            )
+            assert invalid_settings.status_code == 422
+
+            unknown_source = await client.post(
+                "/api/v1/dify/retrieval",
+                headers={"Authorization": "Bearer dify-secret"},
+                json={"knowledge_id": uuid.uuid4().hex, "query": "unknown"},
+            )
+            assert unknown_source.status_code == 404

--- a/apps/api/tests/test_dify_setup.py
+++ b/apps/api/tests/test_dify_setup.py
@@ -1,0 +1,78 @@
+"""可选 Dify 初始化命令的密钥落盘行为。"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _PROJECT_ROOT / "scripts" / "setup_dify.py"
+
+
+def _run_setup(env_file: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--env-file",
+            str(env_file),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_key(env_file: Path) -> str:
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if line.startswith("SAG_DIFY_API_KEY="):
+            return line.partition("=")[2]
+    raise AssertionError("SAG_DIFY_API_KEY was not written")
+
+
+def test_setup_dify_creates_an_idempotent_env_file(tmp_path):
+    env_file = tmp_path / ".env"
+
+    first = _run_setup(env_file)
+    assert first.returncode == 0, first.stderr
+    first_key = _read_key(env_file)
+    assert len(first_key) >= 32
+    assert f"API Key: {first_key}" in first.stdout
+    assert "Endpoint: http://sag:8000/api/v1/dify" in first.stdout
+    if os.name != "nt":
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+
+    original = env_file.read_text(encoding="utf-8")
+    second = _run_setup(env_file)
+    assert second.returncode == 0, second.stderr
+    assert env_file.read_text(encoding="utf-8") == original
+    assert f"API Key: {first_key}" in second.stdout
+
+
+def test_setup_dify_fills_empty_key_and_preserves_existing_configuration(
+    tmp_path,
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "WEB_PORT=3100\nSAG_DIFY_API_KEY=\nSAG_LLM_MODEL=test-model\n",
+        encoding="utf-8",
+    )
+
+    filled = _run_setup(env_file)
+    assert filled.returncode == 0, filled.stderr
+    generated_key = _read_key(env_file)
+    assert generated_key
+    assert "WEB_PORT=3100\n" in env_file.read_text(encoding="utf-8")
+    assert "SAG_LLM_MODEL=test-model\n" in env_file.read_text(encoding="utf-8")
+
+    env_file.write_text(
+        "WEB_PORT=3100\nSAG_DIFY_API_KEY=keep-this-key\n",
+        encoding="utf-8",
+    )
+    preserved = _run_setup(env_file)
+    assert preserved.returncode == 0, preserved.stderr
+    assert _read_key(env_file) == "keep-this-key"
+    assert "API Key: keep-this-key" in preserved.stdout

--- a/compose.dify.yaml
+++ b/compose.dify.yaml
@@ -1,0 +1,14 @@
+# 仅在需要把 SAG 作为 Dify 外部知识库时叠加此文件。
+# 使用：DIFY_NETWORK_NAME=docker_default docker compose -f compose.yaml -f compose.dify.yaml up -d --build
+services:
+  api:
+    networks:
+      default: {}
+      dify:
+        aliases:
+          - sag
+
+networks:
+  dify:
+    external: true
+    name: ${DIFY_NETWORK_NAME:-docker_default}

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,8 @@ services:
       SAG_SECRET_KEY: ${SAG_SECRET_KEY:-dev-insecure-secret-change-me-in-production-0123456789}
       SAG_CORS_ORIGINS: ${SAG_CORS_ORIGINS:-http://localhost:3000}
       SAG_ALLOW_REGISTRATION: ${SAG_ALLOW_REGISTRATION:-false}
+      # 可选 Dify 外部知识库兼容端点；留空时端点拒绝服务。
+      SAG_DIFY_API_KEY: ${SAG_DIFY_API_KEY:-}
       # 四个斜杠表示容器内绝对路径 /data/sag.db。
       SAG_DATABASE_URL: sqlite+aiosqlite:////data/sag.db
       SAG_DATA_DIR: /data/engine

--- a/docs/dify-integration.md
+++ b/docs/dify-integration.md
@@ -1,0 +1,133 @@
+# 将 SAG 作为 Dify 外部知识库
+
+SAG 可以实现 Dify 的外部知识库检索协议。文档上传、解析、分块、Embedding
+和 event–entity 抽取仍由 SAG 完成；Dify 只在应用运行时向 SAG 请求检索证据。
+该能力完全可选，不会替换或修改 Dify、SAG 的其他知识库功能。
+
+## 前提
+
+- SAG 与 Dify 均通过 Docker Compose 运行。
+- SAG 信源中的文档已经处理完成。
+- Dify 容器可以通过一个共同的 Docker 网络访问 SAG API。
+- 当前集成按 SAG 的单用户边界设计，一个 Dify 外部知识库绑定一个 SAG 信源。
+
+## 1. 初始化 SAG 的 Dify 密钥
+
+在 SAG 仓库根目录执行：
+
+```bash
+make setup-dify
+```
+
+命令会生成强随机密钥并保存到被 Git 忽略的根目录 `.env`，同时输出：
+
+```text
+Endpoint: http://sag:8000/api/v1/dify
+API Key: <生成的密钥>
+```
+
+已有非空 `SAG_DIFY_API_KEY` 时不会覆盖。未执行该命令且未手工设置密钥时，
+Dify 兼容端点返回 503，SAG 的默认启动和其他功能不受影响。
+
+## 2. 将 SAG API 加入 Dify 网络
+
+先在 Dify 的 `docker` 目录确认网络名：
+
+```bash
+docker compose ps
+docker network ls
+```
+
+按默认目录名启动的 Dify 通常使用 `docker_default`。在 SAG 根目录叠加可选
+Compose 文件启动：
+
+```bash
+DIFY_NETWORK_NAME=docker_default \
+docker compose -f compose.yaml -f compose.dify.yaml up -d --build
+```
+
+这只会把 SAG 的 `api` 服务加入指定网络，并在该网络中提供主机别名 `sag`。
+不要把 Dify 兼容端点直接暴露到公网。
+
+## 3. 配置 Dify 的容器访问策略
+
+Dify 的外部知识库请求经过 SSRF Proxy。请在 Dify 的 `docker/.env` 中设置：
+
+```dotenv
+SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=sag
+SSRF_DEFAULT_TIME_OUT=30
+SSRF_DEFAULT_READ_TIME_OUT=30
+```
+
+`SSRF_DEFAULT_TIME_OUT` 和 `SSRF_DEFAULT_READ_TIME_OUT` 都必须大于 SAG 的
+单信源检索超时，并预留网络开销。Dify 会单独使用读取超时；只提高总超时仍可能
+在默认 5 秒后中断。启用默认的 `multi → vector` 回退时，一次请求最坏可能连续
+消耗两次单信源超时，因此建议两个 Dify 超时都大于
+`2 × SAG_SEARCH_SOURCE_TIMEOUT + 网络余量`。默认 SAG 单源超时为 12 秒时可设
+30 秒；如果 SAG 提高到 45 秒，Dify 建议至少设为 100 秒。
+
+重新创建 Dify 的相关服务使配置生效：
+
+```bash
+docker compose up -d --force-recreate api ssrf_proxy
+```
+
+这里仅修改部署者自己的 Dify 配置，不需要改动 Dify 源码。
+
+## 4. 查找 SAG Source ID
+
+打开 SAG 的目标信源页面，地址格式为：
+
+```text
+http://localhost:3000/knowledge/<SOURCE_ID>
+```
+
+最后一段 `<SOURCE_ID>` 就是 Dify 要填写的 Knowledge ID。也可以使用带 SAG
+用户 JWT 的 `GET /api/v1/sources` 查询信源列表及其 `id`。
+
+## 5. 在 Dify 创建外部知识库
+
+1. 进入 **知识库 → 创建知识库 → 连接外部知识库**。
+2. 新建外部知识 API：
+   - 名称：例如 `SAG`
+   - Endpoint：`http://sag:8000/api/v1/dify`
+   - API Key：`make setup-dify` 输出的密钥
+3. 创建外部知识库，将 Knowledge ID 填为目标 SAG `source.id`。
+4. 使用命中测试，或在应用中添加知识检索节点验证结果和引用。
+
+Dify 会自动在 Endpoint 后追加 `/retrieval`，所以 Endpoint 中不要重复填写
+`/retrieval`，也不要把容器内 HTTP 地址误写成 HTTPS。
+
+## 检索协议
+
+Dify 最终调用：
+
+```http
+POST /api/v1/dify/retrieval
+Authorization: Bearer <SAG_DIFY_API_KEY>
+Content-Type: application/json
+```
+
+请求示例：
+
+```json
+{
+  "knowledge_id": "<SAG_SOURCE_ID>",
+  "query": "星河计划的识别码是什么",
+  "retrieval_setting": {
+    "top_k": 5,
+    "score_threshold": 0.3
+  }
+}
+```
+
+兼容端点固定使用 SAG `multi` 检索，并沿用 SAG 已有的超时、失败或空结果时
+回退 `vector` 的行为。返回的 `records` 带有 `source_id`、`source_name`、
+`chunk_id`、`heading` 和 `document_id`，用于 Dify 引用溯源。
+
+## 当前限制
+
+- `metadata_condition` 首版不支持，传入时返回 422，不会静默忽略。
+- 一个 Dify 外部知识库只绑定一个 SAG `source.id`。
+- SAG 当前是单用户产品，不将此接口作为跨租户知识隔离边界。
+- 该接口只提供检索证据，不负责从 Dify 上传、更新或删除 SAG 文档。

--- a/scripts/setup_dify.py
+++ b/scripts/setup_dify.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate and persist the optional Dify integration key."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+from pathlib import Path
+
+_SETTING_NAME = "SAG_DIFY_API_KEY"
+_DIFY_ENDPOINT = "http://sag:8000/api/v1/dify"
+
+
+def _secure_env_file(env_file: Path) -> None:
+    if os.name != "nt":
+        env_file.chmod(0o600)
+
+
+def configure_dify_key(env_file: Path) -> str:
+    text = env_file.read_text(encoding="utf-8") if env_file.exists() else ""
+    lines = text.splitlines(keepends=True)
+
+    for index, line in enumerate(lines):
+        body = line.rstrip("\r\n")
+        ending = line[len(body) :]
+        name, separator, value = body.partition("=")
+        if separator and name.strip() == _SETTING_NAME:
+            existing = value.strip()
+            if existing:
+                _secure_env_file(env_file)
+                return existing
+            key = secrets.token_urlsafe(32)
+            lines[index] = f"{_SETTING_NAME}={key}{ending}"
+            env_file.parent.mkdir(parents=True, exist_ok=True)
+            env_file.write_text("".join(lines), encoding="utf-8")
+            _secure_env_file(env_file)
+            return key
+
+    key = secrets.token_urlsafe(32)
+    prefix = text
+    if prefix and not prefix.endswith(("\n", "\r")):
+        prefix += "\n"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(
+        f"{prefix}{_SETTING_NAME}={key}\n",
+        encoding="utf-8",
+    )
+    _secure_env_file(env_file)
+    return key
+
+
+def main() -> int:
+    project_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Configure the opt-in SAG Dify external knowledge API key."
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=project_root / ".env",
+        help="Path to the SAG .env file (default: project root .env).",
+    )
+    args = parser.parse_args()
+
+    key = configure_dify_key(args.env_file)
+    print("Dify external knowledge integration is configured.")
+    print(f"Endpoint: {_DIFY_ENDPOINT}")
+    print(f"API Key: {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a Dify-compatible `POST /api/v1/dify/retrieval` endpoint that maps `knowledge_id` to one SAG source and uses the existing `multi` retrieval strategy
- add dedicated `SAG_DIFY_API_KEY` Bearer authentication, an idempotent `make setup-dify` initializer, and an optional Compose network overlay
- add integration documentation covering Source ID lookup, Dify SSRF/timeout settings, Docker networking, and console configuration
- add focused API and setup-script tests without changing SAG ingestion, storage, Agent, MCP, or Web UI behavior

## Why

Dify external knowledge bases require a specific retrieval request/response contract. SAG previously had no compatible endpoint, so users could not connect an existing SAG source through Dify's “Connect External Knowledge Base” flow without a separate adapter.

This change keeps the integration opt-in and provides the smallest compatibility layer inside SAG while reusing the current retrieval implementation.

## Behavior and impact

- one Dify external knowledge base maps to one SAG `source.id`
- retrieval is fixed to the existing `multi` strategy and keeps SAG's current fallback behavior
- empty probe requests return an empty record list; malformed filters and parameter ranges are rejected explicitly
- response metadata preserves source, document, chunk, and heading information for traceability
- the default SAG Compose startup remains unchanged unless `compose.dify.yaml` is explicitly included

## Validation

- `pytest -q`: 195 passed
- Dify-specific tests: 4 passed
- Ruff: all checks passed
- default Compose configuration: passed
- Dify overlay Compose configuration: passed
- manual Docker E2E: Dify called `http://sag:8000/api/v1/dify/retrieval`, received HTTP 200, and retrieved two SAG chunks for the semantic query `星河计划的识别码是什么`
