### PR TITLE
fix: bootstrap PostgreSQL engine schema before source provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,50 @@ jobs:
       - name: 测试（离线全套）
         run: python -m pytest -q
 
+  backend-postgres-e2e:
+    name: 后端 · PostgreSQL E2E
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sag
+          POSTGRES_PASSWORD: sag-e2e-password
+          POSTGRES_DB: sag_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U sag -d sag_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      SAG_E2E_POSTGRES: "1"
+      SAG_ENVIRONMENT: prod
+      SAG_SECRET_KEY: postgres-e2e-secret-key-at-least-32-bytes
+      SAG_DATABASE_URL: postgresql+asyncpg://sag:sag-e2e-password@127.0.0.1:5432/sag_e2e
+      SAG_SAG_RELATIONAL_PROVIDER: postgres
+      SAG_SAG_VECTOR_PROVIDER: pgvector
+      SAG_SAG_PG_HOST: 127.0.0.1
+      SAG_SAG_PG_PORT: "5432"
+      SAG_SAG_PG_USER: sag
+      SAG_SAG_PG_PASSWORD: sag-e2e-password
+      SAG_SAG_PG_DATABASE: sag_e2e
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: apps/api/pyproject.toml
+      - name: 安装 PostgreSQL E2E 依赖
+        run: pip install -e ".[dev,postgres]"
+      - name: 测试全新 PostgreSQL 引擎初始化
+        run: python -m pytest -q -s tests/test_postgres_schema_e2e.py
+
   frontend:
     name: 前端 · tsc + next build
     runs-on: ubuntu-latest

--- a/apps/api/sag_api/sag/engine_manager.py
+++ b/apps/api/sag_api/sag/engine_manager.py
@@ -209,6 +209,7 @@ class EngineManager:
         self._create_lock = asyncio.Lock()
         self._lifecycle_gate = _EngineLifecycleGate()
         self._cache_size = max(1, settings.engine_cache_size)
+        self._schema_ready = False
         self._universe_indexes_ready = False
 
     async def _ensure_universe_query_indexes(self) -> None:
@@ -339,6 +340,22 @@ class EngineManager:
             overrides = source.config.get("engine")
         return build_engine_config(self._settings, overrides=overrides)
 
+    async def _ensure_engine_schema(self, engine: DataEngine) -> None:
+        if self._schema_ready:
+            return
+
+        from sqlalchemy.exc import SQLAlchemyError
+
+        from sag_api.core.errors import UpstreamError
+
+        try:
+            with map_sag_errors():
+                await engine.init_schema()
+        except SQLAlchemyError as error:
+            log.exception("知识引擎数据库结构初始化失败")
+            raise UpstreamError("信源引擎初始化失败，请稍后重试") from error
+        self._schema_ready = True
+
     async def _ensure_source_config(
         self,
         source_config_id: str,
@@ -403,6 +420,7 @@ class EngineManager:
                     with map_sag_errors():
                         await engine.start()
                     try:
+                        await self._ensure_engine_schema(engine)
                         await self._ensure_source_config(source_config_id, source)
                         await self._ensure_universe_query_indexes()
                     except Exception:

--- a/apps/api/tests/test_hardening.py
+++ b/apps/api/tests/test_hardening.py
@@ -144,6 +144,36 @@ async def test_job_retry_backoff(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_engine_schema_bootstrap_retries_after_failure():
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from sag_api.core.config import settings
+    from sag_api.core.errors import UpstreamError
+    from sag_api.sag.engine_manager import EngineManager
+
+    class SchemaEngine:
+        def __init__(self):
+            self.calls = 0
+
+        async def init_schema(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise SQLAlchemyError("ddl unavailable")
+
+    manager = EngineManager(settings)
+    engine = SchemaEngine()
+
+    with pytest.raises(UpstreamError):
+        await manager._ensure_engine_schema(engine)
+    assert manager._schema_ready is False
+
+    await manager._ensure_engine_schema(engine)
+    await manager._ensure_engine_schema(engine)
+    assert manager._schema_ready is True
+    assert engine.calls == 2
+
+
+@pytest.mark.asyncio
 async def test_engine_lru_eviction():
     """超出缓存上限逐出最久未用；持锁的槽不被逐出。"""
     from sag_api.core.config import settings

--- a/apps/api/tests/test_postgres_schema_e2e.py
+++ b/apps/api/tests/test_postgres_schema_e2e.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from sqlalchemy import func, inspect, select, text
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("SAG_E2E_POSTGRES") != "1",
+    reason="requires the dedicated PostgreSQL E2E environment",
+)
+
+
+async def _table_names(async_engine) -> set[str]:
+    async with async_engine.connect() as connection:
+        return await connection.run_sync(lambda sync: set(inspect(sync).get_table_names()))
+
+
+@pytest.mark.asyncio
+async def test_fresh_postgres_bootstraps_engine_schema_before_first_source():
+    from sag_api.core.db import SessionLocal
+    from sag_api.core.db import engine as application_engine
+    from sag_api.db.models import Source
+    from sag_api.main import app
+
+    async with application_engine.begin() as connection:
+        await connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    assert "source_config" not in await _table_names(application_engine)
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            register = await client.post(
+                "/api/v1/auth/register",
+                json={"email": "postgres-e2e@example.com", "password": "password123"},
+            )
+            assert register.status_code == 201, register.text
+            headers = {"Authorization": f"Bearer {register.json()['access_token']}"}
+            created = await client.post(
+                "/api/v1/sources",
+                headers=headers,
+                json={"name": "PostgreSQL 首个信源"},
+            )
+            assert created.status_code == 201, created.text
+
+        async with SessionLocal() as session:
+            source = await session.get(Source, created.json()["id"])
+            assert source is not None
+            source_config_id = source.sag_source_config_id
+
+        # Before the fix this call fails with PostgreSQL UndefinedTable:
+        # relation "source_config" does not exist.
+        await app.state.engine_manager.provision(source_config_id, source)
+
+        from zleap.sag.db import get_engine, get_session_factory
+        from zleap.sag.db.models import EntityType, SourceConfig
+
+        engine_tables = await _table_names(get_engine())
+        assert {"source_config", "source_chunk", "source_event"} <= engine_tables
+        async with get_session_factory()() as session:
+            parent = await session.get(SourceConfig, source_config_id)
+            entity_type_count = await session.scalar(
+                select(func.count()).select_from(EntityType).where(EntityType.scope == "global")
+            )
+        assert parent is not None
+        assert parent.name == "PostgreSQL 首个信源"
+        assert entity_type_count is not None and entity_type_count > 0
+
+    # A new manager lifecycle must safely repeat the idempotent bootstrap.
+    async with app.router.lifespan_context(app):
+        async with SessionLocal() as session:
+            source = await session.get(Source, created.json()["id"])
+            assert source is not None
+        await app.state.engine_manager.provision(source.sag_source_config_id, source)


### PR DESCRIPTION
## Summary

- initialize the zleap-sag engine schema before the first `SourceConfig` query
- keep schema bootstrap process-local and idempotent, while allowing retries after initialization failures
- add unit coverage for failure/retry behavior and a real PostgreSQL/pgvector E2E regression test
- run the PostgreSQL E2E in a dedicated GitHub Actions job

## Root cause

SAG initializes its application-layer tables during startup, but a fresh PostgreSQL deployment did not initialize the zleap-sag engine tables before provisioning the first source. The first `SourceConfig` query therefore failed with `asyncpg.exceptions.UndefinedTableError: relation "source_config" does not exist`.

## Behavior and impact

The first engine slot now calls `DataEngine.init_schema()` under the existing creation lock before creating the source parent record. The ready flag is only set after a successful bootstrap, so transient SQLAlchemy failures can be retried. Subsequent source slots in the same manager lifecycle skip the extra initialization.

This change does not drop or rewrite existing data and does not replace the project's migration mechanism.

## Validation

- backend Ruff checks passed
- backend test suite: 196 passed, 1 skipped
- dedicated fresh PostgreSQL/pgvector E2E: 1 passed
- frontend typecheck and lint passed
- frontend unit suite: 50 files, 357 tests passed
- frontend production build passed
- manual production Docker Compose validation:
  - PostgreSQL, API, and Web containers became healthy
  - registration and first source creation returned HTTP 201
  - `source_config`, `source_chunk`, and `source_event` were created
  - API restart and source warmup completed successfully

Fixes #27