### PR TITLE
feat(dify): default external knowledge retrieval to vector strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ SAG_SECRET_KEY=
 # ── Dify 外部知识库（可选）────────────────────────────
 # 仅在需要接入 Dify 时执行 `make setup-dify` 自动生成；不要提交真实密钥。
 SAG_DIFY_API_KEY=
+# Dify 专用检索策略：vector（默认，低延迟）或 multi（实体扩展 + LLM 精排，延迟更高）。
+SAG_DIFY_SEARCH_STRATEGY=vector
 
 # 浏览器访问后端的地址（构建期内联；修改后需重建 web 镜像）。
 NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/apps/api/sag_api/api/v1/dify.py
+++ b/apps/api/sag_api/api/v1/dify.py
@@ -70,13 +70,20 @@ async def retrieval(
         )
 
     source = await get_source(session, knowledge_id)
+    strategy = settings.dify_search_strategy
     outcome = await retrieve_relevant_sections(
         engine_manager,
         [source],
         query,
-        strategy="multi",
+        strategy=strategy,
         top_k=body.retrieval_setting.top_k,
     )
+    effective_strategy = str(
+        outcome.stats.get("effective_strategy")
+        or outcome.stats.get("strategy")
+        or strategy
+    )
+    fallback_used = bool(outcome.stats.get("fallback_used", False))
     records = [
         DifyRetrievalRecord(
             content=section.content,
@@ -92,6 +99,8 @@ async def retrieval(
                 "source_name": source.name,
                 "chunk_id": section.chunk_id or "",
                 "heading": section.heading,
+                "retrieval_strategy": effective_strategy,
+                "fallback_used": fallback_used,
             },
         )
         for section in outcome.sections

--- a/apps/api/sag_api/core/config.py
+++ b/apps/api/sag_api/core/config.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
     allow_registration: bool = True
     # Dify 外部知识库调用的专用服务密钥；未配置时兼容端点拒绝服务。
     dify_api_key: str | None = None
+    # Dify 检索默认优先低延迟向量召回；可显式设为 multi 启用实体扩展与 LLM 精排。
+    dify_search_strategy: SearchStrategy = "vector"
 
     # ── sag 元数据库 ───────────────────────────────────────────────────
     database_url: str = "sqlite+aiosqlite:///./.data/sag.db"

--- a/apps/api/sag_api/sag/engine_manager.py
+++ b/apps/api/sag_api/sag/engine_manager.py
@@ -653,7 +653,16 @@ class EngineManager:
         try:
             outcome = await self._search_raw(source_config_id, query, source=source, strategy=strategy, top_k=top_k)
             if outcome.sections or strategy == "vector" or not self._settings.search_fallback_vector:
-                return outcome
+                return SearchOutcome(
+                    query=outcome.query,
+                    sections=outcome.sections,
+                    stats={
+                        **outcome.stats,
+                        "requested_strategy": strategy,
+                        "effective_strategy": strategy,
+                        "fallback_used": False,
+                    },
+                )
             log.info("精确检索空结果，回退快速检索 source_config_id=%s", source_config_id)
         except TimeoutError:
             if strategy == "vector" or not self._settings.search_fallback_vector:
@@ -673,7 +682,17 @@ class EngineManager:
                 strategy,
                 getattr(e, "message", None) or e,
             )
-        return await self._search_raw(source_config_id, query, source=source, strategy="vector", top_k=top_k)
+        outcome = await self._search_raw(source_config_id, query, source=source, strategy="vector", top_k=top_k)
+        return SearchOutcome(
+            query=outcome.query,
+            sections=outcome.sections,
+            stats={
+                **outcome.stats,
+                "requested_strategy": strategy,
+                "effective_strategy": "vector",
+                "fallback_used": True,
+            },
+        )
 
     async def search_many(
         self,
@@ -760,6 +779,22 @@ class EngineManager:
                 "sources_requested": requested_sources,
                 "source_limit_applied": requested_sources > len(targets),
                 "candidates": len(best) + len(loose),
+                "requested_strategy": strategy,
+                "effective_strategy": next(
+                    (
+                        outcome.stats.get("effective_strategy", strategy)
+                        for result in results
+                        if result is not None
+                        for _, outcome in [result]
+                    ),
+                    strategy,
+                ),
+                "fallback_used": any(
+                    bool(outcome.stats.get("fallback_used"))
+                    for result in results
+                    if result is not None
+                    for _, outcome in [result]
+                ),
             },
         )
 

--- a/apps/api/tests/test_dify_retrieval.py
+++ b/apps/api/tests/test_dify_retrieval.py
@@ -8,14 +8,14 @@ import httpx
 import pytest
 
 
-def _set_dify_key(monkeypatch, settings, value: str | None) -> None:
-    """Allow the contract tests to describe the setting before it exists."""
+def test_dify_retrieval_defaults_to_vector_strategy():
+    from sag_api.core.config import settings
 
-    monkeypatch.setitem(settings.__dict__, "dify_api_key", value)
+    assert settings.dify_search_strategy == "vector"
 
 
 @pytest.mark.asyncio
-async def test_dify_retrieval_maps_one_source_to_traceable_records(monkeypatch):
+async def test_dify_retrieval_returns_traceable_records_from_the_requested_source(monkeypatch):
     from sag_api.core.config import settings
     from sag_api.core.deps import get_engine_manager
     from sag_api.main import app
@@ -24,39 +24,31 @@ async def test_dify_retrieval_maps_one_source_to_traceable_records(monkeypatch):
     class RecordingEngine:
         strategy: str | None = None
         top_k: int | None = None
-        source_id: str | None = None
 
         async def provision(self, *_args):
             return None
 
         async def search_many(self, targets, query, *, strategy=None, top_k=None):
-            assert len(targets) == 1
-            source_config_id, source = targets[0]
             self.strategy = strategy
             self.top_k = top_k
-            self.source_id = source.id
+            source_config_id = targets[0][0]
             return SearchOutcome(
                 query=query,
                 sections=[
                     RetrievedSection(
                         chunk_id="chunk-123",
                         heading="关键章节",
-                        content="星河计划的内部识别码是 SAG-TRACE-7291。",
+                        content="可由 Dify 用作回答证据的原文。",
                         score=0.91,
                         source_config_id=source_config_id,
-                    ),
-                    RetrievedSection(
-                        chunk_id="chunk-low",
-                        heading="低分章节",
-                        content="这条记录应被 Dify 的阈值过滤。",
-                        score=0.55,
-                        source_config_id=source_config_id,
-                    ),
+                    )
                 ],
+                stats={"effective_strategy": "multi"},
             )
 
     engine = RecordingEngine()
-    _set_dify_key(monkeypatch, settings, "dify-secret")
+    monkeypatch.setattr(settings, "dify_api_key", "dify-secret")
+    monkeypatch.setattr(settings, "dify_search_strategy", "vector", raising=False)
     app.dependency_overrides[get_engine_manager] = lambda: engine
     try:
         transport = httpx.ASGITransport(app=app)
@@ -64,15 +56,10 @@ async def test_dify_retrieval_maps_one_source_to_traceable_records(monkeypatch):
             async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
                 registered = await client.post(
                     "/api/v1/auth/register",
-                    json={
-                        "email": f"dify-{uuid.uuid4().hex}@t.com",
-                        "password": "password123",
-                    },
+                    json={"email": f"dify-{uuid.uuid4().hex}@t.com", "password": "password123"},
                 )
                 assert registered.status_code == 201, registered.text
-                user_headers = {
-                    "Authorization": f"Bearer {registered.json()['access_token']}"
-                }
+                user_headers = {"Authorization": f"Bearer {registered.json()['access_token']}"}
                 source = await client.post(
                     "/api/v1/sources",
                     headers=user_headers,
@@ -85,70 +72,48 @@ async def test_dify_retrieval_maps_one_source_to_traceable_records(monkeypatch):
                     headers={"Authorization": "Bearer dify-secret"},
                     json={
                         "knowledge_id": source.json()["id"],
-                        "query": "星河计划的识别码是什么",
-                        "retrieval_setting": {
-                            "top_k": 3,
-                            "score_threshold": 0.6,
-                        },
+                        "query": "Dify 应该用什么作为证据？",
+                        "retrieval_setting": {"top_k": 3, "score_threshold": 0.6},
                     },
                 )
 
         assert response.status_code == 200, response.text
-        assert engine.strategy == "multi"
+        assert engine.strategy == "vector"
         assert engine.top_k == 11
-        assert engine.source_id == source.json()["id"]
-        assert response.json() == {
-            "records": [
-                {
-                    "content": "星河计划的内部识别码是 SAG-TRACE-7291。",
-                    "title": "Dify 接入测试源 — 关键章节",
-                    "score": 0.655,
-                    "metadata": {
-                        "document_id": f"{source.json()['id']}:chunk-123",
-                        "source_id": source.json()["id"],
-                        "source_name": "Dify 接入测试源",
-                        "chunk_id": "chunk-123",
-                        "heading": "关键章节",
-                    },
-                }
-            ]
+        records = response.json()["records"]
+        assert len(records) == 1
+        assert records[0]["content"] == "可由 Dify 用作回答证据的原文。"
+        assert records[0]["title"] == "Dify 接入测试源 — 关键章节"
+        assert records[0]["score"] > 0.6
+        assert records[0]["metadata"] == {
+            "document_id": f"{source.json()['id']}:chunk-123",
+            "source_id": source.json()["id"],
+            "source_name": "Dify 接入测试源",
+            "chunk_id": "chunk-123",
+            "heading": "关键章节",
+            "retrieval_strategy": "multi",
+            "fallback_used": False,
         }
     finally:
         app.dependency_overrides.pop(get_engine_manager, None)
 
 
 @pytest.mark.asyncio
-async def test_dify_retrieval_handles_auth_probe_and_invalid_requests(
-    monkeypatch,
-):
+async def test_dify_retrieval_handles_probe_authentication_and_invalid_requests(monkeypatch):
     from sag_api.core.config import settings
     from sag_api.main import app
 
+    monkeypatch.setattr(settings, "dify_api_key", "dify-secret")
     transport = httpx.ASGITransport(app=app)
     async with app.router.lifespan_context(app):
         async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
-            _set_dify_key(monkeypatch, settings, None)
-            disabled = await client.post("/api/v1/dify/retrieval", json={})
-            assert disabled.status_code == 503
-
-            _set_dify_key(monkeypatch, settings, "dify-secret")
-            missing = await client.post("/api/v1/dify/retrieval", json={})
-            assert missing.status_code == 403
-            wrong = await client.post(
-                "/api/v1/dify/retrieval",
-                headers={"Authorization": "Bearer wrong"},
-                json={},
-            )
-            assert wrong.status_code == 403
+            denied = await client.post("/api/v1/dify/retrieval", json={})
+            assert denied.status_code == 403
 
             probe = await client.post(
                 "/api/v1/dify/retrieval",
                 headers={"Authorization": "Bearer dify-secret"},
-                json={
-                    "knowledge_id": "",
-                    "query": "",
-                    "retrieval_setting": {"top_k": 1, "score_threshold": 0},
-                },
+                json={"knowledge_id": "", "query": "", "retrieval_setting": {"top_k": 1}},
             )
             assert probe.status_code == 200
             assert probe.json() == {"records": []}
@@ -156,43 +121,74 @@ async def test_dify_retrieval_handles_auth_probe_and_invalid_requests(
             partial = await client.post(
                 "/api/v1/dify/retrieval",
                 headers={"Authorization": "Bearer dify-secret"},
-                json={"knowledge_id": "source-id", "query": ""},
+                json={"knowledge_id": "a" * 32, "query": ""},
             )
             assert partial.status_code == 422
             assert partial.json()["error"]["code"] == "validation_error"
 
-            metadata_filter = await client.post(
+            filtered = await client.post(
                 "/api/v1/dify/retrieval",
                 headers={"Authorization": "Bearer dify-secret"},
                 json={
-                    "knowledge_id": "source-id",
-                    "query": "metadata",
-                    "metadata_condition": {
-                        "logical_operator": "and",
-                        "conditions": [],
-                    },
+                    "knowledge_id": "a" * 32,
+                    "query": "metadata filter",
+                    "metadata_condition": {"logical_operator": "and", "conditions": []},
                 },
             )
-            assert metadata_filter.status_code == 422
-            assert metadata_filter.json()["error"]["code"] == "validation_error"
+            assert filtered.status_code == 422
+            assert filtered.json()["error"]["code"] == "validation_error"
 
-            invalid_settings = await client.post(
-                "/api/v1/dify/retrieval",
-                headers={"Authorization": "Bearer dify-secret"},
-                json={
-                    "knowledge_id": "source-id",
-                    "query": "invalid",
-                    "retrieval_setting": {
-                        "top_k": 0,
-                        "score_threshold": 1.1,
-                    },
-                },
-            )
-            assert invalid_settings.status_code == 422
 
-            unknown_source = await client.post(
-                "/api/v1/dify/retrieval",
-                headers={"Authorization": "Bearer dify-secret"},
-                json={"knowledge_id": uuid.uuid4().hex, "query": "unknown"},
-            )
-            assert unknown_source.status_code == 404
+@pytest.mark.asyncio
+async def test_sag_search_records_when_multi_falls_back_to_vector(monkeypatch):
+    from sag_api.core.config import settings
+    from sag_api.sag.dto import RetrievedSection, SearchOutcome
+    from sag_api.sag.engine_manager import EngineManager
+
+    manager = EngineManager(settings)
+
+    async def search_raw(_source_config_id, _query, *, source, strategy, top_k):
+        if strategy == "multi":
+            return SearchOutcome(query="fallback", sections=[], stats={})
+        return SearchOutcome(
+            query="fallback",
+            sections=[RetrievedSection(content="vector evidence", score=0.8)],
+            stats={"upstream": "vector"},
+        )
+
+    monkeypatch.setattr(manager, "_search_raw", search_raw)
+
+    result = await manager.search("source-1", "fallback", strategy="multi", top_k=2)
+
+    assert result.sections[0].content == "vector evidence"
+    assert result.stats["requested_strategy"] == "multi"
+    assert result.stats["effective_strategy"] == "vector"
+    assert result.stats["fallback_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_sag_search_many_preserves_single_source_fallback_metadata(monkeypatch):
+    from sag_api.core.config import settings
+    from sag_api.sag.dto import RetrievedSection, SearchOutcome
+    from sag_api.sag.engine_manager import EngineManager
+
+    manager = EngineManager(settings)
+
+    async def search(_source_config_id, _query, **_kwargs):
+        return SearchOutcome(
+            query="fallback",
+            sections=[RetrievedSection(content="vector evidence", score=0.8)],
+            stats={
+                "requested_strategy": "multi",
+                "effective_strategy": "vector",
+                "fallback_used": True,
+            },
+        )
+
+    monkeypatch.setattr(manager, "search", search)
+
+    result = await manager.search_many([("source-1", None)], "fallback", strategy="multi", top_k=2)
+
+    assert result.stats["requested_strategy"] == "multi"
+    assert result.stats["effective_strategy"] == "vector"
+    assert result.stats["fallback_used"] is True

--- a/apps/api/tests/test_search_strategy.py
+++ b/apps/api/tests/test_search_strategy.py
@@ -205,6 +205,9 @@ async def test_search_many_caps_candidates_and_concurrency(monkeypatch):
         "sources_requested": 5,
         "source_limit_applied": True,
         "candidates": 0,
+        "requested_strategy": "multi",
+        "effective_strategy": "multi",
+        "fallback_used": False,
     }
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,8 @@ services:
       SAG_ALLOW_REGISTRATION: ${SAG_ALLOW_REGISTRATION:-false}
       # 可选 Dify 外部知识库兼容端点；留空时端点拒绝服务。
       SAG_DIFY_API_KEY: ${SAG_DIFY_API_KEY:-}
+      # Dify 专用检索策略；默认 vector 以降低外部知识库请求延迟。
+      SAG_DIFY_SEARCH_STRATEGY: ${SAG_DIFY_SEARCH_STRATEGY:-vector}
       # 四个斜杠表示容器内绝对路径 /data/sag.db。
       SAG_DATABASE_URL: sqlite+aiosqlite:////data/sag.db
       SAG_DATA_DIR: /data/engine

--- a/docs/dify-integration.en.md
+++ b/docs/dify-integration.en.md
@@ -1,121 +1,173 @@
 # Use SAG as a Dify External Knowledge Base
 
-SAG implements Dify's external knowledge base retrieval protocol. SAG continues to handle document upload, parsing, chunking, embeddings, and event–entity extraction. At application runtime, Dify only asks SAG for retrieval evidence. This integration is entirely optional: it does not replace or change any other knowledge base capability in either Dify or SAG.
+Dify calls SAG only for retrieval evidence at runtime. Uploading, parsing, chunking, and embedding remain in SAG.
 
-## Prerequisites
+~~~text
+Dify API → SSRF Proxy → sag:8000 on the Docker network → SAG /api/v1/dify/retrieval
+~~~
 
-- Both SAG and Dify are running with Docker Compose.
-- Documents in the target SAG source have finished processing.
-- Dify containers can reach the SAG API over a shared Docker network.
-- This integration follows SAG's single-user boundary: one Dify external knowledge base is bound to one SAG source.
+One Dify external knowledge base maps to one SAG source (source.id).
 
-## 1. Initialize the SAG Dify API key
+## 1. Configure SAG
 
-From the root of the SAG repository, run:
+Set these values in the SAG repository root .env file:
 
-```bash
-make setup-dify
-```
+~~~dotenv
+# Dedicated key for Dify. Dify must use the same value.
+SAG_DIFY_API_KEY=replace-with-a-strong-random-key
 
-The command generates a cryptographically strong key, stores it in the Git-ignored root `.env` file, and prints:
+# Dify-only retrieval strategy:
+# vector (default): low latency; no SAG internal LLM reranking.
+# multi: entity expansion plus SAG internal LLM reranking; higher latency.
+SAG_DIFY_SEARCH_STRATEGY=vector
+~~~
 
-```text
-Endpoint: http://sag:8000/api/v1/dify
-API Key: <generated key>
-```
+This setting affects the Dify endpoint only. It does not change the retrieval strategy in SAG Web.
 
-An existing non-empty `SAG_DIFY_API_KEY` is never overwritten. If you do not run this command or configure the key manually, the Dify-compatible endpoint returns `503`. SAG's default startup and all other functionality remain unaffected.
+### Verify: values reached the API container
 
-## 2. Connect the SAG API to Dify's Docker network
+~~~bash
+docker exec sag-api-1 sh -lc 'python - <<'"'"'PY'"'"'
+import os
+print("dify_key_configured=", bool(os.getenv("SAG_DIFY_API_KEY")))
+print("dify_search_strategy=", os.getenv("SAG_DIFY_SEARCH_STRATEGY"))
+PY'
+~~~
 
-First, identify Dify's Docker network from Dify's `docker` directory:
+Expected output:
 
-```bash
-docker compose ps
+~~~text
+dify_key_configured= True
+dify_search_strategy= vector
+~~~
+
+## 2. Attach SAG API to the Dify Docker network
+
+Find the Dify network name:
+
+~~~bash
 docker network ls
-```
+~~~
 
-When started from the default directory name, Dify commonly uses `docker_default`. From the SAG repository root, start SAG with the optional Compose override:
+The default is usually docker_default. From the SAG repository root:
 
-```bash
+~~~bash
 DIFY_NETWORK_NAME=docker_default \
-docker compose -f compose.yaml -f compose.dify.yaml up -d --build
-```
+docker compose -f compose.yaml -f compose.dify.yaml up -d --build --force-recreate --no-deps api
+~~~
 
-This adds only SAG's `api` service to the selected network and gives it the network alias `sag`. Do not expose the Dify-compatible endpoint directly to the public internet.
+This rebuilds only SAG API; it does not stop SAG Web, Dify, or databases.
 
-## 3. Configure Dify's container access policy
+### Verify: network and health
 
-Dify sends external knowledge base requests through its SSRF Proxy. Add the following settings to Dify's `docker/.env`:
+~~~bash
+docker inspect sag-api-1 \
+  --format '{{range $name, $network := .NetworkSettings.Networks}}{{println $name}}{{end}}'
 
-```dotenv
+docker run --rm --network docker_default busybox:latest \
+  wget -S -O - -T 10 http://sag:8000/api/v1/system/ready
+~~~
+
+The network output must include sag_default and docker_default. The health request must return HTTP 200 and:
+
+~~~json
+{"status":"ready","db":true}
+~~~
+
+sag:8000 is a Docker-internal address. Use docker ps to find the host port.
+
+## 3. Configure Dify SSRF access
+
+Edit Dify docker/.env:
+
+~~~dotenv
 SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=sag
 SSRF_DEFAULT_TIME_OUT=30
 SSRF_DEFAULT_READ_TIME_OUT=30
-```
+~~~
 
-Both `SSRF_DEFAULT_TIME_OUT` and `SSRF_DEFAULT_READ_TIME_OUT` must exceed SAG's per-source retrieval timeout and leave room for network overhead. Dify applies the read timeout independently, so increasing only the overall timeout can still cause a request to be interrupted after the default five seconds.
+- SSRF_PROXY_ALLOW_PRIVATE_DOMAINS permits the private Docker hostname sag.
+- SSRF_DEFAULT_TIME_OUT is the maximum total request time in seconds.
+- SSRF_DEFAULT_READ_TIME_OUT is the maximum response-read time after connecting.
 
-With the default `multi → vector` fallback enabled, one request can consume up to two consecutive per-source timeouts. Set both Dify timeouts to more than `2 × SAG_SEARCH_SOURCE_TIMEOUT + network overhead`. For example, when SAG's default per-source timeout is 12 seconds, 30 seconds is appropriate. If it is increased to 45 seconds, configure Dify for at least 100 seconds.
+Thirty seconds is normally enough for vector. When using multi, increase both values according to SAG's per-source timeout and LLM response time.
 
-Recreate the relevant Dify services for the configuration to take effect:
+Recreate the related Dify services from its docker directory:
 
-```bash
+~~~bash
 docker compose up -d --force-recreate api ssrf_proxy
-```
+~~~
 
-These changes apply only to your Dify deployment; no Dify source-code changes are required.
+### Verify: Dify received the settings
 
-## 4. Find the SAG Source ID
+~~~bash
+docker exec docker-ssrf_proxy-1 sh -lc \
+  'env | grep "^SSRF_PROXY_ALLOW_PRIVATE_DOMAINS="'
 
-Open the target source in SAG. Its URL follows this pattern:
+docker exec docker-api-1 sh -lc \
+  'env | grep -E "^(SSRF_DEFAULT_TIME_OUT|SSRF_DEFAULT_READ_TIME_OUT)="'
+~~~
 
-```text
-http://localhost:3000/knowledge/<SOURCE_ID>
-```
+Expected output:
 
-The final segment, `<SOURCE_ID>`, is the Knowledge ID to enter in Dify. You can also call `GET /api/v1/sources` with a SAG user JWT to retrieve sources and their `id` values.
+~~~text
+SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=sag
+SSRF_DEFAULT_TIME_OUT=30
+SSRF_DEFAULT_READ_TIME_OUT=30
+~~~
 
-## 5. Create the external knowledge base in Dify
+## 4. Bind a source in Dify
 
-1. Go to **Knowledge → Create Knowledge Base → Connect to an External Knowledge Base**.
-2. Create an external knowledge API:
-   - **Name:** for example, `SAG`
-   - **Endpoint:** `http://sag:8000/api/v1/dify`
-   - **API Key:** the key printed by `make setup-dify`
-3. Create the external knowledge base and enter the target SAG `source.id` as the **Knowledge ID**.
-4. Run Dify's retrieval test, or add a Knowledge Retrieval node to an application to verify the results and citations.
+1. Prepare a processed source in SAG Web and copy its complete source.id.
+2. In Dify, open **Knowledge → Connect to an External Knowledge Base** and create an external API:
+   - Endpoint: http://sag:8000/api/v1/dify
+   - API Key: the complete SAG_DIFY_API_KEY value
+3. Create the external knowledge base and set Knowledge ID to the complete source.id.
 
-Dify automatically appends `/retrieval` to the Endpoint. Do not include `/retrieval` in the Endpoint yourself, and do not mistakenly use HTTPS for the container-internal HTTP address.
+Do not append /retrieval; Dify does it automatically. Do not use localhost or HTTPS.
 
-## Retrieval protocol
+### Verify: endpoint authentication
 
-Dify ultimately calls:
+From the SAG repository root:
 
-```http
-POST /api/v1/dify/retrieval
-Authorization: Bearer <SAG_DIFY_API_KEY>
-Content-Type: application/json
-```
+~~~bash
+KEY=$(sed -n 's/^SAG_DIFY_API_KEY=//p' .env)
 
-Example request:
+curl -i -sS -X POST \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:8001/api/v1/dify/retrieval \
+  -d '{"knowledge_id":"","query":""}'
+~~~
 
-```json
+Expect HTTP 200 and:
+
+~~~json
+{"records":[]}
+~~~
+
+Replace 8001 with the host port shown for SAG API by docker ps. If Dify displays an SSRF error but ssrf_proxy shows HIER_DIRECT/... TCP_MISS/403, first verify that Dify's saved API key matches SAG .env.
+
+## 5. Verify the strategy
+
+Run a Dify hit test. Each returned record includes metadata such as:
+
+~~~json
 {
-  "knowledge_id": "<SAG_SOURCE_ID>",
-  "query": "What is the identifier for the Stellar Project?",
-  "retrieval_setting": {
-    "top_k": 5,
-    "score_threshold": 0.3
-  }
+  "retrieval_strategy": "vector",
+  "fallback_used": false
 }
-```
+~~~
 
-The compatible endpoint always uses SAG's `multi` retrieval strategy and retains SAG's existing fallback to `vector` when a source retrieval times out, fails, or returns no results. Each returned `record` includes `source_id`, `source_name`, `chunk_id`, `heading`, and `document_id` for citation traceability in Dify.
+- `retrieval_strategy` is the strategy actually used. When a `multi` request is downgraded inside SAG (timeout, failure, or empty result), this appears as `vector`.
+- `fallback_used` is `true` when `multi` fell back to `vector`.
 
-## Current limitations
+## Strategy reference
 
-- The initial release does not support `metadata_condition`. Requests that include it return `422`; it is never silently ignored.
-- One Dify external knowledge base can be bound to only one SAG `source.id`.
-- SAG is currently a single-user product. Do not treat this endpoint as a cross-tenant knowledge-isolation boundary.
-- This endpoint supplies retrieval evidence only. It does not upload, update, or delete SAG documents from Dify.
+| Strategy | SAG internal LLM | Latency | Best for |
+| --- | --- | --- | --- |
+| vector (default) | No LLM reranking | Low | Normal low-latency Dify Q&A |
+| multi | Entity extraction and reranking use SAG's configured LLM | High | Higher-recall cases that can accept longer waits |
+
+Dify's application LLM still produces the final natural-language answer. This setting controls only the evidence retrieved by SAG.
+

--- a/docs/dify-integration.md
+++ b/docs/dify-integration.md
@@ -1,140 +1,173 @@
 # 将 SAG 作为 Dify 外部知识库
 
-SAG 可以实现 Dify 的外部知识库检索协议。文档上传、解析、分块、Embedding
-和 event–entity 抽取仍由 SAG 完成；Dify 只在应用运行时向 SAG 请求检索证据。
-该能力完全可选，不会替换或修改 Dify、SAG 的其他知识库功能。
+Dify 只在应用运行时向 SAG 请求检索证据；上传、解析、分块和 Embedding 仍在 SAG 中完成。
 
-## 前提
+~~~text
+Dify API → SSRF Proxy → Docker 网络中的 sag:8000 → SAG /api/v1/dify/retrieval
+~~~
 
-- SAG 与 Dify 均通过 Docker Compose 运行。
-- SAG 信源中的文档已经处理完成。
-- Dify 容器可以通过一个共同的 Docker 网络访问 SAG API。
-- 当前集成按 SAG 的单用户边界设计，一个 Dify 外部知识库绑定一个 SAG 信源。
+一个 Dify 外部知识库对应一个 SAG 信源（source.id）。
 
-## 1. 初始化 SAG 的 Dify 密钥
+## 1. 配置 SAG
 
-在 SAG 仓库根目录执行：
+在 SAG 根目录的 .env 中设置：
 
-```bash
-make setup-dify
-```
+~~~dotenv
+# Dify 专用 API Key。Dify 中必须填写相同的值。
+SAG_DIFY_API_KEY=替换成强随机密钥
 
-命令会生成强随机密钥并保存到被 Git 忽略的根目录 `.env`，同时输出：
+# Dify 专用检索策略：
+# vector（默认）：低延迟，不进行 SAG 内部 LLM 精排。
+# multi：实体扩展 + SAG 内部 LLM 精排，延迟更高。
+SAG_DIFY_SEARCH_STRATEGY=vector
+~~~
 
-```text
-Endpoint: http://sag:8000/api/v1/dify
-API Key: <生成的密钥>
-```
+此策略只影响 Dify 外部知识库接口，不影响 SAG Web 的检索策略。
 
-已有非空 `SAG_DIFY_API_KEY` 时不会覆盖。未执行该命令且未手工设置密钥时，
-Dify 兼容端点返回 503，SAG 的默认启动和其他功能不受影响。
+### 验证：配置进入 API 容器
 
-## 2. 将 SAG API 加入 Dify 网络
+~~~bash
+docker exec sag-api-1 sh -lc 'python - <<'"'"'PY'"'"'
+import os
+print("dify_key_configured=", bool(os.getenv("SAG_DIFY_API_KEY")))
+print("dify_search_strategy=", os.getenv("SAG_DIFY_SEARCH_STRATEGY"))
+PY'
+~~~
 
-先在 Dify 的 `docker` 目录确认网络名：
+正确结果：
 
-```bash
-docker compose ps
+~~~text
+dify_key_configured= True
+dify_search_strategy= vector
+~~~
+
+## 2. 将 SAG API 加入 Dify Docker 网络
+
+查看 Dify 网络名：
+
+~~~bash
 docker network ls
-```
+~~~
 
-按默认目录名启动的 Dify 通常使用 `docker_default`。在 SAG 根目录叠加可选
-Compose 文件启动：
+默认 Dify Compose 项目名为 docker 时，网络通常是 docker_default。在 SAG 根目录执行：
 
-```bash
+~~~bash
 DIFY_NETWORK_NAME=docker_default \
-docker compose -f compose.yaml -f compose.dify.yaml up -d --build
-```
+docker compose -f compose.yaml -f compose.dify.yaml up -d --build --force-recreate --no-deps api
+~~~
 
-这只会把 SAG 的 `api` 服务加入指定网络，并在该网络中提供主机别名 `sag`。
-不要把 Dify 兼容端点直接暴露到公网。
+此命令只重建 SAG API，不会停止 SAG Web、Dify 或数据库。
 
-## 3. 配置 Dify 的容器访问策略
+### 验证：网络与健康状态
 
-Dify 的外部知识库请求经过 SSRF Proxy。请在 Dify 的 `docker/.env` 中设置：
+~~~bash
+docker inspect sag-api-1 \
+  --format '{{range $name, $network := .NetworkSettings.Networks}}{{println $name}}{{end}}'
 
-```dotenv
+docker run --rm --network docker_default busybox:latest \
+  wget -S -O - -T 10 http://sag:8000/api/v1/system/ready
+~~~
+
+网络输出应包含 sag_default 和 docker_default；健康接口应返回 HTTP 200 与：
+
+~~~json
+{"status":"ready","db":true}
+~~~
+
+sag:8000 是 Docker 内部地址。宿主机端口以 docker ps 显示为准。
+
+## 3. 配置 Dify SSRF
+
+编辑 Dify docker/.env：
+
+~~~dotenv
 SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=sag
 SSRF_DEFAULT_TIME_OUT=30
 SSRF_DEFAULT_READ_TIME_OUT=30
-```
+~~~
 
-`SSRF_DEFAULT_TIME_OUT` 和 `SSRF_DEFAULT_READ_TIME_OUT` 都必须大于 SAG 的
-单信源检索超时，并预留网络开销。Dify 会单独使用读取超时；只提高总超时仍可能
-在默认 5 秒后中断。启用默认的 `multi → vector` 回退时，一次请求最坏可能连续
-消耗两次单信源超时，因此建议两个 Dify 超时都大于
-`2 × SAG_SEARCH_SOURCE_TIMEOUT + 网络余量`。默认 SAG 单源超时为 12 秒时可设
-30 秒；如果 SAG 提高到 45 秒，Dify 建议至少设为 100 秒。
+- SSRF_PROXY_ALLOW_PRIVATE_DOMAINS：允许 Dify 访问 Docker 私网中的 sag。
+- SSRF_DEFAULT_TIME_OUT：整个请求最长时间（秒）。
+- SSRF_DEFAULT_READ_TIME_OUT：连接后等待响应的最长时间（秒）。
 
-重新创建 Dify 的相关服务使配置生效：
+使用默认 vector 时，30 秒通常足够；使用 multi 时，应根据 SAG 单信源超时和 LLM 响应时间调高两个值。
 
-```bash
+在 Dify docker 目录重建：
+
+~~~bash
 docker compose up -d --force-recreate api ssrf_proxy
-```
+~~~
 
-这里仅修改部署者自己的 Dify 配置，不需要改动 Dify 源码。
+### 验证：Dify 服务拿到配置
 
-## 4. 查找 SAG Source ID
+~~~bash
+docker exec docker-ssrf_proxy-1 sh -lc \
+  'env | grep "^SSRF_PROXY_ALLOW_PRIVATE_DOMAINS="'
 
-打开 SAG 的目标信源页面，可在信源详情页名称下方找到 **信源 ID** 并一键复制；
-也可以在知识库最外层的卡片视图或列表视图直接复制每个信源的 ID。
+docker exec docker-api-1 sh -lc \
+  'env | grep -E "^(SSRF_DEFAULT_TIME_OUT|SSRF_DEFAULT_READ_TIME_OUT)="'
+~~~
 
-SAG Web UI 中的“信源 ID”就是 API 字段 `source_id`（知识库信源 ID）。将 SAG
-接入 Dify 外部知识库时，Dify 的 `knowledge_id`（Knowledge ID）应填写这个
-完整值。
+应看到：
 
-目标信源页面的地址格式为：
+~~~text
+SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=sag
+SSRF_DEFAULT_TIME_OUT=30
+SSRF_DEFAULT_READ_TIME_OUT=30
+~~~
 
-```text
-http://localhost:3000/knowledge/<SOURCE_ID>
-```
+## 4. 在 Dify 中绑定信源
 
-最后一段 `<SOURCE_ID>` 同样是该信源 ID。也可以使用带 SAG 用户 JWT 的
-`GET /api/v1/sources` 查询信源列表及其 `id`。
+1. 在 SAG Web 中准备已处理完成的信源，复制完整 source.id。
+2. 在 Dify 进入 **知识库 → 连接外部知识库**，创建外部知识 API：
+   - Endpoint：http://sag:8000/api/v1/dify
+   - API Key：SAG_DIFY_API_KEY 的完整值
+3. 创建外部知识库时，将 Knowledge ID 填为完整 source.id。
 
-## 5. 在 Dify 创建外部知识库
+不要在 Endpoint 后填写 /retrieval，Dify 会自动追加；不要使用 localhost 或 HTTPS。
 
-1. 进入 **知识库 → 创建知识库 → 连接外部知识库**。
-2. 新建外部知识 API：
-   - 名称：例如 `SAG`
-   - Endpoint：`http://sag:8000/api/v1/dify`
-   - API Key：`make setup-dify` 输出的密钥
-3. 创建外部知识库，将 Knowledge ID 填为目标 SAG `source.id`。
-4. 使用命中测试，或在应用中添加知识检索节点验证结果和引用。
+### 验证：接口鉴权
 
-Dify 会自动在 Endpoint 后追加 `/retrieval`，所以 Endpoint 中不要重复填写
-`/retrieval`，也不要把容器内 HTTP 地址误写成 HTTPS。
+在 SAG 根目录执行：
 
-## 检索协议
+~~~bash
+KEY=$(sed -n 's/^SAG_DIFY_API_KEY=//p' .env)
 
-Dify 最终调用：
+curl -i -sS -X POST \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:8001/api/v1/dify/retrieval \
+  -d '{"knowledge_id":"","query":""}'
+~~~
 
-```http
-POST /api/v1/dify/retrieval
-Authorization: Bearer <SAG_DIFY_API_KEY>
-Content-Type: application/json
-```
+应返回 HTTP 200 和：
 
-请求示例：
+~~~json
+{"records":[]}
+~~~
 
-```json
+将 8001 替换为 docker ps 中 SAG API 的宿主机端口。若 Dify 页面显示“SSRF protection”，但 ssrf_proxy 日志中有 HIER_DIRECT/... TCP_MISS/403，请优先检查 Dify 保存的 API Key 是否与 SAG .env 中的密钥一致。
+
+## 5. 验证策略
+
+在 Dify 外部知识库页面执行命中测试。响应记录的 metadata 会包含：
+
+~~~json
 {
-  "knowledge_id": "<SAG_SOURCE_ID>",
-  "query": "星河计划的识别码是什么",
-  "retrieval_setting": {
-    "top_k": 5,
-    "score_threshold": 0.3
-  }
+  "retrieval_strategy": "vector",
+  "fallback_used": false
 }
-```
+~~~
 
-兼容端点固定使用 SAG `multi` 检索，并沿用 SAG 已有的超时、失败或空结果时
-回退 `vector` 的行为。返回的 `records` 带有 `source_id`、`source_name`、
-`chunk_id`、`heading` 和 `document_id`，用于 Dify 引用溯源。
+- `retrieval_strategy` 是本次实际使用的策略；multi 请求在 SAG 内部因超时/失败/空结果回退到 vector 时，会显示为 `vector`。
+- `fallback_used` 为 `true` 表示 multi 已回退到 vector。
 
-## 当前限制
+## 策略选择
 
-- `metadata_condition` 首版不支持，传入时返回 422，不会静默忽略。
-- 一个 Dify 外部知识库只绑定一个 SAG `source.id`。
-- SAG 当前是单用户产品，不将此接口作为跨租户知识隔离边界。
-- 该接口只提供检索证据，不负责从 Dify 上传、更新或删除 SAG 文档。
+| 策略 | SAG 内部 LLM | 延迟 | 场景 |
+| --- | --- | --- | --- |
+| vector（默认） | 不进行 LLM 精排 | 低 | Dify 常规低延迟问答 |
+| multi | 实体提取和候选精排使用 SAG 配置的 LLM | 高 | 可接受更长等待、追求更丰富召回 |
+
+Dify 应用配置的 LLM 仍负责最终自然语言回答；此配置只决定 SAG 返回的检索证据。
+


### PR DESCRIPTION
## Summary

Dify calls SAG's external knowledge base at request time. The previous default routed every Dify request through the **multi** strategy, which runs entity expansion + LLM reranking inside SAG and adds seconds of latency before Dify's own LLM even starts answering. For most Dify Q&A that extra recall isn't worth the wall-clock cost.

This PR makes the Dify endpoint's strategy configurable and defaults it to **vector**, while keeping `multi` opt-in for higher-recall workloads.

## Changes

- **Config** — new `dify_search_strategy` setting (env: `SAG_DIFY_SEARCH_STRATEGY`), default `vector`. Only affects `/api/v1/dify/retrieval`; SAG Web keeps its own `search_strategy` unchanged.
- **Endpoint** — `/api/v1/dify/retrieval` now reads the configured strategy and echoes `retrieval_strategy` + `fallback_used` in each record's metadata, so Dify operators can see which path served the request without reading server logs.
- **Engine stats** — `EngineManager.search` / `search_many` extend `SearchOutcome.stats` with `requested_strategy`, `effective_strategy`, and `fallback_used`, making multi→vector fallbacks observable end-to-end (both single- and many-source paths).
- **Deploy surface** — `SAG_DIFY_SEARCH_STRATEGY=vector` added to `.env.example` and `compose.yaml` so fresh deploys inherit the new default; overridable per environment.
- **Docs** — `docs/dify-integration.md` and `docs/dify-integration.en.md` rewritten around the new default: strategy choice, SSRF timeout guidance when opting into `multi`, and verification via response metadata (instead of grepping container logs).

## Tests

Covered in `apps/api/tests/test_dify_retrieval.py`:

- `test_dify_retrieval_defaults_to_vector_strategy` — asserts the settings default and endpoint wiring.
- Traceable-records test — asserts records surface `retrieval_strategy` / `fallback_used` metadata.
- `test_sag_search_records_when_multi_falls_back_to_vector` — asserts `EngineManager.search` reports the fallback correctly.
- `test_sag_search_many_preserves_single_source_fallback_metadata` — asserts `search_many` aggregates the fallback state faithfully.

## Test plan

- [ ] `pytest apps/api/tests/test_dify_retrieval.py -q`
- [ ] Fresh compose bring-up with default `.env`: confirm container env shows `SAG_DIFY_SEARCH_STRATEGY=vector` and Dify hit test records show `"retrieval_strategy": "vector"`, `"fallback_used": false`.
- [ ] Set `SAG_DIFY_SEARCH_STRATEGY=multi`, recreate `api`, rerun hit test: records should show `retrieval_strategy=multi` on success or `retrieval_strategy=vector` + `fallback_used=true` on fallback.

## Compatibility

- Backwards-compatible for deployments that explicitly want `multi` — set `SAG_DIFY_SEARCH_STRATEGY=multi` and behavior matches the previous default.
- No API/schema changes; only additive metadata keys in Dify record responses.