### PR TITLE
fix(web): prevent IME Enter from submitting chat

### DIFF
--- a/apps/web/components/features/chat/conversation-panel.tsx
+++ b/apps/web/components/features/chat/conversation-panel.tsx
@@ -10,6 +10,10 @@ import { api } from "@/lib/api";
 import type { ConversationMessage } from "@/lib/conversation-runtime";
 import { parsePetDraft, PET_DRAFT_EVENT, PET_DRAFT_KEY } from "@/lib/pet-events";
 import { formatTokenCount, relativeTime } from "@/lib/format";
+import {
+  isComposerCompositionKeyEvent,
+  shouldSubmitAfterEnter,
+} from "@/lib/composer-keyboard";
 import type { Citation, Source } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/lib/clipboard";
@@ -208,6 +212,9 @@ export function ConversationPanel({
   const docRef = React.useRef<HTMLInputElement>(null);
   const fileRef = React.useRef<HTMLInputElement>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const composingRef = React.useRef(false);
+  const compositionCommitGuardRef = React.useRef(false);
+  const compositionCommitGuardTimerRef = React.useRef<number | null>(null);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const bottomRef = React.useRef<HTMLDivElement>(null);
   const lastScrollAt = React.useRef(0);
@@ -577,12 +584,77 @@ export function ConversationPanel({
       toast.error(error instanceof Error ? error.message : t("approvalFailed"));
     }
   }
-  function onKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      send();
+
+  function startComposition() {
+    composingRef.current = true;
+    compositionCommitGuardRef.current = false;
+    if (compositionCommitGuardTimerRef.current) {
+      window.clearTimeout(compositionCommitGuardTimerRef.current);
+      compositionCommitGuardTimerRef.current = null;
     }
   }
+
+  function endComposition() {
+    composingRef.current = false;
+    compositionCommitGuardRef.current = true;
+    if (compositionCommitGuardTimerRef.current) {
+      window.clearTimeout(compositionCommitGuardTimerRef.current);
+    }
+    compositionCommitGuardTimerRef.current = window.setTimeout(() => {
+      compositionCommitGuardRef.current = false;
+      compositionCommitGuardTimerRef.current = null;
+    }, 30);
+  }
+
+  function isComposingKeyEvent(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    return isComposerCompositionKeyEvent(e, {
+      composing: composingRef.current,
+      commitGuard: compositionCommitGuardRef.current,
+    });
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      const valueBefore = e.currentTarget.value;
+      window.requestAnimationFrame(() => {
+        const valueAfter = textareaRef.current?.value;
+        if (valueAfter === undefined) return;
+        if (shouldSubmitAfterEnter(valueBefore, valueAfter)) send(valueAfter);
+      });
+    }
+  }
+
+  React.useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const onKeyDownCapture = (event: KeyboardEvent) => {
+      if (
+        isComposerCompositionKeyEvent(
+          { key: event.key, nativeEvent: event },
+          {
+            composing: composingRef.current,
+            commitGuard: compositionCommitGuardRef.current,
+          },
+        )
+      ) {
+        // 保留输入法的默认确认行为，同时阻止事件冒泡到 React 的发送处理。
+        event.stopPropagation();
+      }
+    };
+
+    textarea.addEventListener("compositionstart", startComposition);
+    textarea.addEventListener("compositionend", endComposition);
+    textarea.addEventListener("keydown", onKeyDownCapture, true);
+    return () => {
+      textarea.removeEventListener("compositionstart", startComposition);
+      textarea.removeEventListener("compositionend", endComposition);
+      textarea.removeEventListener("keydown", onKeyDownCapture, true);
+      if (compositionCommitGuardTimerRef.current) {
+        window.clearTimeout(compositionCommitGuardTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -761,6 +833,8 @@ export function ConversationPanel({
                 }
               }}
               onKeyDown={(e) => {
+                if (isComposingKeyEvent(e)) return;
+
                 if (mentionOpen) {
                   if (e.key === "ArrowDown") {
                     e.preventDefault();

--- a/apps/web/lib/composer-keyboard.test.ts
+++ b/apps/web/lib/composer-keyboard.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isComposerCompositionKeyEvent,
+  shouldSubmitAfterEnter,
+} from "./composer-keyboard";
+
+describe("isComposerCompositionKeyEvent", () => {
+  it("blocks Enter while a composition session is active", () => {
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("Enter"), {
+        composing: true,
+        commitGuard: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks Enter reported as a native composition event", () => {
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("Enter", { isComposing: true }), {
+        composing: false,
+        commitGuard: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks legacy IME keyCode 229 events", () => {
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("Enter", { keyCode: 229 }), {
+        composing: false,
+        commitGuard: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks only Enter during the post-composition guard", () => {
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("Enter"), {
+        composing: false,
+        commitGuard: true,
+      }),
+    ).toBe(true);
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("a"), {
+        composing: false,
+        commitGuard: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows a normal Enter key press", () => {
+    expect(
+      isComposerCompositionKeyEvent(keyEvent("Enter"), {
+        composing: false,
+        commitGuard: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldSubmitAfterEnter", () => {
+  it("does not submit when Enter commits an IME candidate", () => {
+    expect(shouldSubmitAfterEnter("ni'hao", "你好")).toBe(false);
+  });
+
+  it("submits when Enter only adds the textarea newline", () => {
+    expect(shouldSubmitAfterEnter("hello", "hello\n")).toBe(true);
+  });
+});
+
+function keyEvent(
+  key: string,
+  nativeEvent: { isComposing?: boolean; keyCode?: number } = {},
+) {
+  return { key, nativeEvent };
+}

--- a/apps/web/lib/composer-keyboard.ts
+++ b/apps/web/lib/composer-keyboard.ts
@@ -1,0 +1,28 @@
+export type ComposerCompositionState = {
+  composing: boolean;
+  commitGuard: boolean;
+};
+
+export type ComposerKeyboardEventLike = {
+  key: string;
+  nativeEvent: {
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+};
+
+export function isComposerCompositionKeyEvent(
+  event: ComposerKeyboardEventLike,
+  state: ComposerCompositionState,
+): boolean {
+  return (
+    state.composing ||
+    Boolean(event.nativeEvent.isComposing) ||
+    event.nativeEvent.keyCode === 229 ||
+    (state.commitGuard && event.key === "Enter")
+  );
+}
+
+export function shouldSubmitAfterEnter(valueBefore: string, valueAfter: string): boolean {
+  return valueAfter === valueBefore || valueAfter === `${valueBefore}\n`;
+}


### PR DESCRIPTION
## What changed

- Prevent Enter used to confirm an IME candidate from reaching the chat submit handler.
- Defer normal Enter submission until the browser has applied its default input update, so converted pinyin remains in the composer.
- Add focused unit coverage for composition state and post-Enter value changes.

## Root cause

The composer submitted on keydown before the browser/input method could finish committing the candidate text.

## Impact

Applies to the shared conversation composer used by the main chat view and mini workspace. No API, database, or server-side behavior changes.

## Validation

- npm run test:unit — 53 files, 387 tests passed
- npm run typecheck
- npm run lint