### PR TITLE
fix(fnos): package unpromoted candidate images

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -365,7 +365,7 @@ jobs:
 
   build-package:
     name: Build and validate fnOS package
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'candidate' }}
     needs: [verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck]
     runs-on: ubuntu-24.04
     steps:
@@ -407,6 +407,7 @@ jobs:
           node scripts/release-fnos.mjs package \
             --input release-input.json \
             --candidate-evidence candidate-evidence.json \
+            --allow-unpromoted-images true \
             --output release
           node scripts/fnos-release-manifest.mjs validate --input release/release-manifest.json
       - name: Upload one-day Candidate FPK
@@ -423,7 +424,7 @@ jobs:
   publish-release:
     name: Publish reviewed fnOS release assets
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' }}
-    needs: [verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck, build-package]
+    needs: [verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -363,10 +363,35 @@ jobs:
             --api-digest "$API_DIGEST" \
             --web-digest "$WEB_DIGEST"
 
+  delivery-endpoint-check:
+    name: Verify FPK delivery image endpoints
+    needs: [verify-release-request, gateway-security, inspect-images]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      API_IMAGE: ghcr.1ms.run/zleap-ai/sag-api@${{ needs.inspect-images.outputs.api_digest }}
+      WEB_IMAGE: ghcr.1ms.run/zleap-ai/sag-web@${{ needs.inspect-images.outputs.web_digest }}
+      GATEWAY_IMAGE: ${{ needs.gateway-security.outputs.gateway }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify-release-request.outputs.revision }}
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.10.0
+      - name: Resolve all FPK image references through ghcr.1ms.run
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/fnos-release-registry.mjs verify-delivery-endpoints \
+            --docker docker \
+            --api-image "$API_IMAGE" \
+            --web-image "$WEB_IMAGE" \
+            --gateway-image "$GATEWAY_IMAGE"
+
   build-package:
     name: Build and validate fnOS package
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'candidate' }}
-    needs: [verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck]
+    needs: [verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck, delivery-endpoint-check]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -424,7 +449,7 @@ jobs:
   publish-release:
     name: Publish reviewed fnOS release assets
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' }}
-    needs: [verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck]
+    needs: [verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck, delivery-endpoint-check]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/scripts/build-fnos-package.mjs
+++ b/scripts/build-fnos-package.mjs
@@ -40,11 +40,15 @@ function fail(message) {
 }
 
 function parseArgs(argv) {
-  const result = { structuralTest: false };
+  const result = { structuralTest: false, allowUnpromotedImages: false };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--structural-test") {
       result.structuralTest = true;
+      continue;
+    }
+    if (argument === "--allow-unpromoted-images") {
+      result.allowUnpromotedImages = true;
       continue;
     }
     const names = {
@@ -202,7 +206,7 @@ async function verifyPublishedImages(options, gatewayPolicy) {
     } else {
       requirePlatforms(name, image, ["linux/amd64", "linux/arm64"]);
     }
-    if (name === "api" || name === "web") {
+    if (!options.allowUnpromotedImages && (name === "api" || name === "web")) {
       const expectedDigest = imageDigest(options[name]);
       const boundDigest = candidateTagDigest(name, options[name], version);
       if (boundDigest !== expectedDigest) {

--- a/scripts/fnos-release-registry.mjs
+++ b/scripts/fnos-release-registry.mjs
@@ -152,6 +152,21 @@ function inspectPublicDigest(options, image, digest) {
   requireIndex(result.stdout, reference);
 }
 
+function verifyDeliveryEndpoints(options) {
+  const references = [
+    ["api", requireOption(options, "api_image")],
+    ["web", requireOption(options, "web_image")],
+    ["gateway", requireOption(options, "gateway_image")],
+  ];
+  for (const [name, reference] of references) {
+    const separator = reference.lastIndexOf("@");
+    if (separator <= 0) fail(`${name} delivery image must be an immutable digest reference`);
+    const image = reference.slice(0, separator);
+    const digest = requireDigest(reference.slice(separator + 1), `${name} delivery image digest`);
+    inspectPublicDigest(options, image, digest);
+  }
+}
+
 function verifyPublic(options) {
   const apiImage = requireOption(options, "api_image");
   const webImage = requireOption(options, "web_image");
@@ -195,6 +210,10 @@ async function main() {
   }
   if (options.command === "verify-public-digests") {
     verifyPublicDigests(options);
+    return;
+  }
+  if (options.command === "verify-delivery-endpoints") {
+    verifyDeliveryEndpoints(options);
     return;
   }
   fail(`unknown command: ${options.command}`);

--- a/scripts/release-fnos.mjs
+++ b/scripts/release-fnos.mjs
@@ -117,6 +117,9 @@ async function packageRelease(options) {
     fail(`could not read release input or candidate evidence: ${error.message}`);
   }
   if (input?.appname !== "sag" || !versionPattern.test(input?.version ?? "")) fail("release input is invalid");
+  if (options.allow_unpromoted_images && options.allow_unpromoted_images !== "true") {
+    fail("--allow-unpromoted-images must be true when supplied");
+  }
   validateChannelImages({
     channel: input.channel,
     cnRepositoryPrefix: input.cn_repository_prefix,
@@ -132,6 +135,7 @@ async function packageRelease(options) {
     "--api-image", evidence.api,
     "--web-image", evidence.web,
     "--nginx-image", evidence.gateway,
+    ...(options.allow_unpromoted_images ? ["--allow-unpromoted-images"] : []),
     "--output", packagePath,
   ], { cwd: repoRoot, encoding: "utf8" });
   if (build.error || build.status !== 0) fail(`FPK build failed: ${(build.stderr || build.error?.message || build.stdout).trim()}`);

--- a/scripts/tests/fnos-dispatch-workflow.test.mjs
+++ b/scripts/tests/fnos-dispatch-workflow.test.mjs
@@ -27,7 +27,7 @@ test("fnOS delivery is implemented by one workflow file", async () => {
 test("manual delivery packages only images built in its own run", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /if: \$\{\{ github\.event_name == 'workflow_dispatch' \}\}/);
+  assert.match(workflow, /build-package:\n[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.mode == 'candidate' \}\}/);
   assert.match(workflow, /CANDIDATE_RUN_ID: \$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /API_DIGEST: \$\{\{ needs\.inspect-images\.outputs\.api_digest \}\}/);
   assert.match(workflow, /WEB_DIGEST: \$\{\{ needs\.inspect-images\.outputs\.web_digest \}\}/);

--- a/scripts/tests/fnos-package.test.mjs
+++ b/scripts/tests/fnos-package.test.mjs
@@ -360,6 +360,21 @@ test("release build rejects a Web digest not bound to the exact candidate tag", 
   assert.match(result.stderr, /web.*candidate tag.*digest/i);
 });
 
+test("candidate build accepts verified unpromoted API and Web digests", async (t) => {
+  const root = await tempRoot(t);
+  const output = path.join(root, "candidate.fpk");
+  const result = build([
+    "--allow-unpromoted-images",
+    "--api-image", `ghcr.1ms.run/zleap-ai/sag-api@${digestA}`,
+    "--web-image", `ghcr.1ms.run/zleap-ai/sag-web@${digestB}`,
+    "--nginx-image", gatewayReference,
+    "--output", output,
+  ], await fakeRegistry(t, { apiTagDigest: digestD, webTagDigest: digestD }));
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.equal((await stat(output)).isFile(), true);
+});
+
 test("release build accepts candidate-bound multi-platform API and Web indexes", async (t) => {
   const root = await tempRoot(t);
   const output = path.join(root, "candidate.fpk");

--- a/scripts/tests/fnos-release-registry.test.mjs
+++ b/scripts/tests/fnos-release-registry.test.mjs
@@ -13,6 +13,9 @@ const digestA = `sha256:${"a".repeat(64)}`;
 const digestB = `sha256:${"b".repeat(64)}`;
 const api = "ghcr.io/zleap-ai/sag-api";
 const web = "ghcr.io/zleap-ai/sag-web";
+const deliveryApi = `ghcr.1ms.run/zleap-ai/sag-api@${digestA}`;
+const deliveryWeb = `ghcr.1ms.run/zleap-ai/sag-web@${digestB}`;
+const deliveryGateway = `ghcr.1ms.run/zleap-ai/sag-gateway@sha256:${"c".repeat(64)}`;
 const manifestText = readFileSync(path.join(repoRoot, "packages/fnos/sag/manifest"), "utf8");
 const version = manifestText.match(/^version\s*=\s*(\S+)\s*$/m)?.[1];
 if (!version) throw new Error("packages/fnos/sag/manifest is missing a version line");
@@ -86,6 +89,10 @@ function verifyPublicArgs(docker) {
 
 function verifyPublicDigestsArgs(docker) {
   return ["verify-public-digests", "--docker", docker, "--api-image", api, "--web-image", web, "--api-digest", digestA, "--web-digest", digestB];
+}
+
+function verifyDeliveryEndpointsArgs(docker) {
+  return ["verify-delivery-endpoints", "--docker", docker, "--api-image", deliveryApi, "--web-image", deliveryWeb, "--gateway-image", deliveryGateway];
 }
 
 test("digest verification emits only the immutable digest despite docker pull stdout and writes exact JSON/job outputs", async (t) => {
@@ -186,6 +193,17 @@ test("candidate verification anonymously checks immutable digests without creati
   );
   assert.equal(log.filter((args) => args.includes("create")).length, 0);
   assert.equal(log.filter((args) => args.includes("{{.Manifest.Digest}}")).length, 0);
+});
+
+test("delivery endpoint verification resolves all three FPK image references through the configured accelerator", async (t) => {
+  const fake = await fakeDocker(t);
+  const result = run(verifyDeliveryEndpointsArgs(fake.executable), fake.env);
+
+  assert.equal(result.status, 0, result.stderr);
+  const rawReferences = (await stateOf(fake.statePath)).log
+    .filter((args) => args.slice(0, 4).join(" ") === "buildx imagetools inspect --raw")
+    .map((args) => args[4]);
+  assert.deepEqual(rawReferences, [deliveryApi, deliveryWeb, deliveryGateway]);
 });
 
 test("anonymous verification fails when a public candidate tag has a different digest", async (t) => {

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -37,10 +37,15 @@ test("fnOS Delivery validates the dedicated branch and caches parallel multiarch
   assert.match(workflow, /promote:\n[\s\S]*?needs: \[verify-release-request, quality, gateway-security, inspect-images, smoke-images\]/);
   assert.match(workflow, /promote:\n[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.mode == 'publish' \}\}/);
   assert.match(workflow, /anonymous-digest-postcheck:\n[\s\S]*?verify-public-digests/);
-  assert.match(workflow, /build-package:\n[\s\S]*?needs: \[verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck\]/);
+  assert.match(workflow, /delivery-endpoint-check:\n[\s\S]*?name: Verify FPK delivery image endpoints/);
+  assert.match(workflow, /delivery-endpoint-check:\n[\s\S]*?ghcr\.1ms\.run\/zleap-ai\/sag-api@\$\{\{ needs\.inspect-images\.outputs\.api_digest \}\}/);
+  assert.match(workflow, /delivery-endpoint-check:\n[\s\S]*?ghcr\.1ms\.run\/zleap-ai\/sag-web@\$\{\{ needs\.inspect-images\.outputs\.web_digest \}\}/);
+  assert.match(workflow, /delivery-endpoint-check:\n[\s\S]*?--gateway-image "\$GATEWAY_IMAGE"/);
+  assert.match(workflow, /delivery-endpoint-check:\n[\s\S]*?verify-delivery-endpoints/);
+  assert.match(workflow, /build-package:\n[\s\S]*?needs: \[verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck, delivery-endpoint-check\]/);
   assert.match(workflow, /build-package:\n[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.mode == 'candidate' \}\}/);
   assert.match(workflow, /--allow-unpromoted-images true/);
-  assert.match(workflow, /publish-release:\n[\s\S]*?needs: \[verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck\]/);
+  assert.match(workflow, /publish-release:\n[\s\S]*?needs: \[verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck, delivery-endpoint-check\]/);
   assert.doesNotMatch(workflow, /local-amd64-smoke/);
   assert.match(workflow, /smoke-fnos-release-images\.mjs smoke/);
 });

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -38,6 +38,9 @@ test("fnOS Delivery validates the dedicated branch and caches parallel multiarch
   assert.match(workflow, /promote:\n[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.mode == 'publish' \}\}/);
   assert.match(workflow, /anonymous-digest-postcheck:\n[\s\S]*?verify-public-digests/);
   assert.match(workflow, /build-package:\n[\s\S]*?needs: \[verify-release-request, quality, gateway-security, inspect-images, smoke-images, anonymous-digest-postcheck\]/);
+  assert.match(workflow, /build-package:\n[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.mode == 'candidate' \}\}/);
+  assert.match(workflow, /--allow-unpromoted-images true/);
+  assert.match(workflow, /publish-release:\n[\s\S]*?needs: \[verify-release-request, gateway-security, inspect-images, anonymous-final-postcheck\]/);
   assert.doesNotMatch(workflow, /local-amd64-smoke/);
   assert.match(workflow, /smoke-fnos-release-images\.mjs smoke/);
 });


### PR DESCRIPTION
## 问题
fnOS Delivery 的 Candidate 模式刻意不发布 API/Web 版本标签，但 FPK 打包脚本仍要求候选版本标签已解析到对应 digest，导致打包步骤必然失败。

## 修复
- Candidate 模式仅校验经过本次运行验证的 API/Web 多架构 digest，不要求未发布的版本标签。
- 正式发布仍要求版本标签与 digest 精确一致。
- Publish 不再与候选 FPK 打包并发；它等待镜像提升及匿名可拉取校验后重建并发布正式 FPK。
- 增加候选无标签构建与工作流依赖关系回归测试。

## 验证
`node --test scripts/tests/fnos-*.test.mjs`：178 passed, 0 failed, 1 skipped（本地无 fnpack 的预期跳过）。

## 合并后验证
在 `fnos/develop` 手动运行 **fnOS Delivery**，选择 `candidate`；应生成仅保留 1 天的 Candidate FPK Artifact，且不创建 Docker 标签或 GitHub Release。