### PR TITLE
fix: guard SQLite integer overflow during extraction

### DIFF
--- a/apps/api/sag_api/sag/incremental_processor.py
+++ b/apps/api/sag_api/sag/incremental_processor.py
@@ -28,6 +28,9 @@ StageCallback = Callable[[str], Awaitable[None]]
 
 log = get_logger("sag.incremental")
 
+_SQLITE_INTEGER_MIN = -(2**63)
+_SQLITE_INTEGER_MAX = 2**63 - 1
+
 _KNOWLEDGE_EVENT_REQUIREMENTS = """
 对于书籍、报告、论文等非新闻文档，“事项”也包括可独立理解的观点、事实、定义、
 机制、因果关系、论证和结论，不要求必须包含日期、人物动作或新闻事件。
@@ -161,11 +164,76 @@ def _normalize_event_entity_aliases(event: object, allowed_types: set[str]) -> i
     return normalized
 
 
-def _normalize_extraction_response(response: Any, allowed_types: set[str]) -> int:
-    """Apply the narrow entity-key compatibility rule to one LLM response."""
+def _value_overflows_sqlite_integer(value: object, entity_type: object) -> bool:
+    """Match zleap-sag numeric parsing, then check SQLite's signed range."""
 
-    if not allowed_types:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return not _SQLITE_INTEGER_MIN <= value <= _SQLITE_INTEGER_MAX
+    if not isinstance(value, str):
+        return False
+    from zleap.sag.modules.extract.parser import EntityValueParser
+
+    parse = getattr(EntityValueParser, "_sag_original_parse", EntityValueParser.parse)
+    parsed = parse(EntityValueParser(), value, entity_type=entity_type if isinstance(entity_type, str) else None)
+    return bool(
+        parsed
+        and parsed.get("type") == "int"
+        and not _SQLITE_INTEGER_MIN <= int(parsed["value"]) <= _SQLITE_INTEGER_MAX
+    )
+
+
+def _install_sqlite_integer_guard() -> None:
+    """Guard zleap-sag's parser at the same boundary that persists Entity.int_value."""
+
+    from zleap.sag.modules.extract.parser import EntityValueParser
+
+    if getattr(EntityValueParser, "_sag_sqlite_integer_guard_installed", False):
+        return
+    original_parse = EntityValueParser.parse
+
+    def guarded_parse(self: Any, text: str, *args: Any, **kwargs: Any):
+        result = original_parse(self, text, *args, **kwargs)
+        if result and result.get("type") == "int" and _value_overflows_sqlite_integer(result.get("value"), None):
+            return {**result, "type": "text", "value": str(text), "unit": None}
+        return result
+
+    EntityValueParser.parse = guarded_parse
+    EntityValueParser._sag_original_parse = original_parse
+    EntityValueParser._sag_sqlite_integer_guard_installed = True
+    log.warning("已启用 zleap-sag SQLite 整数范围兼容保护")
+
+
+_install_sqlite_integer_guard()
+
+
+def _normalize_event_entity_values(event: object) -> int:
+    """Downgrade integer entities that SQLite cannot store without losing their text."""
+
+    if not isinstance(event, dict):
         return 0
+    normalized = 0
+    entities = event.get("entities")
+    if isinstance(entities, list):
+        for entity in entities:
+            if not isinstance(entity, dict) or entity.get("value_type") == "text":
+                continue
+            candidate = entity.get("value") if entity.get("value_type") == "int" else entity.get("name")
+            if _value_overflows_sqlite_integer(candidate, entity.get("type")):
+                entity["value_type"] = "text"
+                normalized += 1
+
+    children = event.get("children")
+    if isinstance(children, list):
+        for child in children:
+            normalized += _normalize_event_entity_values(child)
+    return normalized
+
+
+def _normalize_extraction_response(response: Any, allowed_types: set[str]) -> int:
+    """Normalize response fields that would otherwise fail upstream persistence."""
+
     content = getattr(response, "content", None)
     if not isinstance(content, str):
         return 0
@@ -187,7 +255,9 @@ def _normalize_extraction_response(response: Any, allowed_types: set[str]) -> in
     if not isinstance(items, list):
         return 0
 
-    normalized = sum(_normalize_event_entity_aliases(item, allowed_types) for item in items)
+    normalized = sum(
+        _normalize_event_entity_aliases(item, allowed_types) + _normalize_event_entity_values(item) for item in items
+    )
     if normalized:
         response.content = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
     return normalized

--- a/apps/api/tests/test_document_resume.py
+++ b/apps/api/tests/test_document_resume.py
@@ -403,6 +403,142 @@ def test_extraction_response_does_not_invent_unknown_entity_type():
     assert response.content == original
 
 
+def test_extraction_response_downgrades_overflow_integer_entity_value():
+    import json
+
+    from sag_api.sag.incremental_processor import _normalize_extraction_response
+
+    response = SimpleNamespace(
+        content=json.dumps(
+            {
+                "data": {
+                    "items": [
+                        {
+                            "entities": [
+                                {
+                                    "type": "metric",
+                                    "name": "累计交易笔数",
+                                    "description": "统计指标",
+                                    "value_type": "int",
+                                    "value": "9223372036854775808",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    assert _normalize_extraction_response(response, {"metric"}) == 1
+    entity = json.loads(response.content)["data"]["items"][0]["entities"][0]
+    assert entity["value_type"] == "text"
+    assert entity["value"] == "9223372036854775808"
+
+
+def test_extraction_response_keeps_sqlite_integer_boundaries():
+    import json
+
+    from sag_api.sag.incremental_processor import _normalize_extraction_response
+
+    values = ["-9223372036854775808", "9223372036854775807"]
+    response = SimpleNamespace(
+        content=json.dumps(
+            {
+                "data": {
+                    "items": [
+                        {
+                            "entities": [
+                                {
+                                    "type": "metric",
+                                    "name": value,
+                                    "description": "统计指标",
+                                    "value_type": "int",
+                                    "value": value,
+                                }
+                                for value in values
+                            ]
+                        }
+                    ]
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    assert _normalize_extraction_response(response, {"metric"}) == 0
+    entities = json.loads(response.content)["data"]["items"][0]["entities"]
+    assert [entity["value_type"] for entity in entities] == ["int", "int"]
+
+
+def test_upstream_entity_value_parser_downgrades_overflow_integer():
+    from zleap.sag.modules.extract.parser import EntityValueParser
+
+    from sag_api.sag.incremental_processor import _install_sqlite_integer_guard
+
+    _install_sqlite_integer_guard()
+    fields = EntityValueParser().parse_to_typed_fields("9223372036854775808笔", entity_type="metric")
+
+    assert fields["value_type"] == "text"
+    assert fields["int_value"] is None
+
+
+@pytest.mark.asyncio
+async def test_extract_chunk_downgrades_overflow_integer_before_sag_persists(monkeypatch):
+    import json
+
+    from sag_api.sag import incremental_processor as processor_module
+    from sag_api.sag.incremental_processor import IncrementalDocumentProcessor
+
+    payload = {
+        "data": {
+            "items": [
+                {
+                    "entities": [
+                        {
+                            "type": "metric",
+                            "name": "9223372036854775808笔",
+                            "description": "累计交易笔数",
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    class FakeLeafClient:
+        async def chat(self, messages, **kwargs):
+            return SimpleNamespace(
+                content=json.dumps(payload, ensure_ascii=False),
+                usage=SimpleNamespace(total_tokens=42),
+            )
+
+    class FakeRetryClient:
+        def __init__(self):
+            self.client = FakeLeafClient()
+
+    class FakeExtractor:
+        def __init__(self, **kwargs):
+            self.client = FakeRetryClient()
+
+        async def _get_llm_client(self):
+            return self.client
+
+        async def extract(self, config):
+            request = {"data": {"meta": {"entity_types": [{"type": "metric", "description": "指标"}]}}}
+            response = await self.client.client.chat([SimpleNamespace(content=json.dumps(request, ensure_ascii=False))])
+            entity = json.loads(response.content)["data"]["items"][0]["entities"][0]
+            assert entity["value_type"] == "text"
+            return [SimpleNamespace(id="event-1")]
+
+    monkeypatch.setattr(processor_module, "EventExtractor", FakeExtractor)
+    engine = SimpleNamespace(_extractor=SimpleNamespace(prompt_manager=object(), model_config={}))
+    processor = IncrementalDocumentProcessor(engine, "source-config", max_concurrency=1)
+
+    assert await processor._extract_chunk("chunk-1") == (["event-1"], 42)
+
+
 @pytest.mark.asyncio
 async def test_extract_chunk_raises_when_sag_swallows_chunk_failure(monkeypatch):
     from sag_api.sag import incremental_processor as processor_module


### PR DESCRIPTION
## Summary

- Add a temporary SAG-side compatibility guard for integers that exceed SQLite's signed 64-bit range.
- Preserve overflow values as text instead of failing document extraction.
- Add regression coverage and a manually uploadable reproduction fixture.

## Root cause

`zleap-sag` parses numeric entity values and persists them to SQLite without validating the signed 64-bit integer range. A large numeric identifier can therefore fail the entire chunk during entity persistence.

## Validation

- `pytest tests/test_document_resume.py -q` — 18 passed
- `ruff check sag_api/sag/incremental_processor.py tests/test_document_resume.py`

The full backend suite also passed previously (219 passed, 1 skipped); a later rerun reported an unrelated SQLite lock during `test_entity_read_path` teardown.

