### PR TITLE
docs: add dedicated SAG CLI usage guide (EN/CN)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -271,7 +271,7 @@ sag auth login                   # 隐藏输入 JWT
 sag agent connect claude-code
 ```
 
-CLI **不会**把 JWT 写入 Agent 配置文件，可用时优先保存到操作系统凭据存储，且只会删除自己创建的 MCP 条目。任何写入操作都可以用 `--dry-run` 预览。完整命令参考见 [SAG CLI 说明文档](https://www.npmjs.com/package/@zleap-ai/sag-cli)。
+CLI **不会**把 JWT 写入 Agent 配置文件，可用时优先保存到操作系统凭据存储，且只会删除自己创建的 MCP 条目。任何写入操作都可以用 `--dry-run` 预览。完整使用指南见 [SAG CLI 使用指南](docs/sag-cli.md)。
 
 #### 可选：Agent Skill
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ sag auth login                   # prompts for JWT (hidden input)
 sag agent connect claude-code
 ```
 
-The CLI **never** writes your JWT into an Agent's config file, stores tokens in the OS keychain when available, and only removes MCP entries it created itself. Preview any write with `--dry-run`. Full command reference: see the [SAG CLI README](https://www.npmjs.com/package/@zleap-ai/sag-cli).
+The CLI **never** writes your JWT into an Agent's config file, stores tokens in the OS keychain when available, and only removes MCP entries it created itself. Preview any write with `--dry-run`. Full guide: [SAG CLI User Guide](docs/sag-cli.en.md).
 
 #### Optional: Agent Skill
 

--- a/docs/sag-cli.en.md
+++ b/docs/sag-cli.en.md
@@ -1,0 +1,179 @@
+# SAG CLI User Guide
+
+`@zleap-ai/sag-cli` is the official command-line client for SAG knowledge bases. From your terminal it lets you:
+
+- Sign in to and validate a running SAG instance;
+- Inspect sources and document processing status, and search knowledge directly;
+- Verify the local Docker SAG knowledge-base MCP and wire it into Codex and Claude Code with a single command.
+
+## Is this tool for you
+
+- You already have a SAG instance (local Docker or remote HTTP) and want to query, diagnose, and expose it to coding agents from the terminal.
+- You are developing or operating SAG and need diagnostics such as `doctor` and `mcp test`.
+- You want to use SAG for retrieval inside Codex or Claude Code without hand-writing an MCP config.
+
+## Prerequisites
+
+| Task                                 | Requirement                                                               |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| Install and run the CLI              | Node.js **≥ 20.19**                                                       |
+| Sign in and search via the HTTP API  | A reachable SAG origin (e.g. `http://localhost:8000`) plus a SAG JWT      |
+| Use the local Docker token-less path | Docker CLI, with a SAG API container running `sag_api.mcp.server` locally |
+| Wire into Codex                      | Codex CLI (≥ 0.145) installed                                             |
+| Wire into Claude Code                | Claude Code (≥ 2.1) installed                                             |
+
+**Where to get the JWT**: sign in to SAG Web → **Settings → Integrations** and copy the JWT. The CLI hides the input and prefers the OS credential store (macOS Keychain, Windows Credential Manager, Linux Secret Service). When that is unavailable the token stays only in the current process; use the `SAG_TOKEN` environment variable in automation.
+
+## Install
+
+```bash
+npm install --global @zleap-ai/sag-cli
+sag --help
+sag version
+```
+
+## Quick start: pick the path that fits you
+
+The CLI offers two independent paths. Pick one based on your situation.
+
+### Path A: Local Docker, no token required (recommended for local dev)
+
+Requires a SAG API container running locally in Docker. The CLI discovers the container, talks to it over stdio MCP via `docker exec`, and never needs the JWT.
+
+```bash
+# 1. Verify the local Docker SAG MCP works
+sag mcp test
+
+# 2. Wire it into an agent (either or both)
+sag agent connect codex
+sag agent connect claude-code
+
+# 3. Check status any time
+sag agent status
+```
+
+Scope to a single source with `--source-id`:
+
+```bash
+sag mcp test --source-id <source-id>
+sag agent connect codex --source-id <source-id>
+```
+
+Preview the plan with `--dry-run` before writing anything:
+
+```bash
+sag agent connect codex --dry-run
+```
+
+Undo an integration:
+
+```bash
+sag agent disconnect codex
+```
+
+### Path B: HTTP API + JWT (across machines, or no Docker)
+
+Authenticate and search against SAG's HTTP API directly.
+
+```bash
+# 1. Register a SAG instance
+sag profile add local http://localhost:8000
+sag profile use local
+
+# 2. Sign in (prompts for the JWT)
+sag auth login
+sag auth status
+
+# 3. Health check and browse
+sag doctor
+sag source list
+sag document status --source <source-id>
+
+# 4. Search
+sag search "how to wire MCP" --source <source-id> --top-k 5
+```
+
+A profile stores only `scheme://host[:port]`. The `/api/v1` prefix is added by the CLI — do not put it in the URL yourself.
+
+## Command reference
+
+```text
+sag version
+sag auth login | status | logout
+sag profile add | list | use | show | remove
+sag doctor
+sag source list | get | status
+sag document list | get | status
+sag search <query>
+sag mcp test
+sag agent list
+sag agent connect <codex | claude-code>
+sag agent status [codex | claude-code]
+sag agent disconnect <codex | claude-code>
+```
+
+Common examples:
+
+```bash
+sag profile list --json
+sag source get <source-id>
+sag document list --source <source-id>
+sag search "how to wire MCP" --source <source-id> --strategy multi
+sag mcp test --container sag-api-1 --timeout 15000
+sag agent connect claude-code --name sag-knowledge-local
+```
+
+## Global options
+
+```text
+--profile <name>   Select a profile
+--url <origin>     Override the SAG origin for one command
+--json             Emit stable JSON (schema: sag.cli.v1)
+--quiet            Print only the essential value
+--yes              Confirm a safe local configuration operation
+```
+
+## Environment variables and resolution order
+
+Priority: **CLI flag > environment variable > current profile > local default probe**.
+
+```bash
+SAG_URL=http://localhost:8000
+SAG_TOKEN=<jwt>
+SAG_PROFILE=local
+```
+
+Profile storage locations:
+
+| Platform | Path                                                                      |
+| -------- | ------------------------------------------------------------------------- |
+| macOS    | `~/Library/Application Support/sag-cli/config.yaml`                       |
+| Linux    | `$XDG_CONFIG_HOME/sag-cli/config.yaml` or `~/.config/sag-cli/config.yaml` |
+| Windows  | `%APPDATA%\sag-cli\config.yaml`                                           |
+
+Agent-integration managed state is kept in `managed-connections.yaml` (mode `0600`). Do not edit it by hand.
+
+## Agent integration safety
+
+- SAG CLI **never** writes the JWT into agent configuration. The local Docker path needs no token at all.
+- The default MCP entry name is `sag-knowledge-<profile>`, or `sag-knowledge-local` when no profile is active.
+- The CLI only removes MCP entries it created whose fingerprint is unchanged. Same-name user entries and external edits block overwrite and delete.
+- `--dry-run` shows the plan only; `--yes` skips confirmation but never skips conflict checks.
+
+## JSON output and exit codes
+
+Under `--json`, both success and failure use a fixed schema:
+
+```json
+{ "schema": "sag.cli.v1", "ok": true, "data": {} }
+```
+
+```json
+{
+  "schema": "sag.cli.v1",
+  "ok": false,
+  "error": { "code": "AUTH_REQUIRED", "message": "No SAG token is configured" }
+}
+```
+
+Tokens never appear in JSON, logs, or error output. Full error and exit codes live in the [CLI architecture docs](https://github.com/Zleap-AI/sag-cli).

--- a/docs/sag-cli.md
+++ b/docs/sag-cli.md
@@ -1,0 +1,179 @@
+# SAG CLI 使用指南
+
+`@zleap-ai/sag-cli` 是 SAG 知识库的官方命令行客户端。从终端里你可以：
+
+- 登录并验证一个正在运行的 SAG 实例；
+- 查看信源、文档处理状态，直接检索知识内容；
+- 验证本机 Docker SAG 的知识库 MCP，并把它一键接入 Codex 和 Claude Code。
+
+## 你适不适合用它
+
+- 你手上已经有一个 SAG 实例（本机 Docker 或远程 HTTP），想在终端里查它、调它、把它接给编码 Agent。
+- 你在开发或运维 SAG，需要 `doctor`、`mcp test` 这类诊断能力。
+- 你只是想在 Codex 或 Claude Code 里用 SAG 做知识检索，又不想手写 MCP 配置。
+
+## 前置条件
+
+| 你想做的事                  | 需要准备                                                    |
+| --------------------------- | ----------------------------------------------------------- |
+| 安装并运行 CLI              | Node.js **≥ 20.19**                                         |
+| 用 HTTP API 登录、搜索      | 一个可访问的 SAG Origin（如 `http://localhost:8000`）+ JWT  |
+| 用本机 Docker 免 Token 路径 | Docker CLI，且本机运行着含 `sag_api.mcp.server` 的 SAG 容器 |
+| 接入 Codex                  | 已安装 Codex CLI（≥ 0.145）                                 |
+| 接入 Claude Code            | 已安装 Claude Code（≥ 2.1）                                 |
+
+**JWT 从哪拿**：登录 SAG Web → **Settings → Integrations**，复制其中的 JWT。CLI 会隐藏输入并优先保存到系统凭据存储（macOS Keychain、Windows Credential Manager、Linux Secret Service）；不可用时只保留在当前进程，自动化环境请改用 `SAG_TOKEN` 环境变量。
+
+## 安装
+
+```bash
+npm install --global @zleap-ai/sag-cli
+sag --help
+sag version
+```
+
+## 快速上手：选一条适合你的路径
+
+CLI 提供两条互相独立的路径，按你的场景选。
+
+### 路径 A：本机 Docker，免 Token（推荐给本地开发者）
+
+前提是本机 Docker 已经在跑 SAG API 容器。CLI 会自动发现容器，通过 `docker exec` 走 stdio MCP，全程不需要 JWT。
+
+```bash
+# 1. 验证本机 Docker SAG MCP 可以工作
+sag mcp test
+
+# 2. 把它接入你的 Agent（选一个或两个都接）
+sag agent connect codex
+sag agent connect claude-code
+
+# 3. 随时看接入状态
+sag agent status
+```
+
+只想验证 / 接入某一个信源时加 `--source-id`：
+
+```bash
+sag mcp test --source-id <source-id>
+sag agent connect codex --source-id <source-id>
+```
+
+不放心可以先 `--dry-run` 看计划：
+
+```bash
+sag agent connect codex --dry-run
+```
+
+想撤掉接入：
+
+```bash
+sag agent disconnect codex
+```
+
+### 路径 B：HTTP API + JWT（跨机器、或本机没有 Docker）
+
+用 SAG 的 HTTP API 做认证、查询、检索。
+
+```bash
+# 1. 记录一个 SAG 实例
+sag profile add local http://localhost:8000
+sag profile use local
+
+# 2. 登录（会提示输入 JWT）
+sag auth login
+sag auth status
+
+# 3. 体检 + 看信源
+sag doctor
+sag source list
+sag document status --source <source-id>
+
+# 4. 检索
+sag search "MCP 如何接入" --source <source-id> --top-k 5
+```
+
+Profile URL 只保存 `scheme://host[:port]`。API 前缀 `/api/v1` 由 CLI 自动补齐，不要自己写。
+
+## 命令一览
+
+```text
+sag version
+sag auth login | status | logout
+sag profile add | list | use | show | remove
+sag doctor
+sag source list | get | status
+sag document list | get | status
+sag search <query>
+sag mcp test
+sag agent list
+sag agent connect <codex | claude-code>
+sag agent status [codex | claude-code]
+sag agent disconnect <codex | claude-code>
+```
+
+常用示例：
+
+```bash
+sag profile list --json
+sag source get <source-id>
+sag document list --source <source-id>
+sag search "MCP 如何接入" --source <source-id> --strategy multi
+sag mcp test --container sag-api-1 --timeout 15000
+sag agent connect claude-code --name sag-knowledge-local
+```
+
+## 全局参数
+
+```text
+--profile <name>   选择 Profile
+--url <origin>     临时指定 SAG Origin
+--json             输出稳定 JSON（schema: sag.cli.v1）
+--quiet            只输出核心值
+--yes              确认安全的本地配置操作
+```
+
+## 环境变量与配置优先级
+
+优先级：**命令行参数 > 环境变量 > 当前 Profile > 本地默认探测**。
+
+```bash
+SAG_URL=http://localhost:8000
+SAG_TOKEN=<jwt>
+SAG_PROFILE=local
+```
+
+Profile 配置存放位置：
+
+| 平台    | 路径                                                                      |
+| ------- | ------------------------------------------------------------------------- |
+| macOS   | `~/Library/Application Support/sag-cli/config.yaml`                       |
+| Linux   | `$XDG_CONFIG_HOME/sag-cli/config.yaml` 或 `~/.config/sag-cli/config.yaml` |
+| Windows | `%APPDATA%\sag-cli\config.yaml`                                           |
+
+Agent 接入的受管状态另存于 `managed-connections.yaml`（权限 `0600`），不要手工编辑。
+
+## Agent 接入的安全约束
+
+- SAG CLI **不会** 把 JWT 写入 Agent 配置。本机 Docker 路径无需 Token。
+- 默认 MCP 名称为 `sag-knowledge-<profile>`，无 Profile 时为 `sag-knowledge-local`。
+- 只删除自己创建、指纹未变化的 MCP 条目；检测到同名用户配置或外部改动会拒绝覆盖。
+- `--dry-run` 只展示计划；`--yes` 跳过确认但不跳过冲突检查。
+
+## JSON 输出与退出码
+
+`--json` 下成功与失败使用固定 Schema：
+
+```json
+{ "schema": "sag.cli.v1", "ok": true, "data": {} }
+```
+
+```json
+{
+  "schema": "sag.cli.v1",
+  "ok": false,
+  "error": { "code": "AUTH_REQUIRED", "message": "No SAG token is configured" }
+}
+```
+
+Token 不会出现在 JSON、日志或错误输出里。完整错误码与退出码见 [CLI 架构文档](https://github.com/Zleap-AI/sag-cli)。


### PR DESCRIPTION
## Summary

- Adds a standalone, detailed SAG CLI user guide in both English (`docs/sag-cli.en.md`) and Chinese (`docs/sag-cli.md`), covering installation, quick-start paths, command reference, global options, env vars, safety guarantees, and JSON output.
- Updates the README MCP guide "Recommended" subsection in both languages to link to the new in-repo guide instead of pointing to the npm package page for full command reference.
- Content is adapted from the CLI's own README, excluding dev-process sections (architecture, development, compatibility, release, contributing).

## Test plan

- [ ] Verify `docs/sag-cli.md` and `docs/sag-cli.en.md` render correctly on GitHub
- [ ] Confirm cross-links from README.md and README-CN.md MCP guide sections point to the correct doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)