### PR TITLE
ci(fnos): expose manual release entry

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -1,0 +1,190 @@
+name: fnOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Build verification mode
+        required: true
+        default: dry-run
+        type: choice
+        options: [dry-run, publish]
+      publish_confirmation:
+        description: Required only for publish; type PUBLISH
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fnos-release-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  verify-release-request:
+    name: Verify fnOS release request
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      revision: ${{ steps.metadata.outputs.revision }}
+      candidate_tag: ${{ steps.metadata.outputs.candidate_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: fnos/develop
+          fetch-depth: 0
+      - id: metadata
+        name: Require the permanent fnOS branch and explicit publish confirmation
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/fnos/develop)"
+          manifest_version="$(awk -F= '/^version[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2}' packages/fnos/sag/manifest)"
+          case "$manifest_version" in
+            [0-9]*.[0-9]*.[0-9]*-fnos.[0-9]*) ;;
+            *) echo "invalid fnOS version" >&2; exit 1 ;;
+          esac
+          if [ "${{ inputs.mode }}" = "publish" ]; then
+            test "${{ inputs.publish_confirmation }}" = "PUBLISH"
+          fi
+          revision="$(git rev-parse HEAD)"
+          printf 'version=%s\n' "$manifest_version" >> "$GITHUB_OUTPUT"
+          printf 'revision=%s\n' "$revision" >> "$GITHUB_OUTPUT"
+          printf 'candidate_tag=fnos-candidate-%s-%s\n' "$manifest_version" "${revision:0:12}" >> "$GITHUB_OUTPUT"
+      - name: Run fnOS static release tests
+        shell: bash
+        run: node --test scripts/tests/fnos-*.test.mjs
+
+  resolve-candidate:
+    name: Resolve approved candidate evidence
+    needs: verify-release-request
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      candidate_run_id: ${{ steps.evidence.outputs.candidate_run_id }}
+      api_digest: ${{ steps.evidence.outputs.api_digest }}
+      web_digest: ${{ steps.evidence.outputs.web_digest }}
+      gateway: ${{ steps.evidence.outputs.gateway }}
+    env:
+      CANDIDATE_TAG: ${{ needs.verify-release-request.outputs.candidate_tag }}
+      CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
+      CANDIDATE_REVISION: ${{ needs.verify-release-request.outputs.revision }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify-release-request.outputs.revision }}
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
+      - id: evidence
+        name: Require a successful candidate run and exact public images
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidate_run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?event=push&head_sha=${CANDIDATE_REVISION}&per_page=100" \
+            --jq '.workflow_runs[] | select(.name == "fnOS Candidate Images" and .head_branch == env.CANDIDATE_TAG and .conclusion == "success") | .id' \
+            | head -n 1)"
+          test -n "$candidate_run_id"
+          api_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "ghcr.io/zleap-ai/sag-api:${CANDIDATE_VERSION}")"
+          web_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "ghcr.io/zleap-ai/sag-web:${CANDIDATE_VERSION}")"
+          node scripts/fnos-release-registry.mjs verify-public \
+            --docker docker --api-image ghcr.io/zleap-ai/sag-api --web-image ghcr.io/zleap-ai/sag-web \
+            --candidate-version "$CANDIDATE_VERSION" --api-digest "$api_digest" --web-digest "$web_digest"
+          gateway="$(node scripts/fnos-gateway-policy.mjs verify --docker docker)"
+          printf 'candidate_run_id=%s\n' "$candidate_run_id" >> "$GITHUB_OUTPUT"
+          printf 'api_digest=%s\n' "$api_digest" >> "$GITHUB_OUTPUT"
+          printf 'web_digest=%s\n' "$web_digest" >> "$GITHUB_OUTPUT"
+          printf 'gateway=%s\n' "$gateway" >> "$GITHUB_OUTPUT"
+
+  build-package:
+    name: Build and validate fnOS package
+    needs: [verify-release-request, resolve-candidate]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify-release-request.outputs.revision }}
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
+      - name: Install checksum-pinned fnpack
+        shell: bash
+        run: |
+          set -euo pipefail
+          fnpack_path="$RUNNER_TEMP/fnpack"
+          curl --fail --location --retry 3 --output "$fnpack_path" https://static2.fnnas.com/fnpack/fnpack-1.2.3-linux-amd64
+          printf '%s  %s\n' 54b97fa7b70968c4d05c79840f5daeff508957d0bb2062fdb0376d00d9615c93 "$fnpack_path" | sha256sum --check --strict
+          chmod 0755 "$fnpack_path"
+          printf '%s\n' "$RUNNER_TEMP" >> "$GITHUB_PATH"
+      - name: Produce immutable evidence and FPK in runner workspace
+        env:
+          CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
+          CANDIDATE_RUN_ID: ${{ needs.resolve-candidate.outputs.candidate_run_id }}
+          API_DIGEST: ${{ needs.resolve-candidate.outputs.api_digest }}
+          WEB_DIGEST: ${{ needs.resolve-candidate.outputs.web_digest }}
+          GATEWAY_IMAGE: ${{ needs.resolve-candidate.outputs.gateway }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          node scripts/release-fnos.mjs prepare --version "$CANDIDATE_VERSION" --channel global --candidate-run-id "$CANDIDATE_RUN_ID" --output release/release-input.json
+          cat > release/candidate-evidence.json <<EOF
+          {"api":"ghcr.1ms.run/zleap-ai/sag-api@${API_DIGEST}","web":"ghcr.1ms.run/zleap-ai/sag-web@${WEB_DIGEST}","gateway":"${GATEWAY_IMAGE}"}
+          EOF
+          node scripts/release-fnos.mjs package --input release/release-input.json --candidate-evidence release/candidate-evidence.json --output release
+          node scripts/fnos-release-manifest.mjs validate --input release/release-manifest.json
+
+  publish-release:
+    name: Publish reviewed fnOS release assets
+    if: ${{ inputs.mode == 'publish' }}
+    needs: [verify-release-request, resolve-candidate, build-package]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify-release-request.outputs.revision }}
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
+      - name: Install checksum-pinned fnpack
+        shell: bash
+        run: |
+          set -euo pipefail
+          fnpack_path="$RUNNER_TEMP/fnpack"
+          curl --fail --location --retry 3 --output "$fnpack_path" https://static2.fnnas.com/fnpack/fnpack-1.2.3-linux-amd64
+          printf '%s  %s\n' 54b97fa7b70968c4d05c79840f5daeff508957d0bb2062fdb0376d00d9615c93 "$fnpack_path" | sha256sum --check --strict
+          chmod 0755 "$fnpack_path"
+          printf '%s\n' "$RUNNER_TEMP" >> "$GITHUB_PATH"
+      - name: Rebuild immutable release files for publication
+        env:
+          CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
+          CANDIDATE_RUN_ID: ${{ needs.resolve-candidate.outputs.candidate_run_id }}
+          API_DIGEST: ${{ needs.resolve-candidate.outputs.api_digest }}
+          WEB_DIGEST: ${{ needs.resolve-candidate.outputs.web_digest }}
+          GATEWAY_IMAGE: ${{ needs.resolve-candidate.outputs.gateway }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          node scripts/release-fnos.mjs prepare --version "$CANDIDATE_VERSION" --channel global --candidate-run-id "$CANDIDATE_RUN_ID" --output release/release-input.json
+          cat > release/candidate-evidence.json <<EOF
+          {"api":"ghcr.1ms.run/zleap-ai/sag-api@${API_DIGEST}","web":"ghcr.1ms.run/zleap-ai/sag-web@${WEB_DIGEST}","gateway":"${GATEWAY_IMAGE}"}
+          EOF
+          node scripts/release-fnos.mjs package --input release/release-input.json --candidate-evidence release/candidate-evidence.json --output release
+      - name: Create immutable GitHub Release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
+          CANDIDATE_REVISION: ${{ needs.verify-release-request.outputs.revision }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "release/sag-${CANDIDATE_VERSION}.fpk"
+          test -f "release/sag-${CANDIDATE_VERSION}.fpk.sha256"
+          test -f release/release-manifest.json
+          node scripts/fnos-release-manifest.mjs validate --input release/release-manifest.json
+          gh release create "fnos-${CANDIDATE_VERSION}" --target "$CANDIDATE_REVISION" --title "SAG fnOS ${CANDIDATE_VERSION}" --notes "Verified fnOS package for ${CANDIDATE_REVISION}. Runtime images are digest-pinned and delivered through ghcr.1ms.run." "release/sag-${CANDIDATE_VERSION}.fpk" "release/sag-${CANDIDATE_VERSION}.fpk.sha256" release/release-manifest.json


### PR DESCRIPTION
## Summary

Adds the `fnOS Release` manual GitHub Actions entry to the default branch so GitHub displays it in the Actions sidebar.

## Safety boundary

- This PR only adds `.github/workflows/fnos-release.yml`.
- It does not change `CI`, `Desktop Release`, or application code on `main`.
- Every job checks out `fnos/develop`, so release logic and artifacts remain isolated from `main`.
- `dry-run` does not publish an FPK; `publish` still requires explicit `PUBLISH` confirmation.

## Validation

- YAML parser validation passed.
