### PR TITLE
fix: support DeepSeek V4 agent tool routing

### DIFF
--- a/apps/api/sag_api/core/litellm_policy.py
+++ b/apps/api/sag_api/core/litellm_policy.py
@@ -14,6 +14,7 @@ from typing import Any
 from sag_api.core.config import Settings
 
 _COMPLETION_CALL_TYPES = {"completion", "acompletion"}
+_DEEPSEEK_V4_MODELS = {"deepseek-v4-flash", "deepseek-v4-pro"}
 
 
 def _thinking_override(extra_body: object) -> bool | None:
@@ -34,6 +35,11 @@ def _is_openai_route(model: str, settings: Settings) -> bool:
     if "/" in model:
         return model.split("/", 1)[0].casefold() == "openai"
     return settings.llm_provider == "openai"
+
+
+def _is_deepseek_v4(model: str) -> bool:
+    model_id = model.rsplit("/", 1)[-1].casefold()
+    return model_id in _DEEPSEEK_V4_MODELS
 
 
 def _with_allowed_openai_param(request: dict[str, Any], name: str) -> None:
@@ -66,6 +72,11 @@ def apply_litellm_completion_policy(
         normalized["extra_body"] = dict(settings.llm_extra_body)
 
     model = str(normalized.get("model") or settings.routed_llm_model)
+    if normalized.get("tools") and _is_deepseek_v4(model):
+        extra_body = dict(normalized.get("extra_body") or {})
+        extra_body["thinking"] = {"type": "disabled"}
+        normalized["extra_body"] = extra_body
+
     thinking = _thinking_override(normalized.get("extra_body"))
     if "reasoning_effort" not in normalized:
         if thinking is False or (thinking is None and "qwen" in model.casefold()):

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -116,6 +116,103 @@ def test_litellm_policy_preserves_explicit_reasoning_and_allowed_params():
     assert request["allowed_openai_params"] == ["seed", "reasoning_effort"]
 
 
+@pytest.mark.parametrize("tool_choice", ["none", "required", None])
+@pytest.mark.parametrize(
+    ("base_url", "model"),
+    [
+        ("https://api.deepseek.com", "deepseek-v4-flash"),
+        ("https://api.deepseek.com", "deepseek-v4-pro"),
+        ("https://openai-compatible.example.com/v1", "deepseek/deepseek-v4-flash"),
+    ],
+)
+def test_deepseek_v4_disables_thinking_for_every_agent_tool_turn(tool_choice, base_url, model):
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url=base_url,
+        llm_api_key="provider-key",
+        llm_model=model,
+    )
+    raw = {
+        "model": configured.routed_llm_model,
+        "messages": [],
+        "tools": [{"type": "function", "function": {"name": "search_context"}}],
+    }
+    if tool_choice is not None:
+        raw["tool_choice"] = tool_choice
+
+    request = apply_litellm_completion_policy(configured, raw)
+
+    assert request["extra_body"]["thinking"] == {"type": "disabled"}
+    if tool_choice is None:
+        assert "tool_choice" not in request
+    else:
+        assert request["tool_choice"] == tool_choice
+
+
+def test_deepseek_v4_plain_completion_keeps_provider_default_thinking():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://api.deepseek.com",
+        llm_api_key="provider-key",
+        llm_model="deepseek-v4-pro",
+    )
+
+    request = apply_litellm_completion_policy(
+        configured,
+        {"model": configured.routed_llm_model, "messages": []},
+    )
+
+    assert "extra_body" not in request
+
+
+def test_deepseek_v4_tool_policy_preserves_other_extra_body_fields():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://api.deepseek.com",
+        llm_api_key="provider-key",
+        llm_model="deepseek-v4-flash",
+        llm_extra_body={"user_id": "sag-local"},
+    )
+
+    request = apply_litellm_completion_policy(
+        configured,
+        {
+            "model": configured.routed_llm_model,
+            "messages": [],
+            "tools": [{"type": "function", "function": {"name": "search_context"}}],
+            "tool_choice": "required",
+        },
+    )
+
+    assert request["extra_body"] == {
+        "user_id": "sag-local",
+        "thinking": {"type": "disabled"},
+    }
+
+
+def test_non_deepseek_openai_compatible_tool_request_is_unchanged():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://openai-compatible.example.com/v1",
+        llm_api_key="provider-key",
+        llm_model="custom-model",
+    )
+    raw = {
+        "model": configured.routed_llm_model,
+        "messages": [],
+        "tools": [{"type": "function", "function": {"name": "search_context"}}],
+        "tool_choice": "required",
+    }
+
+    request = apply_litellm_completion_policy(configured, raw)
+
+    assert request == raw
+
+
 @pytest.mark.asyncio
 async def test_installed_litellm_policy_covers_dependency_owned_calls():
     import litellm
@@ -196,6 +293,61 @@ async def test_llm_timeout_and_retries_reach_unified_client(monkeypatch):
     assert engine.llm.model == "openai/qwen3.6-flash"
     assert engine.llm.timeout == 45
     assert engine.llm.max_retries == 3
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_agent_turn_sends_non_thinking_tool_request(monkeypatch):
+    from sag_agent import AgentMessage, CancellationToken, ModelRequest
+    from sag_api.generation import llm as generation_llm
+
+    class EmptyStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            return None
+
+    seen: dict = {}
+
+    async def fake_completion(**kwargs):
+        seen.update(kwargs)
+        return EmptyStream()
+
+    monkeypatch.setattr(generation_llm, "_litellm_completion", fake_completion)
+    client = generation_llm.LLMClient(
+        Settings(
+            _env_file=None,
+            llm_provider="openai",
+            llm_base_url="https://api.deepseek.com",
+            llm_api_key="provider-key",
+            llm_model="deepseek-v4-flash",
+        )
+    )
+    request = ModelRequest(
+        messages=(AgentMessage(role="user", content="你好"),),
+        tools=(
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_context",
+                    "description": "search",
+                    "parameters": {"type": "object"},
+                },
+            },
+        ),
+        tool_choice="none",
+        turn=1,
+    )
+
+    chunks = [chunk async for chunk in client.stream_turn(request, CancellationToken())]
+
+    assert chunks == []
+    assert seen["model"] == "openai/deepseek-v4-flash"
+    assert seen["tool_choice"] == "none"
+    assert seen["extra_body"]["thinking"] == {"type": "disabled"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- detect `deepseek-v4-flash` and `deepseek-v4-pro`, including provider-prefixed model IDs
- automatically send `thinking: {"type": "disabled"}` for DeepSeek V4 requests that expose Agent tools
- preserve SAG's existing `tool_choice` routing and leave plain completions in the provider's default thinking mode
- add policy and LLM adapter regression coverage for official and OpenAI-compatible endpoints

## Root cause

DeepSeek V4 enables thinking mode by default, but its thinking mode rejects requests containing `tool_choice`. SAG intentionally sends `tool_choice` on Agent turns to enforce deterministic tool routing, which caused the upstream API to return HTTP 400 through LiteLLM.

The fix disables DeepSeek V4 thinking only when the request contains tools. This also avoids entering the unsupported multi-turn `reasoning_content` replay path while preserving existing Agent behavior.

## Impact

Users running SAG locally can configure DeepSeek V4 through the official API or an OpenAI-compatible gateway without Agent chat failing on tool-enabled turns. Other models and non-tool DeepSeek completions are unchanged.

## Validation

- complete API test suite: `213 passed, 1 skipped`
- Ruff checks passed for the changed production and test files
- PR scope: 1 commit, 2 files changed