### PR TITLE
fix: add structured output compatibility fallback

### DIFF
--- a/apps/api/sag_api/core/litellm_policy.py
+++ b/apps/api/sag_api/core/litellm_policy.py
@@ -72,7 +72,7 @@ def apply_litellm_completion_policy(
         normalized["extra_body"] = dict(settings.llm_extra_body)
 
     model = str(normalized.get("model") or settings.routed_llm_model)
-    if normalized.get("tools") and _is_deepseek_v4(model):
+    if _is_deepseek_v4(model):
         extra_body = dict(normalized.get("extra_body") or {})
         extra_body["thinking"] = {"type": "disabled"}
         normalized["extra_body"] = extra_body

--- a/apps/api/sag_api/sag/compat.py
+++ b/apps/api/sag_api/sag/compat.py
@@ -14,6 +14,28 @@ from sag_api.core.logging import get_logger
 log = get_logger("sag.compat")
 
 
+def _is_json_schema_response_format_unsupported(error: Exception) -> bool:
+    """Only downgrade the known structured-output capability rejection."""
+    message = str(error).casefold()
+    return "response_format" in message and (
+        "unavailable" in message or "not support" in message or "unsupported" in message
+    )
+
+
+def _validate_response_schema(result: Any, schema: dict[str, Any]) -> None:
+    """Keep local validation when the provider only guarantees a JSON object."""
+    try:
+        import jsonschema
+    except ImportError:
+        expected_type = schema.get("type")
+        if expected_type == "object" and not isinstance(result, dict):
+            raise ValueError("响应类型不符合Schema: 期望 object") from None
+        if expected_type == "array" and not isinstance(result, list):
+            raise ValueError("响应类型不符合Schema: 期望 array") from None
+        return
+    jsonschema.validate(instance=result, schema=schema)
+
+
 def _without_required_field(node: dict[str, Any], field: str) -> bool:
     required = node.get("required")
     if not isinstance(required, list) or field not in required:
@@ -106,7 +128,20 @@ def install_zleap_sag_extract_compat() -> None:
         active_schema = schema
         if _looks_like_extract_response_schema(schema):
             active_schema = _relax_extract_schema(schema)
-        result = await current(self, messages, active_schema)
+        try:
+            result = await current(self, messages, active_schema)
+        except Exception as error:
+            if not _is_json_schema_response_format_unsupported(error):
+                raise
+            log.warning("模型不支持 response_format=json_schema，降级为 json_object")
+            # response_schema=None prevents zleap-sag from re-injecting json_schema.
+            # Its client still parses JSON; SAG performs the same schema validation locally.
+            result = await self.llm_client.chat_with_schema(
+                messages,
+                response_schema=None,
+                response_format={"type": "json_object"},
+            )
+            _validate_response_schema(result, active_schema)
         repaired = _repair_extract_response(result)
         if repaired:
             log.info("已兼容补齐 zleap-sag 事项抽取响应字段：%s", ", ".join(sorted(repaired)))

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -150,7 +150,7 @@ def test_deepseek_v4_disables_thinking_for_every_agent_tool_turn(tool_choice, ba
         assert request["tool_choice"] == tool_choice
 
 
-def test_deepseek_v4_plain_completion_keeps_provider_default_thinking():
+def test_deepseek_v4_plain_completion_disables_thinking():
     configured = Settings(
         _env_file=None,
         llm_provider="openai",
@@ -164,7 +164,7 @@ def test_deepseek_v4_plain_completion_keeps_provider_default_thinking():
         {"model": configured.routed_llm_model, "messages": []},
     )
 
-    assert "extra_body" not in request
+    assert request["extra_body"]["thinking"] == {"type": "disabled"}
 
 
 def test_deepseek_v4_tool_policy_preserves_other_extra_body_fields():
@@ -693,6 +693,70 @@ async def test_zleap_sag_extract_compat_repairs_missing_is_valid():
     item = result["data"]["items"][0]
     assert item["is_valid"] is True
     assert item["children"][0]["is_valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_zleap_sag_extract_compat_falls_back_to_json_object_when_json_schema_is_unavailable():
+    from zleap.sag.core.ai.base import BaseLLMClient
+    from zleap.sag.core.ai.models import LLMMessage, LLMResponse, LLMRole
+    from zleap.sag.modules.extract.processor import EventProcessor
+
+    from sag_api.sag.compat import install_zleap_sag_extract_compat
+
+    class JsonObjectOnlyClient(BaseLLMClient):
+        def __init__(self):
+            self.config = SimpleNamespace(
+                model="moonshotai/kimi-k3",
+                base_url="https://api.example.test/v1",
+            )
+            self.response_formats = []
+
+        async def chat(self, _messages, **kwargs):
+            response_format = kwargs.get("response_format")
+            self.response_formats.append(response_format)
+            if response_format and response_format.get("type") == "json_schema":
+                raise RuntimeError("This response_format type is unavailable now")
+            assert response_format == {"type": "json_object"}
+            return LLMResponse(
+                content='{"type":"response","data":{"items":[],"meta":{"reason":"ok"}}}',
+                model="moonshotai/kimi-k3",
+            )
+
+        async def chat_stream(self, *_args, **_kwargs):
+            if False:
+                yield ""
+
+    install_zleap_sag_extract_compat()
+    schema = {
+        "type": "object",
+        "required": ["type", "data"],
+        "properties": {
+            "type": {"const": "response"},
+            "data": {
+                "type": "object",
+                "required": ["items", "meta"],
+                "properties": {
+                    "items": {"type": "array"},
+                    "meta": {
+                        "type": "object",
+                        "required": ["reason"],
+                        "properties": {"reason": {"type": "string"}},
+                    },
+                },
+            },
+        },
+    }
+    client = JsonObjectOnlyClient()
+    fake_processor = SimpleNamespace(llm_client=client)
+
+    result = await EventProcessor._call_llm_with_retry(
+        fake_processor,
+        [LLMMessage(role=LLMRole.USER, content="extract")],
+        schema,
+    )
+
+    assert result["data"]["meta"]["reason"] == "ok"
+    assert [item["type"] for item in client.response_formats] == ["json_schema", "json_object"]
 
 
 def test_agent_name_is_injected_into_prompt():


### PR DESCRIPTION
## Summary

- Fall back from unsupported `response_format: json_schema` to `json_object` during event extraction, while retaining local JSON Schema validation.
- Disable thinking for every DeepSeek V4 request, including document chunk extraction.

## Root cause

Some OpenAI-compatible providers reject `json_schema`; the previous compatibility layer retried every chunk only after that deterministic request failure. DeepSeek V4 document extraction did not carry tools, so it bypassed the existing thinking-disable policy.

## Validation

- `ruff check sag_api/core/litellm_policy.py sag_api/sag/compat.py tests/test_units.py`
- `pytest tests/test_units.py tests/test_document_resume.py -q` (`54 passed`)
