### PR TITLE
docs: SAG CLI release note, usage guide, and Skill migration

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -46,7 +46,7 @@ https://github.com/user-attachments/assets/cae70570-3885-490f-9126-dea23dcb369c
 
 **2026 年 7 月 31 日**
 
-发布 SAG 官方命令行客户端 [`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli)。一条命令（`sag agent connect codex | claude-code`）即可把 SAG 知识库 MCP 挂载进 Codex 或 Claude Code，不再需要复制 JWT 或手改配置文件。下方「MCP 指南」已改以 CLI 为主要接入路径。
+发布 SAG 官方命令行客户端 [`@zleap-ai/sag-cli`](docs/sag-cli.md)。一条命令（`sag agent connect codex | claude-code`）即可把 SAG 知识库 MCP 挂载进 Codex 或 Claude Code，不再需要复制 JWT 或手改配置文件。下方「MCP 指南」已改以 CLI 为主要接入路径。
 
 **2026 年 7 月 14 日**
 
@@ -249,7 +249,7 @@ PDF 在 MinerU 配置完整时优先使用 MinerU；未配置或解析失败时�
 
 #### 第一步：用 CLI 挂载 MCP
 
-[`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli) 是 SAG 的官方命令行客户端。它会自动发现本机 Docker SAG 容器，验证 MCP 可用，并把它接入 Codex 或 Claude Code —— 本机 Docker 路径全程不需要 JWT。
+[`@zleap-ai/sag-cli`](docs/sag-cli.md) 是 SAG 的官方命令行客户端。它会自动发现本机 Docker SAG 容器，验证 MCP 可用，并把它接入 Codex 或 Claude Code —— 本机 Docker 路径全程不需要 JWT。
 
 安装（Node.js ≥ 20.19）：
 
@@ -279,7 +279,7 @@ CLI **不会**把 JWT 写入 Agent 配置文件，可用时优先保存到操作
 
 #### 第二步：安装 Skill
 
-Skill 随 [`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli) 发布，复制到 Agent 的 skills 目录即可：
+Skill 随 [`@zleap-ai/sag-cli`](docs/sag-cli.md) 发布，复制到 Agent 的 skills 目录即可：
 
 ```bash
 # Claude Code

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://github.com/user-attachments/assets/9bb618e9-fef8-4d07-8a30-3f7d83beb0ff
 
 **July 31, 2026**
 
-Published the official command-line client [`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli). One command (`sag agent connect codex | claude-code`) mounts the SAG Knowledge MCP into Codex or Claude Code — no JWT copy-paste, no hand-edited config files. The MCP guide below now leads with the CLI.
+Published the official command-line client [`@zleap-ai/sag-cli`](docs/sag-cli.en.md). One command (`sag agent connect codex | claude-code`) mounts the SAG Knowledge MCP into Codex or Claude Code — no JWT copy-paste, no hand-edited config files. The MCP guide below now leads with the CLI.
 
 **July 14, 2026**
 
@@ -249,7 +249,7 @@ The recommended path is two steps: **CLI** mounts the MCP, **Skill** teaches the
 
 #### Step 1: mount MCP with the CLI
 
-[`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli) is the official command-line client. It auto-discovers your local Docker SAG container, verifies the MCP works, and wires it into Codex or Claude Code — for the local Docker path no JWT is needed.
+[`@zleap-ai/sag-cli`](docs/sag-cli.en.md) is the official command-line client. It auto-discovers your local Docker SAG container, verifies the MCP works, and wires it into Codex or Claude Code — for the local Docker path no JWT is needed.
 
 Install (Node.js ≥ 20.19):
 
@@ -279,7 +279,7 @@ The CLI **never** writes your JWT into an Agent's config file, stores tokens in 
 
 #### Step 2: install the Skill
 
-The Skill ships in [`@zleap-ai/sag-cli`](https://www.npmjs.com/package/@zleap-ai/sag-cli). Copy it into your Agent's skills directory:
+The Skill ships in [`@zleap-ai/sag-cli`](docs/sag-cli.en.md). Copy it into your Agent's skills directory:
 
 ```bash
 # Claude Code


### PR DESCRIPTION
## Summary

- Add SAG CLI usage guide (`docs/sag-cli.md` / `docs/sag-cli.en.md`)
- Restructure README MCP guide: CLI as primary path, Skill ships with npm package
- Migrate Skill from `skills/sag/` to sag-cli repo
- Add HTTP API routes for outline, grep, read, entity context (supports sag-cli knowledge commands)
- Update WeChat community QR code

## Changes

- `CHANGELOG.md` — log the initial `@zleap-ai/sag-cli` release
- `README.md` / `README-CN.md` — MCP guide leads with CLI, links point to local docs
- `docs/sag-cli.md` / `docs/sag-cli.en.md` — dedicated CLI usage guide
- `apps/api/sag_api/api/v1/knowledge.py` — new HTTP routes for knowledge retrieval
- `apps/api/sag_api/schemas/chunk.py` — response models
- `skills/sag/` — removed (Skill moved to sag-cli repo)
- `docs/assets/readme/wechat-community-qr.png` — updated