### PR TITLE
ci(fnos): unify candidate and release delivery

### DIFF
--- a/.github/workflows/fnos-image-release.yml
+++ b/.github/workflows/fnos-image-release.yml
@@ -1,21 +1,21 @@
-name: fnOS Candidate Images
+name: fnOS Delivery internals
 
 on:
-  push:
-    branches: [fnos/develop]
-    paths:
-      - ".github/workflows/fnos-image-release.yml"
-      - ".github/workflows/fnos-release.yml"
-      - "apps/api/**"
-      - "apps/web/**"
-      - "packages/fnos/**"
-      - "scripts/fnos-*.mjs"
-      - "scripts/release-fnos.mjs"
-      - "scripts/validate-fnos-release.mjs"
-      - "scripts/smoke-fnos-release-images.mjs"
+  workflow_call:
+    inputs:
+      revision:
+        required: true
+        type: string
+    outputs:
+      api_digest:
+        value: ${{ jobs.inspect-staging.outputs.api_digest }}
+      web_digest:
+        value: ${{ jobs.inspect-staging.outputs.web_digest }}
+      gateway:
+        value: ${{ jobs.gateway-security.outputs.gateway }}
 
 concurrency:
-  group: fnos-candidate-${{ github.repository }}
+  group: fnos-delivery-images-${{ inputs.revision }}
   cancel-in-progress: false
 
 permissions:
@@ -33,23 +33,21 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.revision }}
           fetch-depth: 0
       - id: metadata
-        name: Verify repository, branch, manifest, and dedicated branch HEAD
+        name: Verify repository, revision, manifest, and dedicated branch HEAD
         shell: bash
         run: |
           set -euo pipefail
           test "$GITHUB_REPOSITORY" = "Zleap-AI/SAG"
-          test "$GITHUB_REF_TYPE" = "branch"
-          test "$GITHUB_REF_NAME" = "fnos/develop"
-          test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
+          test "${{ inputs.revision }}" = "$(git rev-parse HEAD)"
           remote_line="$(git ls-remote --heads origin fnos/develop)"
           read -r remote_revision remote_ref extra <<<"$remote_line"
           test -n "$remote_revision"
           test "$remote_ref" = "refs/heads/fnos/develop"
           test -z "${extra:-}"
-          test "$GITHUB_SHA" = "$remote_revision"
+          test "${{ inputs.revision }}" = "$remote_revision"
           appname=$(awk -F= '/^appname[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2}' packages/fnos/sag/manifest)
           version=$(awk -F= '/^version[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2}' packages/fnos/sag/manifest)
           test "$appname" = "sag"
@@ -58,8 +56,9 @@ jobs:
             *) exit 1 ;;
           esac
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
-          printf 'revision=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          printf 'staging_tag=staging-fnos-%s-%s-%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+          revision="${{ inputs.revision }}"
+          printf 'revision=%s\n' "$revision" >> "$GITHUB_OUTPUT"
+          printf 'staging_tag=staging-fnos-%s-%s-%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "${revision:0:12}" >> "$GITHUB_OUTPUT"
 
   quality:
     needs: candidate
@@ -73,6 +72,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    outputs:
+      gateway: ${{ steps.policy.outputs.gateway }}
     env:
       TRIVY_VERSION: "0.70.0"
       TRIVY_SHA256: "8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
@@ -81,12 +82,14 @@ jobs:
         with:
           ref: ${{ needs.candidate.outputs.revision }}
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
-      - name: Verify reviewed policy and raw OCI index
+      - id: policy
+        name: Verify reviewed policy and raw OCI index
         shell: bash
         run: |
           set -euo pipefail
           gateway_image="$(node scripts/fnos-gateway-policy.mjs verify --docker docker)"
           printf 'GATEWAY_IMAGE=%s\n' "$gateway_image" >> "$GITHUB_ENV"
+          printf 'gateway=%s\n' "$gateway_image" >> "$GITHUB_OUTPUT"
       - name: Install checksum-pinned Trivy
         shell: bash
         run: |

--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -1,6 +1,18 @@
-name: fnOS Release
+name: fnOS Delivery
 
 on:
+  push:
+    branches: [fnos/develop]
+    paths:
+      - ".github/workflows/fnos-image-release.yml"
+      - ".github/workflows/fnos-release.yml"
+      - "apps/api/**"
+      - "apps/web/**"
+      - "packages/fnos/**"
+      - "scripts/fnos-*.mjs"
+      - "scripts/release-fnos.mjs"
+      - "scripts/validate-fnos-release.mjs"
+      - "scripts/smoke-fnos-release-images.mjs"
   workflow_dispatch:
     inputs:
       mode:
@@ -18,7 +30,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: fnos-release-${{ github.run_id }}
+  group: fnos-delivery-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -44,7 +56,7 @@ jobs:
             [0-9]*.[0-9]*.[0-9]*-fnos.[0-9]*) ;;
             *) echo "invalid fnOS version" >&2; exit 1 ;;
           esac
-          if [ "${{ inputs.mode }}" = "publish" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "publish" ]; then
             test "${{ inputs.publish_confirmation }}" = "PUBLISH"
           fi
           revision="$(git rev-parse HEAD)"
@@ -54,56 +66,19 @@ jobs:
         shell: bash
         run: node --test scripts/tests/fnos-*.test.mjs
 
-  resolve-candidate:
-    name: Resolve approved candidate evidence
+  candidate:
+    name: Build and verify release images
     needs: verify-release-request
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: read
-    outputs:
-      candidate_run_id: ${{ steps.evidence.outputs.candidate_run_id }}
-      api_digest: ${{ steps.evidence.outputs.api_digest }}
-      web_digest: ${{ steps.evidence.outputs.web_digest }}
-      gateway: ${{ steps.evidence.outputs.gateway }}
-    env:
-      CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
-      CANDIDATE_REVISION: ${{ needs.verify-release-request.outputs.revision }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.verify-release-request.outputs.revision }}
-          fetch-depth: 0
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
-      - id: evidence
-        name: Require a successful candidate run and exact public images
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          candidate_run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?event=push&head_sha=${CANDIDATE_REVISION}&per_page=100" \
-            --jq '.workflow_runs[] | select(.name == "fnOS Candidate Images" and .head_branch == "fnos/develop" and .conclusion == "success") | .id' \
-            | head -n 1)"
-          test -n "$candidate_run_id"
-          api_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "ghcr.io/zleap-ai/sag-api:${CANDIDATE_VERSION}")"
-          web_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "ghcr.io/zleap-ai/sag-web:${CANDIDATE_VERSION}")"
-          node scripts/fnos-release-registry.mjs verify-public \
-            --docker docker \
-            --api-image ghcr.io/zleap-ai/sag-api \
-            --web-image ghcr.io/zleap-ai/sag-web \
-            --candidate-version "$CANDIDATE_VERSION" \
-            --api-digest "$api_digest" \
-            --web-digest "$web_digest"
-          gateway="$(node scripts/fnos-gateway-policy.mjs verify --docker docker)"
-          printf 'candidate_run_id=%s\n' "$candidate_run_id" >> "$GITHUB_OUTPUT"
-          printf 'api_digest=%s\n' "$api_digest" >> "$GITHUB_OUTPUT"
-          printf 'web_digest=%s\n' "$web_digest" >> "$GITHUB_OUTPUT"
-          printf 'gateway=%s\n' "$gateway" >> "$GITHUB_OUTPUT"
+    # Keep the fnOS implementation on its permanent branch even when this
+    # dispatcher is manually launched from the default branch for visibility.
+    uses: Zleap-AI/SAG/.github/workflows/fnos-image-release.yml@fnos/develop
+    with:
+      revision: ${{ needs.verify-release-request.outputs.revision }}
 
   build-package:
     name: Build and validate fnOS package
-    needs: [verify-release-request, resolve-candidate]
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: [verify-release-request, candidate]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -126,10 +101,10 @@ jobs:
       - name: Produce immutable evidence and FPK in runner workspace
         env:
           CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
-          CANDIDATE_RUN_ID: ${{ needs.resolve-candidate.outputs.candidate_run_id }}
-          API_DIGEST: ${{ needs.resolve-candidate.outputs.api_digest }}
-          WEB_DIGEST: ${{ needs.resolve-candidate.outputs.web_digest }}
-          GATEWAY_IMAGE: ${{ needs.resolve-candidate.outputs.gateway }}
+          CANDIDATE_RUN_ID: ${{ github.run_id }}
+          API_DIGEST: ${{ needs.candidate.outputs.api_digest }}
+          WEB_DIGEST: ${{ needs.candidate.outputs.web_digest }}
+          GATEWAY_IMAGE: ${{ needs.candidate.outputs.gateway }}
         shell: bash
         run: |
           set -euo pipefail
@@ -148,8 +123,8 @@ jobs:
           node scripts/fnos-release-manifest.mjs validate --input release/release-manifest.json
   publish-release:
     name: Publish reviewed fnOS release assets
-    if: ${{ inputs.mode == 'publish' }}
-    needs: [verify-release-request, resolve-candidate, build-package]
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' }}
+    needs: [verify-release-request, candidate, build-package]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -174,10 +149,10 @@ jobs:
       - name: Rebuild immutable release files for publication
         env:
           CANDIDATE_VERSION: ${{ needs.verify-release-request.outputs.version }}
-          CANDIDATE_RUN_ID: ${{ needs.resolve-candidate.outputs.candidate_run_id }}
-          API_DIGEST: ${{ needs.resolve-candidate.outputs.api_digest }}
-          WEB_DIGEST: ${{ needs.resolve-candidate.outputs.web_digest }}
-          GATEWAY_IMAGE: ${{ needs.resolve-candidate.outputs.gateway }}
+          CANDIDATE_RUN_ID: ${{ github.run_id }}
+          API_DIGEST: ${{ needs.candidate.outputs.api_digest }}
+          WEB_DIGEST: ${{ needs.candidate.outputs.web_digest }}
+          GATEWAY_IMAGE: ${{ needs.candidate.outputs.gateway }}
         shell: bash
         run: |
           set -euo pipefail

--- a/scripts/fnos-release-manifest.mjs
+++ b/scripts/fnos-release-manifest.mjs
@@ -45,9 +45,6 @@ export function validateReleaseManifest(value) {
     fail("built_at_utc must be an RFC3339 UTC timestamp with second precision");
   }
   if (manifest.source_branch !== "fnos/develop") fail("source_branch must be fnos/develop");
-  const expectedCandidateTag = `fnos-candidate-${manifest.version}-${manifest.revision.slice(0, 12)}`;
-  if (manifest.candidate_tag !== expectedCandidateTag) fail("candidate tag must match version and revision");
-
   const workflow = requireObject(manifest.candidate_workflow, "candidate_workflow");
   if (typeof workflow.run_id !== "string" || !/^\d+$/.test(workflow.run_id)) fail("candidate workflow run_id must be numeric");
   if (typeof workflow.url !== "string" || !workflowUrlPattern.test(workflow.url)) fail("candidate workflow URL is invalid");

--- a/scripts/release-fnos.mjs
+++ b/scripts/release-fnos.mjs
@@ -95,7 +95,6 @@ async function prepare(options) {
     ...(channel === "cn" ? { cn_repository_prefix: cnRepositoryPrefix } : {}),
     revision,
     ...buildMetadata(),
-    candidate_tag: `fnos-candidate-${version}-${revision.slice(0, 12)}`,
     candidate_workflow: {
       run_id: candidateRunId,
       url: `https://github.com/${releaseRepository}/actions/runs/${candidateRunId}`,

--- a/scripts/tests/fnos-dispatch-workflow.test.mjs
+++ b/scripts/tests/fnos-dispatch-workflow.test.mjs
@@ -7,47 +7,25 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const workflowPath = path.join(repoRoot, ".github/workflows/fnos-release.yml");
 
-test("fnOS release entry is manual, isolated, and checks out fnos/develop", async () => {
+test("fnOS Delivery is the only user-facing push and manual entry", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  assert.match(workflow, /^name: fnOS Release$/m);
+
+  assert.match(workflow, /^name: fnOS Delivery$/m);
+  assert.match(workflow, /push:\n    branches: \[fnos\/develop\]/);
   assert.match(workflow, /workflow_dispatch:/);
-  assert.doesNotMatch(workflow, /\n      version:\n        description:/);
-  assert.match(workflow, /mode:/);
-  assert.match(workflow, /publish_confirmation:/);
-  assert.match(workflow, /ref: fnos\/develop/);
-  assert.match(workflow, /git rev-parse HEAD.*git rev-parse origin\/fnos\/develop/);
+  assert.match(workflow, /uses: Zleap-AI\/SAG\/\.github\/workflows\/fnos-image-release\.yml@fnos\/develop/);
+  assert.doesNotMatch(workflow, /resolve-candidate|Candidate Images|workflow_runs\?event=push/);
+});
+
+test("manual delivery packages only images built in its own run", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /if: \$\{\{ github\.event_name == 'workflow_dispatch' \}\}/);
+  assert.match(workflow, /CANDIDATE_RUN_ID: \$\{\{ github\.run_id \}\}/);
+  assert.match(workflow, /API_DIGEST: \$\{\{ needs\.candidate\.outputs\.api_digest \}\}/);
+  assert.match(workflow, /WEB_DIGEST: \$\{\{ needs\.candidate\.outputs\.web_digest \}\}/);
+  assert.match(workflow, /GATEWAY_IMAGE: \$\{\{ needs\.candidate\.outputs\.gateway \}\}/);
+  assert.match(workflow, /inputs\.mode == 'publish'/);
   assert.match(workflow, /publish_confirmation \}\}" = "PUBLISH"/);
-  assert.doesNotMatch(workflow, /on:\n  push:/);
-  assert.doesNotMatch(workflow, /\.github\/workflows\/ci\.yml/);
-  assert.doesNotMatch(workflow, /candidate_tag|CANDIDATE_TAG|fnos-candidate-/);
-  assert.match(workflow, /event=push&head_sha=\$\{CANDIDATE_REVISION\}/);
-  assert.match(workflow, /\.head_branch == "fnos\/develop" and \.conclusion == "success"/);
-});
-
-test("fnOS release never publishes a dry-run package and only creates public assets after explicit confirmation", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-
-  assert.match(workflow, /^permissions:\n  contents: read$/m);
-  assert.match(workflow, /resolve-candidate:/);
-  assert.match(workflow, /resolve-candidate:[\s\S]*?permissions:\n      actions: read\n      contents: read/);
-  assert.match(workflow, /build-package:/);
-  assert.match(workflow, /publish-release:/);
-  assert.match(workflow, /if: \$\{\{ inputs\.mode == 'publish' \}\}/);
-  assert.match(workflow, /permissions:\n      contents: write/);
-  assert.match(workflow, /gh release create/);
-  assert.match(workflow, /fnpack-1\.2\.3-linux-amd64/);
-  assert.match(workflow, /sha256sum --check --strict/);
-  assert.match(workflow, /release-fnos\.mjs prepare/);
-  assert.match(workflow, /release-fnos\.mjs package/);
-  assert.match(workflow, /fnos-release-manifest\.mjs validate/);
-  assert.doesNotMatch(workflow, /upload-artifact/);
-});
-
-test("fnOS package output is created only by the package command", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-
   assert.doesNotMatch(workflow, /mkdir -p release/);
-  assert.match(workflow, /--output release-input\.json/);
-  assert.match(workflow, /candidate-evidence\.json/);
-  assert.match(workflow, /--output release/);
 });

--- a/scripts/tests/fnos-production-release.test.mjs
+++ b/scripts/tests/fnos-production-release.test.mjs
@@ -97,7 +97,6 @@ test("package rejects candidate evidence that is not pinned to approved registri
     version: "1.5.0-fnos.1",
     channel: "global",
     revision: "a".repeat(40),
-    candidate_tag: "fnos-candidate-1.5.0-fnos.1-aaaaaaaaaaaa",
     candidate_workflow: { run_id: "30798626087", url: "https://github.com/Zleap-AI/SAG/actions/runs/30798626087" },
   }));
   await writeFile(evidence, JSON.stringify({

--- a/scripts/tests/fnos-release-manifest.test.mjs
+++ b/scripts/tests/fnos-release-manifest.test.mjs
@@ -20,7 +20,6 @@ function validManifest() {
     build_id: "20260804.112701Z",
     built_at_utc: "2026-08-04T11:27:01Z",
     source_branch: "fnos/develop",
-    candidate_tag: "fnos-candidate-1.5.0-fnos.1-aaaaaaaaaaaa",
     candidate_workflow: {
       run_id: "30798626087",
       url: "https://github.com/Zleap-AI/SAG/actions/runs/30798626087",
@@ -60,13 +59,12 @@ test("release manifest accepts a complete global immutable release record", asyn
 test("release manifest rejects mutable image tags and inconsistent identity fields", async (t) => {
   const manifest = validManifest();
   manifest.images.api = "ghcr.1ms.run/zleap-ai/sag-api:1.5.0-fnos.1";
-  manifest.candidate_tag = "fnos-candidate-1.4.0-fnos.6-aaaaaaaaaaaa";
   manifest.fpk.filename = "sag-1.4.0-fnos.8.fpk";
   const input = await withManifest(t, manifest);
   const result = validate(input);
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /immutable|candidate tag|filename/i);
+  assert.match(result.stderr, /immutable|filename/i);
 });
 
 test("release manifest rejects missing or malformed build provenance", async (t) => {

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -6,154 +6,26 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const workflowPath = path.join(repoRoot, ".github/workflows/fnos-image-release.yml");
-const ciPath = path.join(repoRoot, ".github/workflows/ci.yml");
 
-function job(workflow, name) {
-  const match = new RegExp(`^  ${name}:\\n([\\s\\S]*?)(?=^  [a-z][a-z-]+:|(?![\\s\\S]))`, "m").exec(workflow);
-  assert.ok(match, `missing ${name} job`);
-  return match[1];
-}
+test("fnOS internal image workflow is callable only and returns immutable evidence", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
 
-test("dedicated fnOS branch push builds candidates without publishing Git tags", async () => {
-  const [workflow, ci] = await Promise.all([
-    readFile(workflowPath, "utf8"),
-    readFile(ciPath, "utf8"),
-  ]);
-  const candidate = job(workflow, "candidate");
-
-  assert.match(ci, /branches: \[main, dev, fnos\/develop\]/);
-  assert.match(workflow, /push:\n    branches: \[fnos\/develop\]/);
-  assert.match(workflow, /paths:/);
-  assert.match(workflow, /"\.github\/workflows\/fnos-release\.yml"/);
-  assert.match(workflow, /"scripts\/release-fnos\.mjs"/);
-  assert.doesNotMatch(workflow, /push:\n    tags:|expected_tag=|GITHUB_REF_TYPE" = "tag"|workflow_dispatch|refs\/heads\/main|\binputs\./);
-  assert.match(workflow, /concurrency:\n  group: fnos-candidate-\$\{\{ github\.repository \}\}\n  cancel-in-progress: false/);
-  assert.match(candidate, /git ls-remote --heads origin fnos\/develop/);
-  assert.doesNotMatch(candidate, /test "\$version" = "1\.[0-9]+\.[0-9]+-fnos\.\d+"/);
-  assert.match(candidate, /case "\$version" in\n            1\.\[0-9\]\*\.\[0-9\]\*-fnos\.\[0-9\]\*\) ;;/);
-  assert.match(candidate, /test "\$GITHUB_REF_TYPE" = "branch"/);
-  assert.match(candidate, /test "\$GITHUB_REF_NAME" = "fnos\/develop"/);
-  assert.match(candidate, /test "\$GITHUB_SHA" = "\$remote_revision"/);
-  assert.match(candidate, /revision: \$\{\{ steps\.metadata\.outputs\.revision \}\}/);
-  assert.match(job(workflow, "quality"), /needs: candidate/);
-
-  for (const name of [
-    "gateway-security",
-    "staging",
-    "inspect-staging",
-    "smoke-staging",
-    "promote",
-    "anonymous-postcheck",
-  ]) {
-    const releaseJob = job(workflow, name);
-    assert.match(releaseJob, /needs(?:\.candidate|: [^\n]*candidate)/);
-    assert.match(releaseJob, /ref: \$\{\{ needs\.candidate\.outputs\.revision \}\}/);
-  }
-  assert.match(candidate, /ref: \$\{\{ github\.sha \}\}/);
-  assert.doesNotMatch(workflow.replace(candidate, ""), /ref: \$\{\{ github\.sha \}\}/);
-  assert.doesNotMatch(workflow, /revision=\$\{\{ github\.sha \}\}|sha-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /^name: fnOS Delivery internals$/m);
+  assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /revision:\n        required: true\n        type: string/);
+  assert.match(workflow, /api_digest:\n        value: \$\{\{ jobs\.inspect-staging\.outputs\.api_digest \}\}/);
+  assert.match(workflow, /web_digest:\n        value: \$\{\{ jobs\.inspect-staging\.outputs\.web_digest \}\}/);
+  assert.match(workflow, /gateway:\n        value: \$\{\{ jobs\.gateway-security\.outputs\.gateway \}\}/);
+  assert.doesNotMatch(workflow, /\n  push:|fnos-candidate-/);
 });
 
-test("fnOS release workflow pins actions and scopes package permissions", async () => {
+test("fnOS internal image workflow validates the requested fnos revision and caches multiarch builds", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const externalActions = workflow.match(/^\s*-?\s*uses: (?!\.\/)(.+)$/gm) ?? [];
 
-  assert.ok(externalActions.length > 0);
-  for (const action of externalActions) assert.match(action, /@[a-f0-9]{40}\s+# v/);
-  assert.match(workflow, /^permissions:\n  contents: read$/m);
-  assert.doesNotMatch(workflow, /^permissions:\n(?:.*\n)*?  packages:/m);
-  assert.doesNotMatch(job(workflow, "candidate"), /packages:/);
-  assert.doesNotMatch(job(workflow, "quality"), /packages: write/);
-  assert.match(job(workflow, "inspect-staging"), /permissions:\n      contents: read\n      packages: read/);
-  assert.match(job(workflow, "smoke-staging"), /permissions:\n      contents: read\n      packages: read/);
-  assert.match(job(workflow, "anonymous-postcheck"), /permissions:\n      contents: read/);
-  assert.doesNotMatch(job(workflow, "anonymous-postcheck"), /packages:|GITHUB_TOKEN|docker\/login-action/);
-  for (const name of ["staging", "promote"]) {
-    assert.match(job(workflow, name), /permissions:\n      contents: read\n      packages: write/);
-  }
-  assert.doesNotMatch(workflow, /visibility=public|--method PATCH/);
-});
-
-test("promotion is followed by an unauthenticated exact-digest public check", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const postcheck = job(workflow, "anonymous-postcheck");
-
-  assert.match(postcheck, /needs: \[candidate, inspect-staging, promote\]/);
-  assert.match(postcheck, /fnos-release-registry\.mjs verify-public/);
-  assert.match(postcheck, /--candidate-version "\$CANDIDATE_VERSION"/);
-  assert.match(postcheck, /--api-digest "\$API_DIGEST"/);
-  assert.match(postcheck, /--web-digest "\$WEB_DIGEST"/);
-  assert.doesNotMatch(postcheck, /docker\/login-action|username:|password:|GITHUB_TOKEN|packages: read/);
-});
-
-test("promotion requires an exact captured-digest runtime smoke", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const smoke = job(workflow, "smoke-staging");
-  const promote = job(workflow, "promote");
-
-  assert.match(smoke, /needs: \[candidate, inspect-staging\]/);
-  assert.match(smoke, /API_IMAGE: ghcr\.io\/zleap-ai\/sag-api@\$\{\{ needs\.inspect-staging\.outputs\.api_digest \}\}/);
-  assert.match(smoke, /WEB_IMAGE: ghcr\.io\/zleap-ai\/sag-web@\$\{\{ needs\.inspect-staging\.outputs\.web_digest \}\}/);
-  assert.match(smoke, /smoke-fnos-release-images\.mjs smoke/);
-  assert.match(smoke, /if: \$\{\{ always\(\) \}\}/);
-  assert.match(smoke, /smoke-fnos-release-images\.mjs cleanup/);
-  assert.doesNotMatch(smoke, /STAGING_TAG|staging-fnos|build-push-action|sag-(api|web)-smoke:/);
-  assert.match(promote, /needs: \[candidate, inspect-staging, smoke-staging\]/);
-});
-
-test("fnOS release workflow invokes the executable digest handoff and promotion state machine", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const inspect = job(workflow, "inspect-staging");
-  const promote = job(workflow, "promote");
-
-  assert.match(inspect, /outputs:\n      api_digest: \$\{\{ steps\.digests\.outputs\.api_digest \}\}/);
-  assert.match(inspect, /web_digest: \$\{\{ steps\.digests\.outputs\.web_digest \}\}/);
-  assert.match(inspect, /id: digests/);
-  assert.match(inspect, /fnos-release-registry\.mjs verify-staging/);
-  assert.match(inspect, /fnos-release-registry\.mjs write-handoff/);
-  assert.match(inspect, /--github-output "\$GITHUB_OUTPUT" --artifact verified-digests\.json/);
-  assert.match(inspect, /actions\/upload-artifact@[a-f0-9]{40}\s+# v/);
-  assert.match(promote, /API_DIGEST: \$\{\{ needs\.inspect-staging\.outputs\.api_digest \}\}/);
-  assert.match(promote, /WEB_DIGEST: \$\{\{ needs\.inspect-staging\.outputs\.web_digest \}\}/);
-  assert.doesNotMatch(promote, /\$STAGING_TAG/);
-  assert.match(promote, /fnos-release-registry\.mjs promote/);
-  assert.doesNotMatch(promote, /reconcile_tag\(\)|inspect_final_tag\(\)/);
-  assert.match(workflow, /concurrency:\n  group: fnos-candidate-/);
-});
-
-test("candidate staging does not duplicate a local amd64 build and retains exact-digest smoke", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const staging = job(workflow, "staging");
-  const smoke = job(workflow, "smoke-staging");
-
+  assert.match(workflow, /ref: \$\{\{ inputs\.revision \}\}/);
+  assert.match(workflow, /test "\$\{\{ inputs\.revision \}\}" = "\$\(git rev-parse HEAD\)"/);
+  assert.match(workflow, /cache-from: type=gha,scope=\$\{\{ matrix\.cache_scope \}\}/);
+  assert.match(workflow, /cache-to: type=gha,mode=max,scope=\$\{\{ matrix\.cache_scope \}\}/);
   assert.doesNotMatch(workflow, /local-amd64-smoke/);
-  assert.match(staging, /cache-from: type=gha,scope=\$\{\{ matrix\.cache_scope \}\}/);
-  assert.match(staging, /cache-to: type=gha,mode=max,scope=\$\{\{ matrix\.cache_scope \}\}/);
-  assert.match(smoke, /smoke-fnos-release-images\.mjs smoke/);
-});
-
-test("gateway scan gates publication with a checksum-pinned Trivy binary and exact reviewed digest", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const gateway = job(workflow, "gateway-security");
-  const staging = job(workflow, "staging");
-
-  assert.match(gateway, /permissions:\n      contents: read/);
-  assert.doesNotMatch(gateway, /packages: write/);
-  assert.match(gateway, /fnos-gateway-policy\.mjs verify/);
-  assert.match(gateway, /TRIVY_VERSION: "0\.70\.0"/);
-  assert.match(gateway, /TRIVY_SHA256: "8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"/);
-  assert.match(gateway, /sha256sum --check --strict/);
-  assert.match(gateway, /--platform linux\/amd64/);
-  assert.match(gateway, /--severity CRITICAL,HIGH/);
-  assert.match(gateway, /--ignore-unfixed/);
-  assert.match(gateway, /--exit-code 1/);
-  assert.match(gateway, /"\$GATEWAY_IMAGE"/);
-  assert.match(gateway, /trivy_status="\$\?"/);
-  assert.match(gateway, /canonicalize-fnos-trivy-report\.mjs/);
-  assert.match(gateway, /summarize-fnos-gateway-scan\.mjs/);
-  assert.match(gateway, /--source-report "\$raw_report"/);
-  assert.match(gateway, /--scanner-exit-code "\$trivy_status"/);
-  assert.match(gateway, /test "\$trivy_status" -eq 0/);
-  assert.match(gateway, /if: \$\{\{ always\(\) \}\}/);
-  assert.match(staging, /needs: \[candidate, gateway-security\]/);
+  assert.match(workflow, /smoke-fnos-release-images\.mjs smoke/);
 });


### PR DESCRIPTION
## What changed
- Replace the separate visible candidate workflow with one fnOS Delivery entry.
- Pushes to fnos/develop build and verify fnOS images; manual dry-run and publish build, verify, and package in the same run.
- Remove the cross-run lookup that failed when a candidate was still running.
- Remove the old fnos-candidate Git-tag provenance field; image staging tags remain internal to GHCR.

## Validation
- node --test scripts/tests/fnos-*.test.mjs
- YAML parsing and git diff --check

## Follow-up
Merge this before the default-branch entry PR, because that entry calls the reusable image workflow from fnos/develop.