### PR TITLE
fix: use json object mode for deepseek

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -266,12 +266,12 @@ sag agent connect claude-code    # 或挂载进 Claude Code
 sag agent status                 # 查看当前接入状态
 ```
 
-接入远程 SAG 实例（本机没有 Docker）时，从 **设置 → 集成** 复制 JWT 并先登录：
+接入远程 SAG 实例（本机没有 Docker）时，先在终端登录：
 
 ```bash
 sag profile add prod https://sag.example.com
 sag profile use prod
-sag auth login                   # 隐藏输入 JWT
+sag auth login --name "你的名字" # 直接登录 SAG
 sag agent connect claude-code
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,12 +266,12 @@ sag agent connect claude-code    # or mount into Claude Code
 sag agent status                 # see what's wired
 ```
 
-For a remote SAG instance (no local Docker), grab a JWT from **Settings → Integrations** and log in first:
+For a remote SAG instance (no local Docker), sign in from the terminal first:
 
 ```bash
 sag profile add prod https://sag.example.com
 sag profile use prod
-sag auth login                   # prompts for JWT (hidden input)
+sag auth login --name "Your name" # signs in to SAG directly
 sag agent connect claude-code
 ```
 

--- a/apps/api/sag_api/sag/compat.py
+++ b/apps/api/sag_api/sag/compat.py
@@ -14,6 +14,23 @@ from sag_api.core.logging import get_logger
 log = get_logger("sag.compat")
 
 
+
+
+
+def _llm_model_name(client: Any) -> str:
+    current = client
+    while current is not None:
+        model = getattr(getattr(current, "config", None), "model", None)
+        if isinstance(model, str) and model:
+            return model
+        current = getattr(current, "client", None)
+    return ""
+
+
+def _uses_deepseek(client: Any) -> bool:
+    return "deepseek" in _llm_model_name(client).rsplit("/", 1)[-1].casefold()
+
+
 def _is_json_schema_response_format_unsupported(error: Exception) -> bool:
     """Only downgrade the known structured-output capability rejection."""
     message = str(error).casefold()
@@ -128,20 +145,27 @@ def install_zleap_sag_extract_compat() -> None:
         active_schema = schema
         if _looks_like_extract_response_schema(schema):
             active_schema = _relax_extract_schema(schema)
-        try:
-            result = await current(self, messages, active_schema)
-        except Exception as error:
-            if not _is_json_schema_response_format_unsupported(error):
-                raise
-            log.warning("模型不支持 response_format=json_schema，降级为 json_object")
-            # response_schema=None prevents zleap-sag from re-injecting json_schema.
-            # Its client still parses JSON; SAG performs the same schema validation locally.
+        if _uses_deepseek(self.llm_client):
+            log.info("DeepSeek 固定使用 response_format=json_object")
             result = await self.llm_client.chat_with_schema(
                 messages,
                 response_schema=None,
                 response_format={"type": "json_object"},
             )
             _validate_response_schema(result, active_schema)
+        else:
+            try:
+                result = await current(self, messages, active_schema)
+            except Exception as error:
+                if not _is_json_schema_response_format_unsupported(error):
+                    raise
+                log.warning("模型不支持 response_format=json_schema，降级为 json_object")
+                result = await self.llm_client.chat_with_schema(
+                    messages,
+                    response_schema=None,
+                    response_format={"type": "json_object"},
+                )
+                _validate_response_schema(result, active_schema)
         repaired = _repair_extract_response(result)
         if repaired:
             log.info("已兼容补齐 zleap-sag 事项抽取响应字段：%s", ", ".join(sorted(repaired)))

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -759,6 +759,32 @@ async def test_zleap_sag_extract_compat_falls_back_to_json_object_when_json_sche
     assert [item["type"] for item in client.response_formats] == ["json_schema", "json_object"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["openai/deepseek-v4-flash", "openai/deepseek-v3"])
+async def test_zleap_sag_extract_compat_uses_json_object_directly_for_deepseek(model):
+    from zleap.sag.modules.extract.processor import EventProcessor
+
+    from sag_api.sag.compat import install_zleap_sag_extract_compat
+
+    class DeepSeekClient:
+        def __init__(self):
+            self.config = SimpleNamespace(model=model)
+            self.calls = []
+
+        async def chat_with_schema(self, _messages, response_schema, **kwargs):
+            self.calls.append((response_schema, kwargs.get("response_format")))
+            return {"type": "response", "data": {"items": [], "meta": {"reason": "ok"}}}
+
+    install_zleap_sag_extract_compat()
+    schema = {"type": "object", "properties": {"type": {"const": "response"}}}
+    client = DeepSeekClient()
+
+    result = await EventProcessor._call_llm_with_retry(SimpleNamespace(llm_client=client), [], schema)
+
+    assert result["data"]["meta"]["reason"] == "ok"
+    assert client.calls == [(None, {"type": "json_object"})]
+
+
 def test_agent_name_is_injected_into_prompt():
     messages = build_agent_messages(
         "小跃",

--- a/docs/sag-cli.en.md
+++ b/docs/sag-cli.en.md
@@ -17,12 +17,12 @@
 | Task                                 | Requirement                                                               |
 | ------------------------------------ | ------------------------------------------------------------------------- |
 | Install and run the CLI              | Node.js **≥ 20.19**                                                       |
-| Sign in and search via the HTTP API  | A reachable SAG origin (e.g. `http://localhost:8000`) plus a SAG JWT      |
+| Sign in and search via the HTTP API  | A reachable SAG origin (e.g. `http://localhost:8000`)                      |
 | Use the local Docker token-less path | Docker CLI, with a SAG API container running `sag_api.mcp.server` locally |
 | Wire into Codex                      | Codex CLI (≥ 0.145) installed                                             |
 | Wire into Claude Code                | Claude Code (≥ 2.1) installed                                             |
 
-**Where to get the JWT**: sign in to SAG Web → **Settings → Integrations** and copy the JWT. The CLI hides the input and prefers the OS credential store (macOS Keychain, Windows Credential Manager, Linux Secret Service). When that is unavailable the token stays only in the current process; use the `SAG_TOKEN` environment variable in automation.
+**How to sign in**: run `sag auth login --name "Your name"`, or omit `--name` and enter the name in the terminal. The CLI calls SAG's existing login API and prefers the OS credential store (macOS Keychain, Windows Credential Manager, Linux Secret Service). You can also use the `SAG_TOKEN` environment variable in automation.
 
 ## Install
 
@@ -71,7 +71,7 @@ Undo an integration:
 sag agent disconnect codex
 ```
 
-### Path B: HTTP API + JWT (across machines, or no Docker)
+### Path B: HTTP API direct sign-in (across machines, or no Docker)
 
 Authenticate and search against SAG's HTTP API directly.
 
@@ -80,8 +80,8 @@ Authenticate and search against SAG's HTTP API directly.
 sag profile add local http://localhost:8000
 sag profile use local
 
-# 2. Sign in (prompts for the JWT)
-sag auth login
+# 2. Sign in through SAG's existing login API
+sag auth login --name "Your name"
 sag auth status
 
 # 3. Health check and browse
@@ -105,6 +105,10 @@ sag doctor
 sag source list | get | status
 sag document list | get | status
 sag search <query>
+sag outline <document-id>
+sag grep <pattern>
+sag read <document-id>
+sag get-entity <name>
 sag mcp test
 sag agent list
 sag agent connect <codex | claude-code>

--- a/docs/sag-cli.md
+++ b/docs/sag-cli.md
@@ -17,12 +17,12 @@
 | 你想做的事                  | 需要准备                                                    |
 | --------------------------- | ----------------------------------------------------------- |
 | 安装并运行 CLI              | Node.js **≥ 20.19**                                         |
-| 用 HTTP API 登录、搜索      | 一个可访问的 SAG Origin（如 `http://localhost:8000`）+ JWT  |
+| 用 HTTP API 登录、搜索      | 一个可访问的 SAG Origin（如 `http://localhost:8000`）       |
 | 用本机 Docker 免 Token 路径 | Docker CLI，且本机运行着含 `sag_api.mcp.server` 的 SAG 容器 |
 | 接入 Codex                  | 已安装 Codex CLI（≥ 0.145）                                 |
 | 接入 Claude Code            | 已安装 Claude Code（≥ 2.1）                                 |
 
-**JWT 从哪拿**：登录 SAG Web → **Settings → Integrations**，复制其中的 JWT。CLI 会隐藏输入并优先保存到系统凭据存储（macOS Keychain、Windows Credential Manager、Linux Secret Service）；不可用时只保留在当前进程，自动化环境请改用 `SAG_TOKEN` 环境变量。
+**登录方式**：执行 `sag auth login --name "你的名字"`，或省略 `--name` 后在终端输入名字。CLI 调用 SAG 现有登录接口，并优先把凭据保存到系统凭据存储（macOS Keychain、Windows Credential Manager、Linux Secret Service）。自动化环境也可以使用 `SAG_TOKEN` 环境变量。
 
 ## 安装
 
@@ -71,7 +71,7 @@ sag agent connect codex --dry-run
 sag agent disconnect codex
 ```
 
-### 路径 B：HTTP API + JWT（跨机器、或本机没有 Docker）
+### 路径 B：HTTP API 直连登录（跨机器、或本机没有 Docker）
 
 用 SAG 的 HTTP API 做认证、查询、检索。
 
@@ -80,8 +80,8 @@ sag agent disconnect codex
 sag profile add local http://localhost:8000
 sag profile use local
 
-# 2. 登录（会提示输入 JWT）
-sag auth login
+# 2. 登录（直接调用 SAG 登录接口）
+sag auth login --name "你的名字"
 sag auth status
 
 # 3. 体检 + 看信源
@@ -105,6 +105,10 @@ sag doctor
 sag source list | get | status
 sag document list | get | status
 sag search <query>
+sag outline <document-id>
+sag grep <pattern>
+sag read <document-id>
+sag get-entity <name>
 sag mcp test
 sag agent list
 sag agent connect <codex | claude-code>


### PR DESCRIPTION
## Summary

- Send DeepSeek extraction requests directly with `response_format: {"type": "json_object"}`.
- Keep local JSON Schema validation after parsing the provider response.

## Why

DeepSeek gateways that do not support `json_schema` previously received one deterministic 400 request per chunk before SAG fell back to `json_object`.

## Validation

- `ruff check sag_api/core/litellm_policy.py sag_api/sag/compat.py tests/test_units.py`
- `pytest tests/test_units.py tests/test_document_resume.py -q` (`56 passed`)
