### PR TITLE
ci(fnos): automate candidate builds and cache images

### DIFF
--- a/.github/workflows/fnos-image-release.yml
+++ b/.github/workflows/fnos-image-release.yml
@@ -2,8 +2,17 @@ name: fnOS Candidate Images
 
 on:
   push:
-    tags:
-      - "fnos-candidate-*"
+    branches: [fnos/develop]
+    paths:
+      - ".github/workflows/fnos-image-release.yml"
+      - ".github/workflows/fnos-release.yml"
+      - "apps/api/**"
+      - "apps/web/**"
+      - "packages/fnos/**"
+      - "scripts/fnos-*.mjs"
+      - "scripts/release-fnos.mjs"
+      - "scripts/validate-fnos-release.mjs"
+      - "scripts/smoke-fnos-release-images.mjs"
 
 concurrency:
   group: fnos-candidate-${{ github.repository }}
@@ -27,15 +36,14 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
       - id: metadata
-        name: Verify repository, tag, manifest, and dedicated branch HEAD
+        name: Verify repository, branch, manifest, and dedicated branch HEAD
         shell: bash
         run: |
           set -euo pipefail
           test "$GITHUB_REPOSITORY" = "Zleap-AI/SAG"
-          test "$GITHUB_REF_TYPE" = "tag"
+          test "$GITHUB_REF_TYPE" = "branch"
+          test "$GITHUB_REF_NAME" = "fnos/develop"
           test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
-          tag_revision="$(git rev-list -n 1 "${GITHUB_REF_NAME}^{commit}")"
-          test "$GITHUB_SHA" = "$tag_revision"
           remote_line="$(git ls-remote --heads origin fnos/develop)"
           read -r remote_revision remote_ref extra <<<"$remote_line"
           test -n "$remote_revision"
@@ -49,8 +57,6 @@ jobs:
             1.[0-9]*.[0-9]*-fnos.[0-9]*) ;;
             *) exit 1 ;;
           esac
-          expected_tag="fnos-candidate-${version}-${GITHUB_SHA:0:12}"
-          test "$GITHUB_REF_NAME" = "$expected_tag"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
           printf 'revision=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           printf 'staging_tag=staging-fnos-%s-%s-%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
@@ -136,75 +142,9 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  local-amd64-smoke:
-    name: Build and smoke local linux/amd64 images
-    needs: [candidate, quality]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.candidate.outputs.revision }}
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
-      - name: Build local API image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.17.0
-        with:
-          context: ./apps/api
-          load: true
-          platforms: linux/amd64
-          tags: sag-api-smoke:${{ needs.candidate.outputs.revision }}
-          labels: |
-            org.opencontainers.image.revision=${{ needs.candidate.outputs.revision }}
-            org.opencontainers.image.version=${{ needs.candidate.outputs.version }}
-      - name: Build local Web image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.17.0
-        with:
-          context: ./apps/web
-          load: true
-          platforms: linux/amd64
-          build-args: NEXT_PUBLIC_API_BASE=/
-          tags: sag-web-smoke:${{ needs.candidate.outputs.revision }}
-          labels: |
-            org.opencontainers.image.revision=${{ needs.candidate.outputs.revision }}
-            org.opencontainers.image.version=${{ needs.candidate.outputs.version }}
-      - name: Smoke API readiness and Web root
-        shell: bash
-        run: |
-          set -euo pipefail
-          trap 'docker rm -f sag-api-smoke sag-web-smoke >/dev/null 2>&1 || true' EXIT
-          docker run --detach --name sag-api-smoke --publish 18000:8000 \
-            --env SAG_ENVIRONMENT=prod \
-            --env SAG_DEBUG=false \
-            --env SAG_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-            --env SAG_AUTH_MODE=single_user \
-            sag-api-smoke:"${{ needs.candidate.outputs.revision }}"
-          docker run --detach --name sag-web-smoke --publish 13000:3000 sag-web-smoke:"${{ needs.candidate.outputs.revision }}"
-          for attempt in {1..30}; do
-            curl --fail --silent --show-error http://127.0.0.1:18000/api/v1/system/ready >/dev/null && break
-            sleep 2
-            test "$attempt" -lt 30 || { docker logs sag-api-smoke; exit 1; }
-          done
-          empty_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-            http://127.0.0.1:18000/api/v1/auth/session)"
-          test "$empty_status" = 200
-          initialized_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-            --header 'Content-Type: application/json' \
-            --data '{"name":"Smoke Owner"}' \
-            http://127.0.0.1:18000/api/v1/auth/session)"
-          test "$initialized_status" = 201
-          anonymous_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-            http://127.0.0.1:18000/api/v1/auth/me)"
-          test "$anonymous_status" = 200
-          for attempt in {1..20}; do
-            curl --fail --silent --show-error http://127.0.0.1:13000/ >/dev/null && break
-            sleep 2
-            test "$attempt" -lt 20 || { docker logs sag-web-smoke; exit 1; }
-          done
-
   staging:
     name: Publish multi-platform staging images
-    needs: [candidate, local-amd64-smoke, gateway-security]
+    needs: [candidate, gateway-security]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -217,10 +157,12 @@ jobs:
             context: ./apps/api
             image: ghcr.io/zleap-ai/sag-api
             build_args: ""
+            cache_scope: fnos-sag-api-multiarch
           - name: Web
             context: ./apps/web
             image: ghcr.io/zleap-ai/sag-web
             build_args: NEXT_PUBLIC_API_BASE=/
+            cache_scope: fnos-sag-web-multiarch
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -239,6 +181,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: ${{ matrix.build_args }}
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
           tags: ${{ matrix.image }}:${{ needs.candidate.outputs.staging_tag }}
           labels: |
             org.opencontainers.image.revision=${{ needs.candidate.outputs.revision }}

--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -28,7 +28,6 @@ jobs:
     outputs:
       version: ${{ steps.metadata.outputs.version }}
       revision: ${{ steps.metadata.outputs.revision }}
-      candidate_tag: ${{ steps.metadata.outputs.candidate_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -51,7 +50,6 @@ jobs:
           revision="$(git rev-parse HEAD)"
           printf 'version=%s\n' "$manifest_version" >> "$GITHUB_OUTPUT"
           printf 'revision=%s\n' "$revision" >> "$GITHUB_OUTPUT"
-          printf 'candidate_tag=fnos-candidate-%s-%s\n' "$manifest_version" "${revision:0:12}" >> "$GITHUB_OUTPUT"
       - name: Run fnOS static release tests
         shell: bash
         run: node --test scripts/tests/fnos-*.test.mjs
@@ -69,7 +67,6 @@ jobs:
       web_digest: ${{ steps.evidence.outputs.web_digest }}
       gateway: ${{ steps.evidence.outputs.gateway }}
     env:
-      CANDIDATE_TAG: ${{ needs.verify-release-request.outputs.candidate_tag }}
       CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
       CANDIDATE_REVISION: ${{ needs.verify-release-request.outputs.revision }}
     steps:
@@ -86,7 +83,7 @@ jobs:
         run: |
           set -euo pipefail
           candidate_run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?event=push&head_sha=${CANDIDATE_REVISION}&per_page=100" \
-            --jq '.workflow_runs[] | select(.name == "fnOS Candidate Images" and .head_branch == env.CANDIDATE_TAG and .conclusion == "success") | .id' \
+            --jq '.workflow_runs[] | select(.name == "fnOS Candidate Images" and .head_branch == "fnos/develop" and .conclusion == "success") | .id' \
             | head -n 1)"
           test -n "$candidate_run_id"
           api_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "ghcr.io/zleap-ai/sag-api:${CANDIDATE_VERSION}")"

--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -133,18 +133,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p release
           node scripts/release-fnos.mjs prepare \
             --version "$CANDIDATE_VERSION" \
             --channel global \
             --candidate-run-id "$CANDIDATE_RUN_ID" \
-            --output release/release-input.json
-          cat > release/candidate-evidence.json <<EOF
+            --output release-input.json
+          cat > candidate-evidence.json <<EOF
           {"api":"ghcr.1ms.run/zleap-ai/sag-api@${API_DIGEST}","web":"ghcr.1ms.run/zleap-ai/sag-web@${WEB_DIGEST}","gateway":"${GATEWAY_IMAGE}"}
           EOF
           node scripts/release-fnos.mjs package \
-            --input release/release-input.json \
-            --candidate-evidence release/candidate-evidence.json \
+            --input release-input.json \
+            --candidate-evidence candidate-evidence.json \
             --output release
           node scripts/fnos-release-manifest.mjs validate --input release/release-manifest.json
   publish-release:
@@ -182,18 +181,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p release
           node scripts/release-fnos.mjs prepare \
             --version "$CANDIDATE_VERSION" \
             --channel global \
             --candidate-run-id "$CANDIDATE_RUN_ID" \
-            --output release/release-input.json
-          cat > release/candidate-evidence.json <<EOF
+            --output release-input.json
+          cat > candidate-evidence.json <<EOF
           {"api":"ghcr.1ms.run/zleap-ai/sag-api@${API_DIGEST}","web":"ghcr.1ms.run/zleap-ai/sag-web@${WEB_DIGEST}","gateway":"${GATEWAY_IMAGE}"}
           EOF
           node scripts/release-fnos.mjs package \
-            --input release/release-input.json \
-            --candidate-evidence release/candidate-evidence.json \
+            --input release-input.json \
+            --candidate-evidence candidate-evidence.json \
             --output release
       - name: Create immutable GitHub Release assets
         env:

--- a/scripts/tests/fnos-dispatch-workflow.test.mjs
+++ b/scripts/tests/fnos-dispatch-workflow.test.mjs
@@ -42,3 +42,12 @@ test("fnOS release never publishes a dry-run package and only creates public ass
   assert.match(workflow, /fnos-release-manifest\.mjs validate/);
   assert.doesNotMatch(workflow, /upload-artifact/);
 });
+
+test("fnOS package output is created only by the package command", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.doesNotMatch(workflow, /mkdir -p release/);
+  assert.match(workflow, /--output release-input\.json/);
+  assert.match(workflow, /candidate-evidence\.json/);
+  assert.match(workflow, /--output release/);
+});

--- a/scripts/tests/fnos-dispatch-workflow.test.mjs
+++ b/scripts/tests/fnos-dispatch-workflow.test.mjs
@@ -19,6 +19,9 @@ test("fnOS release entry is manual, isolated, and checks out fnos/develop", asyn
   assert.match(workflow, /publish_confirmation \}\}" = "PUBLISH"/);
   assert.doesNotMatch(workflow, /on:\n  push:/);
   assert.doesNotMatch(workflow, /\.github\/workflows\/ci\.yml/);
+  assert.doesNotMatch(workflow, /candidate_tag|CANDIDATE_TAG|fnos-candidate-/);
+  assert.match(workflow, /event=push&head_sha=\$\{CANDIDATE_REVISION\}/);
+  assert.match(workflow, /\.head_branch == "fnos\/develop" and \.conclusion == "success"/);
 });
 
 test("fnOS release never publishes a dry-run package and only creates public assets after explicit confirmation", async () => {

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -14,7 +14,7 @@ function job(workflow, name) {
   return match[1];
 }
 
-test("dedicated fnOS branch CI and immutable candidate tag gate release writes", async () => {
+test("dedicated fnOS branch push builds candidates without publishing Git tags", async () => {
   const [workflow, ci] = await Promise.all([
     readFile(workflowPath, "utf8"),
     readFile(ciPath, "utf8"),
@@ -22,21 +22,23 @@ test("dedicated fnOS branch CI and immutable candidate tag gate release writes",
   const candidate = job(workflow, "candidate");
 
   assert.match(ci, /branches: \[main, dev, fnos\/develop\]/);
-  assert.match(workflow, /push:\n    tags:\n      - "fnos-candidate-\*"/);
-  assert.doesNotMatch(workflow, /workflow_dispatch|refs\/heads\/main|\binputs\./);
+  assert.match(workflow, /push:\n    branches: \[fnos\/develop\]/);
+  assert.match(workflow, /paths:/);
+  assert.match(workflow, /"\.github\/workflows\/fnos-release\.yml"/);
+  assert.match(workflow, /"scripts\/release-fnos\.mjs"/);
+  assert.doesNotMatch(workflow, /push:\n    tags:|expected_tag=|GITHUB_REF_TYPE" = "tag"|workflow_dispatch|refs\/heads\/main|\binputs\./);
   assert.match(workflow, /concurrency:\n  group: fnos-candidate-\$\{\{ github\.repository \}\}\n  cancel-in-progress: false/);
   assert.match(candidate, /git ls-remote --heads origin fnos\/develop/);
   assert.doesNotMatch(candidate, /test "\$version" = "1\.[0-9]+\.[0-9]+-fnos\.\d+"/);
   assert.match(candidate, /case "\$version" in\n            1\.\[0-9\]\*\.\[0-9\]\*-fnos\.\[0-9\]\*\) ;;/);
-  assert.match(candidate, /expected_tag="fnos-candidate-\$\{version\}-\$\{GITHUB_SHA:0:12\}"/);
-  assert.match(candidate, /test "\$GITHUB_REF_NAME" = "\$expected_tag"/);
+  assert.match(candidate, /test "\$GITHUB_REF_TYPE" = "branch"/);
+  assert.match(candidate, /test "\$GITHUB_REF_NAME" = "fnos\/develop"/);
   assert.match(candidate, /test "\$GITHUB_SHA" = "\$remote_revision"/);
   assert.match(candidate, /revision: \$\{\{ steps\.metadata\.outputs\.revision \}\}/);
   assert.match(job(workflow, "quality"), /needs: candidate/);
 
   for (const name of [
     "gateway-security",
-    "local-amd64-smoke",
     "staging",
     "inspect-staging",
     "smoke-staging",
@@ -62,7 +64,6 @@ test("fnOS release workflow pins actions and scopes package permissions", async 
   assert.doesNotMatch(workflow, /^permissions:\n(?:.*\n)*?  packages:/m);
   assert.doesNotMatch(job(workflow, "candidate"), /packages:/);
   assert.doesNotMatch(job(workflow, "quality"), /packages: write/);
-  assert.doesNotMatch(job(workflow, "local-amd64-smoke"), /packages: write/);
   assert.match(job(workflow, "inspect-staging"), /permissions:\n      contents: read\n      packages: read/);
   assert.match(job(workflow, "smoke-staging"), /permissions:\n      contents: read\n      packages: read/);
   assert.match(job(workflow, "anonymous-postcheck"), /permissions:\n      contents: read/);
@@ -120,17 +121,15 @@ test("fnOS release workflow invokes the executable digest handoff and promotion 
   assert.match(workflow, /concurrency:\n  group: fnos-candidate-/);
 });
 
-test("amd64 smoke starts the API in no-auth single-user mode", async () => {
+test("candidate staging does not duplicate a local amd64 build and retains exact-digest smoke", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const smoke = job(workflow, "local-amd64-smoke");
+  const staging = job(workflow, "staging");
+  const smoke = job(workflow, "smoke-staging");
 
-  assert.match(smoke, /--env SAG_AUTH_MODE=single_user/);
-  const sessionSecret = /--env SAG_SECRET_KEY=([a-f0-9]{64})/.exec(smoke)?.[1];
-  assert.ok(sessionSecret);
-  assert.doesNotMatch(smoke, /SAG_AUTH_BOOTSTRAP_TOKEN|bootstrap_token|password_status/);
-  assert.match(smoke, /\/api\/v1\/auth\/session/);
-  assert.match(smoke, /test "\$initialized_status" = 201/);
-  assert.match(smoke, /test "\$anonymous_status" = 200/);
+  assert.doesNotMatch(workflow, /local-amd64-smoke/);
+  assert.match(staging, /cache-from: type=gha,scope=\$\{\{ matrix\.cache_scope \}\}/);
+  assert.match(staging, /cache-to: type=gha,mode=max,scope=\$\{\{ matrix\.cache_scope \}\}/);
+  assert.match(smoke, /smoke-fnos-release-images\.mjs smoke/);
 });
 
 test("gateway scan gates publication with a checksum-pinned Trivy binary and exact reviewed digest", async () => {
@@ -156,5 +155,5 @@ test("gateway scan gates publication with a checksum-pinned Trivy binary and exa
   assert.match(gateway, /--scanner-exit-code "\$trivy_status"/);
   assert.match(gateway, /test "\$trivy_status" -eq 0/);
   assert.match(gateway, /if: \$\{\{ always\(\) \}\}/);
-  assert.match(staging, /needs: \[candidate, local-amd64-smoke, gateway-security\]/);
+  assert.match(staging, /needs: \[candidate, gateway-security\]/);
 });


### PR DESCRIPTION
## What changed

- Replaced public `fnos-candidate-*` Git tag triggering with automatic, path-filtered candidate builds on `fnos/develop`.
- Removed the duplicate local amd64 API/Web build; release staging images are still smoked by exact amd64 digest before promotion.
- Added separate GitHub Actions BuildKit cache scopes for API and Web multi-platform builds.
- Made the manual FPK release resolve successful candidate evidence by `fnos/develop` commit SHA instead of public candidate tags.

## Why

Candidate tags polluted the public tag list, and the previous pipeline built amd64 images twice.

## Safety

- No changes to `.github/workflows/ci.yml` or main application code.
- FPK publication remains manual and still requires a successful candidate run, public exact-digest verification, and explicit `PUBLISH` confirmation.

## Validation

- `node --test scripts/tests/fnos-*.test.mjs`
- YAML parsing for both fnOS workflows
- `git diff --check`