### PR TITLE
feat(web): 诊断日志导出能力（web + 桌面端）

### DIFF
--- a/apps/api/sag_api/api/v1/agents.py
+++ b/apps/api/sag_api/api/v1/agents.py
@@ -16,6 +16,7 @@ from sag_api.core.deps import (
     get_llm,
     get_tool_registry,
 )
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ConfigurationError, ConflictError, NotFoundError
 from sag_api.core.logging import get_logger
 from sag_api.db.models import User
@@ -390,7 +391,7 @@ async def ask(
                 "turn": 0,
                 "payload": {
                     "error": {
-                        "code": "stream_error",
+                        "code": ErrorCode.STREAM_ERROR,
                         "message": f"生成中断：{getattr(e, 'message', None) or e}",
                         "retryable": True,
                         "details": {},

--- a/apps/api/sag_api/api/v1/search.py
+++ b/apps/api/sag_api/api/v1/search.py
@@ -12,6 +12,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from sag_api.core.db import get_session
 from sag_api.core.deps import get_current_user, get_engine_manager, get_llm
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ApiError
 from sag_api.core.logging import get_logger
 from sag_api.db.models import Source, User
@@ -390,7 +391,7 @@ async def global_search_stream(
             log.exception("搜索流未处理异常：%s", error)
             yield _sse(
                 "error",
-                {"code": "stream_error", "message": "搜索生成意外中断"},
+                {"code": ErrorCode.STREAM_ERROR, "message": "搜索生成意外中断"},
             )
 
     return EventSourceResponse(

--- a/apps/api/sag_api/core/db.py
+++ b/apps/api/sag_api/core/db.py
@@ -62,6 +62,8 @@ _COLUMN_UPGRADES: dict[str, dict[str, str]] = {
     "documents": {
         "progress": "INTEGER NOT NULL DEFAULT 0",
         "token_usage": "BIGINT NOT NULL DEFAULT 0",
+        "error_layer": "VARCHAR(16)",
+        "error_stage": "VARCHAR(16)",
     },
     "threads": {"archived": "BOOLEAN NOT NULL DEFAULT 0"},
     "messages": {

--- a/apps/api/sag_api/core/error_taxonomy.py
+++ b/apps/api/sag_api/core/error_taxonomy.py
@@ -1,0 +1,86 @@
+"""错误分类维度：链路环节（stage）+ 责任归属（layer）。
+
+背景：历史上错误码只有 HTTP 语义（not_found / upstream_error / …），
+一个 `UpstreamError` 同时装了「引擎内部错」「LLM 厂商错」「DB 存储错」，
+用户上报日志时无法判断问题出在哪一环、该找谁排查。
+
+这里引入两个正交维度，与现有 HTTP `code` 并存（不替换、向后兼容）：
+
+- **layer（责任归属）**：这个错误的根子在谁那里 —— 前端 / SAG 自身 /
+  zleap-sag 引擎 / LLM 厂商 / 存储。决定「找谁排查」。
+- **stage（链路环节）**：错误发生在业务链路的哪一步。决定「哪一步崩了」。
+
+前端把 layer/stage/code/message/request_id 一并采集进诊断日志，研发拿到
+日志即可精准定位「哪个环节 + 谁的责任 + 具体报错原文」。
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ErrorLayer(StrEnum):
+    """责任归属：这个错误应该找谁排查。"""
+
+    CLIENT = "client"
+    """前端 / 网络 / SSE 协议层 —— 浏览器侧或链路传输问题。"""
+
+    API = "api"
+    """SAG 后端自身 —— 编排、鉴权、参数校验、配置缺失等本地逻辑。"""
+
+    ENGINE = "engine"
+    """zleap-sag 引擎 —— 分块、抽取、schema 校验、引擎内部存储等。"""
+
+    LLM = "llm"
+    """LLM 厂商 —— 超时、限流、鉴权失败、返回结构不合规（如 schema 拒绝）。"""
+
+    STORE = "store"
+    """持久化层 —— 数据库 / 向量库读写、事务、外键约束等。"""
+
+
+class ErrorStage(StrEnum):
+    """链路环节：错误发生在业务流程的哪一步。
+
+    文档摄入链：upload → parse → chunk → embed → extract → persist
+    问答链：      retrieve → generate → tool → persist
+    横切：        config / auth / unknown
+    """
+
+    # —— 文档摄入链 ——
+    UPLOAD = "upload"
+    """上传接收：文件校验（扩展名 / 大小 / 空文件）、落盘。"""
+
+    PARSE = "parse"
+    """解析：非 Markdown 文档转 Markdown（MinerU / MarkItDown）。"""
+
+    CHUNK = "chunk"
+    """分块：文本切片，写入 chunk 与其向量前的加载阶段。"""
+
+    EMBED = "embed"
+    """向量化：调用 embedding 模型生成向量。"""
+
+    EXTRACT = "extract"
+    """提取事项：逐 chunk 抽取事件 / 实体（structured output）。"""
+
+    PERSIST = "persist"
+    """入库：chunk / 事件 / 答案的持久化与计数提交。"""
+
+    # —— 问答链 ——
+    RETRIEVE = "retrieve"
+    """召回：向量 / 多路检索相关片段。"""
+
+    GENERATE = "generate"
+    """生成：LLM 生成答案（含流式 turn）。"""
+
+    TOOL = "tool"
+    """工具调用：Agent 执行 search_context / web_search 等工具。"""
+
+    # —— 横切 ——
+    CONFIG = "config"
+    """配置：LLM / embedding / 引擎所需配置缺失或非法。"""
+
+    AUTH = "auth"
+    """鉴权：未认证、凭证失效、无权访问。"""
+
+    UNKNOWN = "unknown"
+    """未归类：尚未打上 stage 标记的错误。"""

--- a/apps/api/sag_api/core/error_taxonomy.py
+++ b/apps/api/sag_api/core/error_taxonomy.py
@@ -1,22 +1,105 @@
-"""错误分类维度：链路环节（stage）+ 责任归属（layer）。
+"""错误分类三维度：错误码（code）+ 链路环节（stage）+ 责任归属（layer）。
 
 背景：历史上错误码只有 HTTP 语义（not_found / upstream_error / …），
 一个 `UpstreamError` 同时装了「引擎内部错」「LLM 厂商错」「DB 存储错」，
 用户上报日志时无法判断问题出在哪一环、该找谁排查。
 
-这里引入两个正交维度，与现有 HTTP `code` 并存（不替换、向后兼容）：
+这里定义描述一个错误的三个正交维度，是全项目错误分类的唯一事实来源：
 
+- **code（错误码）**：机器可读的错误身份，前端据此做逻辑分支、错误文案映射。
+  历史上散落在各抛出点的字面量（``code="xxx"``）统一收敛到 :class:`ErrorCode`，
+  杜绝魔法值；新增错误码一律在本文件登记。
 - **layer（责任归属）**：这个错误的根子在谁那里 —— 前端 / SAG 自身 /
   zleap-sag 引擎 / LLM 厂商 / 存储。决定「找谁排查」。
 - **stage（链路环节）**：错误发生在业务链路的哪一步。决定「哪一步崩了」。
 
-前端把 layer/stage/code/message/request_id 一并采集进诊断日志，研发拿到
+前端把 code/layer/stage/message/request_id 一并采集进诊断日志，研发拿到
 日志即可精准定位「哪个环节 + 谁的责任 + 具体报错原文」。
+
+维护约定：
+- 枚举**成员值**即对外契约（前端逻辑、诊断日志、SSE 帧都依赖它），
+  一旦发布**不可随意更名**；确需废弃时保留旧值并标注 deprecated。
+- 新增错误码时挑选或新增合适的分组，补一行 docstring 说明触发场景。
 """
 
 from __future__ import annotations
 
 from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """全项目机器可读错误码的唯一登记处。
+
+    成员值必须与历史字面量逐字一致（前后端契约），只做集中收敛、不改语义。
+    按业务域分组，新增时归入对应分组或新建分组。
+    """
+
+    # —— 通用 HTTP 语义（ApiError 家族基类默认码）——
+    INTERNAL_ERROR = "internal_error"
+    """未归类的服务端内部错误（500 兜底）。"""
+
+    NOT_FOUND = "not_found"
+    """请求的资源不存在（404）。"""
+
+    CONFLICT = "conflict"
+    """资源冲突，如重复创建（409）。"""
+
+    VALIDATION_ERROR = "validation_error"
+    """输入参数校验失败（422）。"""
+
+    UNAUTHORIZED = "unauthorized"
+    """未认证或凭证无效（401）。"""
+
+    FORBIDDEN = "forbidden"
+    """已认证但无权访问该资源（403）。"""
+
+    CONFIGURATION_ERROR = "configuration_error"
+    """缺少必要配置，如未配置 LLM（400）。"""
+
+    UPSTREAM_ERROR = "upstream_error"
+    """上游（LLM / 引擎）返回错误（502）。"""
+
+    SERVICE_UNAVAILABLE = "service_unavailable"
+    """暂时不可用，可重试，如限流 / 超时（503）。"""
+
+    # —— LLM / 结构化输出 ——
+    LLM_UNAVAILABLE = "llm_unavailable"
+    """LLM 暂时性失败：超时 / 限流 / 5xx，可重试。"""
+
+    LLM_AUTH_ERROR = "llm_auth_error"
+    """LLM 鉴权失败：API Key 或权限问题，需改配置，不可重试。"""
+
+    LLM_BAD_REQUEST = "llm_bad_request"
+    """LLM 拒绝请求：请求非法 / 上下文超限。"""
+
+    LLM_EMPTY_RESPONSE = "llm_empty_response"
+    """LLM 未返回任何候选答案。"""
+
+    SCHEMA_VALIDATION_ERROR = "schema_validation_error"
+    """模型输出不符合结构化 schema（如 references 的 minItems）。"""
+
+    # —— 分页 / 游标 ——
+    INVALID_CURSOR = "invalid_cursor"
+    """消息分页游标无效（签名不符 / 格式错误 / 过长）。"""
+
+    INVALID_PAGE_LIMIT = "invalid_page_limit"
+    """分页大小越界。"""
+
+    # —— 知识宇宙（universe）——
+    SNAPSHOT_CHANGED = "snapshot_changed"
+    """探索期间知识图谱快照已变更，需重新开始当前探索。"""
+
+    # —— 检索 / 信源 ——
+    TOO_MANY_SEARCH_SOURCES = "too_many_search_sources"
+    """单次检索指定的信源数量超过上限。"""
+
+    # —— 流式传输（SSE）——
+    STREAM_ERROR = "stream_error"
+    """SSE 流式生成中途意外中断（问答 / 搜索通用）。"""
+
+    # —— MCP 工具 ——
+    MCP_CONNECTION_FAILED = "mcp_connection_failed"
+    """连接外部 MCP 服务器失败。"""
 
 
 class ErrorLayer(StrEnum):

--- a/apps/api/sag_api/core/errors.py
+++ b/apps/api/sag_api/core/errors.py
@@ -1,9 +1,19 @@
 """sag 领域异常 —— 与框架无关，路由层统一映射为 HTTP 响应。
 
 领域服务只抛这些异常；`sag/` 适配层负责把 `zleap-sag` 的 `SagError` 家族翻译到这里。
+
+每个异常带三个维度：
+- ``code``：HTTP 语义错误码（历史字段，向后兼容，前端逻辑沿用）。
+- ``layer``：责任归属（谁该排查），见 :class:`ErrorLayer`。
+- ``stage``：链路环节（哪一步崩），见 :class:`ErrorStage`。
+另有 ``retryable`` 标识是否可安全重试。layer/stage/retryable 可在构造时按
+实际发生点覆盖 —— 同一个 ``ValidationError`` 在 extract 阶段和 upload 阶段
+应打上不同的 stage。
 """
 
 from __future__ import annotations
+
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
 
 
 class ApiError(Exception):
@@ -11,12 +21,42 @@ class ApiError(Exception):
 
     status_code: int = 500
     code: str = "internal_error"
+    layer: ErrorLayer = ErrorLayer.API
+    stage: ErrorStage = ErrorStage.UNKNOWN
+    retryable: bool = False
 
-    def __init__(self, message: str | None = None, *, code: str | None = None):
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        code: str | None = None,
+        layer: ErrorLayer | None = None,
+        stage: ErrorStage | None = None,
+        retryable: bool | None = None,
+    ):
         self.message = message or self.__class__.__doc__ or "Internal error"
         if code:
             self.code = code
+        if layer is not None:
+            self.layer = layer
+        if stage is not None:
+            self.stage = stage
+        if retryable is not None:
+            self.retryable = retryable
         super().__init__(self.message)
+
+    def to_envelope(self, *, request_id: str | None = None) -> dict:
+        """序列化为响应/日志用的结构化错误信封。"""
+        error: dict[str, object] = {
+            "code": self.code,
+            "message": self.message,
+            "layer": self.layer.value,
+            "stage": self.stage.value,
+            "retryable": self.retryable,
+        }
+        if request_id:
+            error["request_id"] = request_id
+        return {"error": error}
 
 
 class NotFoundError(ApiError):
@@ -45,6 +85,8 @@ class AuthError(ApiError):
 
     status_code = 401
     code = "unauthorized"
+    layer = ErrorLayer.API
+    stage = ErrorStage.AUTH
 
 
 class ForbiddenError(ApiError):
@@ -52,6 +94,8 @@ class ForbiddenError(ApiError):
 
     status_code = 403
     code = "forbidden"
+    layer = ErrorLayer.API
+    stage = ErrorStage.AUTH
 
 
 class ConfigurationError(ApiError):
@@ -59,6 +103,8 @@ class ConfigurationError(ApiError):
 
     status_code = 400
     code = "configuration_error"
+    layer = ErrorLayer.API
+    stage = ErrorStage.CONFIG
 
 
 class UpstreamError(ApiError):
@@ -66,6 +112,7 @@ class UpstreamError(ApiError):
 
     status_code = 502
     code = "upstream_error"
+    layer = ErrorLayer.LLM
 
 
 class ServiceUnavailableError(ApiError):
@@ -73,3 +120,4 @@ class ServiceUnavailableError(ApiError):
 
     status_code = 503
     code = "service_unavailable"
+    retryable = True

--- a/apps/api/sag_api/core/errors.py
+++ b/apps/api/sag_api/core/errors.py
@@ -13,14 +13,14 @@
 
 from __future__ import annotations
 
-from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.error_taxonomy import ErrorCode, ErrorLayer, ErrorStage
 
 
 class ApiError(Exception):
     """所有 sag 领域异常的基类。"""
 
     status_code: int = 500
-    code: str = "internal_error"
+    code: str = ErrorCode.INTERNAL_ERROR
     layer: ErrorLayer = ErrorLayer.API
     stage: ErrorStage = ErrorStage.UNKNOWN
     retryable: bool = False
@@ -63,28 +63,28 @@ class NotFoundError(ApiError):
     """请求的资源不存在。"""
 
     status_code = 404
-    code = "not_found"
+    code = ErrorCode.NOT_FOUND
 
 
 class ConflictError(ApiError):
     """资源冲突（如重复创建）。"""
 
     status_code = 409
-    code = "conflict"
+    code = ErrorCode.CONFLICT
 
 
 class ValidationError(ApiError):
     """输入校验失败。"""
 
     status_code = 422
-    code = "validation_error"
+    code = ErrorCode.VALIDATION_ERROR
 
 
 class AuthError(ApiError):
     """未认证或凭证无效。"""
 
     status_code = 401
-    code = "unauthorized"
+    code = ErrorCode.UNAUTHORIZED
     layer = ErrorLayer.API
     stage = ErrorStage.AUTH
 
@@ -93,7 +93,7 @@ class ForbiddenError(ApiError):
     """无权访问该资源。"""
 
     status_code = 403
-    code = "forbidden"
+    code = ErrorCode.FORBIDDEN
     layer = ErrorLayer.API
     stage = ErrorStage.AUTH
 
@@ -102,7 +102,7 @@ class ConfigurationError(ApiError):
     """缺少必要配置（如未配置 LLM）。"""
 
     status_code = 400
-    code = "configuration_error"
+    code = ErrorCode.CONFIGURATION_ERROR
     layer = ErrorLayer.API
     stage = ErrorStage.CONFIG
 
@@ -111,7 +111,7 @@ class UpstreamError(ApiError):
     """上游（LLM / 引擎）返回错误。"""
 
     status_code = 502
-    code = "upstream_error"
+    code = ErrorCode.UPSTREAM_ERROR
     layer = ErrorLayer.LLM
 
 
@@ -119,5 +119,5 @@ class ServiceUnavailableError(ApiError):
     """暂时不可用（可重试，如限流 / 超时）。"""
 
     status_code = 503
-    code = "service_unavailable"
+    code = ErrorCode.SERVICE_UNAVAILABLE
     retryable = True

--- a/apps/api/sag_api/db/models/document.py
+++ b/apps/api/sag_api/db/models/document.py
@@ -29,5 +29,9 @@ class Document(IDMixin, TimestampMixin, Base):
     progress: Mapped[int] = mapped_column(Integer, default=0)
     token_usage: Mapped[int] = mapped_column(BigInteger, default=0)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 失败归属：责任层（api/engine/llm/store）与链路环节（parse/chunk/extract/...），
+    # 便于研发从导出日志直接定位。仅在 status=failed 时有值。
+    error_layer: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    error_stage: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # zleap-sag ingest 返回的 source_id（用于溯源）
     sag_source_id: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/apps/api/sag_api/generation/llm.py
+++ b/apps/api/sag_api/generation/llm.py
@@ -16,7 +16,7 @@ from typing import Any
 from sag_agent import CancellationToken, ModelChunk, ModelRequest, Usage
 from sag_agent import ToolCall as RuntimeToolCall
 from sag_api.core.config import Settings
-from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.error_taxonomy import ErrorCode, ErrorLayer, ErrorStage
 from sag_api.core.errors import (
     ApiError,
     ConfigurationError,
@@ -65,7 +65,7 @@ def _classify_llm_error(e: Exception, *, stage: ErrorStage) -> ApiError:
     if name in _retryable_names or status in {408, 429, 503}:
         return ServiceUnavailableError(
             f"模型调用暂时失败（{name}），请稍后重试：{e}",
-            code="llm_unavailable",
+            code=ErrorCode.LLM_UNAVAILABLE,
             layer=ErrorLayer.LLM,
             stage=stage,
         )
@@ -73,7 +73,7 @@ def _classify_llm_error(e: Exception, *, stage: ErrorStage) -> ApiError:
     if name in {"AuthenticationError", "PermissionDeniedError"} or status in {401, 403}:
         return ConfigurationError(
             f"模型鉴权失败（{name}），请检查 API Key 配置：{e}",
-            code="llm_auth_error",
+            code=ErrorCode.LLM_AUTH_ERROR,
             layer=ErrorLayer.LLM,
             stage=ErrorStage.CONFIG,
         )
@@ -81,7 +81,7 @@ def _classify_llm_error(e: Exception, *, stage: ErrorStage) -> ApiError:
     if name in {"BadRequestError", "ContextWindowExceededError", "UnprocessableEntityError"} or status in {400, 422}:
         return UpstreamError(
             f"模型拒绝请求（{name}）：{e}",
-            code="llm_bad_request",
+            code=ErrorCode.LLM_BAD_REQUEST,
             layer=ErrorLayer.LLM,
             stage=stage,
         )
@@ -245,7 +245,7 @@ class LLMClient:
             if not choices:
                 raise UpstreamError(
                     "模型未返回候选答案",
-                    code="llm_empty_response",
+                    code=ErrorCode.LLM_EMPTY_RESPONSE,
                     layer=ErrorLayer.LLM,
                     stage=ErrorStage.GENERATE,
                 )

--- a/apps/api/sag_api/generation/llm.py
+++ b/apps/api/sag_api/generation/llm.py
@@ -16,7 +16,13 @@ from typing import Any
 from sag_agent import CancellationToken, ModelChunk, ModelRequest, Usage
 from sag_agent import ToolCall as RuntimeToolCall
 from sag_api.core.config import Settings
-from sag_api.core.errors import ConfigurationError, UpstreamError
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.errors import (
+    ApiError,
+    ConfigurationError,
+    ServiceUnavailableError,
+    UpstreamError,
+)
 from sag_api.core.litellm_policy import apply_litellm_completion_policy
 from sag_api.core.logging import get_logger
 
@@ -36,6 +42,51 @@ def _attr(value: Any, name: str, default: Any = None) -> Any:
     if isinstance(value, dict):
         return value.get(name, default)
     return getattr(value, name, default)
+
+
+def _classify_llm_error(e: Exception, *, stage: ErrorStage) -> ApiError:
+    """把 LiteLLM 的裸异常拆分为带 layer/stage 的领域异常。
+
+    历史上所有厂商错误都塌缩成一个 ``UpstreamError``，研发无法区分
+    「超时/限流（可重试）」与「鉴权/请求非法（改配置才行）」。这里按
+    LiteLLM 的异常类型名与 status_code 做粗分类，全部归到 LLM 层。
+    """
+    name = type(e).__name__
+    status = getattr(e, "status_code", None)
+    detail = f"{name}: {e}"
+    # 超时 / 限流 / 服务暂不可用 —— 可安全重试
+    _retryable_names = {
+        "Timeout",
+        "APITimeoutError",
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "InternalServerError",
+    }
+    if name in _retryable_names or status in {408, 429, 503}:
+        return ServiceUnavailableError(
+            f"模型调用暂时失败（{name}），请稍后重试：{e}",
+            code="llm_unavailable",
+            layer=ErrorLayer.LLM,
+            stage=stage,
+        )
+    # 鉴权失败 —— API key / 权限问题，需改配置
+    if name in {"AuthenticationError", "PermissionDeniedError"} or status in {401, 403}:
+        return ConfigurationError(
+            f"模型鉴权失败（{name}），请检查 API Key 配置：{e}",
+            code="llm_auth_error",
+            layer=ErrorLayer.LLM,
+            stage=ErrorStage.CONFIG,
+        )
+    # 请求非法 / 上下文超限 —— 请求本身的问题
+    if name in {"BadRequestError", "ContextWindowExceededError", "UnprocessableEntityError"} or status in {400, 422}:
+        return UpstreamError(
+            f"模型拒绝请求（{name}）：{e}",
+            code="llm_bad_request",
+            layer=ErrorLayer.LLM,
+            stage=stage,
+        )
+    # 其它一律归为通用生成失败
+    return UpstreamError(f"生成失败：{detail}", layer=ErrorLayer.LLM, stage=stage)
 
 
 class LLMClient:
@@ -178,7 +229,7 @@ class LLMClient:
             raise
         except Exception as e:  # noqa: BLE001
             log.warning("LLM 轮次流式调用失败：%s", e)
-            raise UpstreamError(f"生成失败：{e}") from e
+            raise _classify_llm_error(e, stage=ErrorStage.GENERATE) from e
         finally:
             if stream is not None:
                 try:
@@ -192,10 +243,17 @@ class LLMClient:
             resp = await self._create_completion(messages)
             choices = _attr(resp, "choices", []) or []
             if not choices:
-                raise UpstreamError("模型未返回候选答案")
+                raise UpstreamError(
+                    "模型未返回候选答案",
+                    code="llm_empty_response",
+                    layer=ErrorLayer.LLM,
+                    stage=ErrorStage.GENERATE,
+                )
             return _attr(_attr(choices[0], "message", {}), "content", "") or ""
+        except ApiError:
+            raise
         except Exception as e:  # noqa: BLE001
-            raise UpstreamError(f"生成失败：{e}") from e
+            raise _classify_llm_error(e, stage=ErrorStage.GENERATE) from e
 
     async def stream_complete(self, messages: list[Message]) -> AsyncIterator[str]:
         """Stream plain text completion deltas without the Agent/tool protocol."""
@@ -214,7 +272,7 @@ class LLMClient:
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001
-            raise UpstreamError(f"生成失败：{e}") from e
+            raise _classify_llm_error(e, stage=ErrorStage.GENERATE) from e
         finally:
             # Closing explicitly makes browser aborts release the upstream HTTP
             # connection immediately, even when the stream is only partly read.

--- a/apps/api/sag_api/jobs/tasks.py
+++ b/apps/api/sag_api/jobs/tasks.py
@@ -15,7 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sag_api.core.config import settings
 from sag_api.core.db import SessionLocal
-from sag_api.core.errors import NotFoundError
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.errors import ApiError, NotFoundError
 from sag_api.core.logging import get_logger
 from sag_api.db.models import Document, Job, Source
 from sag_api.enums import DocumentStatus, JobType
@@ -27,6 +28,30 @@ from sag_api.sag.dto import ProcessCheckpoint
 log = get_logger("jobs")
 
 TaskHandler = Callable[[AsyncSession, Job], Awaitable[None]]
+
+# 文档失败时的当前状态 → 链路环节。这是「唯一知道 stage 的地方」的兜底映射：
+# 当异常本身没带 stage（非 ApiError，例如逃逸的 jsonschema 错误）时，用文档处在
+# 哪个状态推断它卡在哪个环节。
+_STATUS_TO_STAGE: dict[DocumentStatus, ErrorStage] = {
+    DocumentStatus.PENDING: ErrorStage.PARSE,
+    DocumentStatus.LOADING: ErrorStage.PARSE,
+    DocumentStatus.EXTRACTING: ErrorStage.EXTRACT,
+}
+
+
+def _classify_document_failure(
+    e: Exception, current_status: DocumentStatus
+) -> tuple[ErrorLayer, ErrorStage]:
+    """推断失败的责任层与链路环节。
+
+    优先信任领域异常自带的 layer/stage（LLM 分类、引擎翻译层都会填）；
+    否则退化为「按文档当前状态猜环节」，责任层归 engine（zleap-sag 抽取/入库
+    过程中逃逸的裸异常，如 jsonschema.ValidationError，几乎都发生在引擎侧）。
+    """
+    if isinstance(e, ApiError) and e.layer is not None and e.stage is not None:
+        return e.layer, e.stage
+    stage = _STATUS_TO_STAGE.get(current_status, ErrorStage.EXTRACT)
+    return ErrorLayer.ENGINE, stage
 
 
 async def process_document(
@@ -131,8 +156,18 @@ async def process_document(
     except JobPaused:
         raise
     except Exception as e:  # noqa: BLE001 - 记录到文档后再上抛给 worker
+        layer, stage = _classify_document_failure(e, document.status)
         document.status = DocumentStatus.FAILED
         document.error = getattr(e, "message", None) or str(e)
+        document.error_layer = layer.value
+        document.error_stage = stage.value
+        log.warning(
+            "文档处理失败 doc=%s layer=%s stage=%s error=%s",
+            document.id,
+            layer.value,
+            stage.value,
+            document.error,
+        )
         await session.commit()
         raise
 

--- a/apps/api/sag_api/main.py
+++ b/apps/api/sag_api/main.py
@@ -16,7 +16,7 @@ from sag_api.api.v1 import api_router
 from sag_api.branding import PRODUCT_NAME
 from sag_api.core.config import settings
 from sag_api.core.db import SessionLocal, dispose_db, init_db
-from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.error_taxonomy import ErrorCode, ErrorLayer, ErrorStage
 from sag_api.core.errors import ApiError
 from sag_api.core.litellm_policy import install_litellm_policy, uninstall_litellm_policy
 from sag_api.core.logging import RequestContextMiddleware, configure_logging, get_logger
@@ -180,7 +180,7 @@ def create_app() -> FastAPI:
         log.exception("未处理异常：%s", exc)
         request_id = getattr(request.state, "request_id", None)
         error: dict[str, object] = {
-            "code": "internal_error",
+            "code": ErrorCode.INTERNAL_ERROR,
             "message": "服务器内部错误",
             "layer": ErrorLayer.API.value,
             "stage": ErrorStage.UNKNOWN.value,

--- a/apps/api/sag_api/main.py
+++ b/apps/api/sag_api/main.py
@@ -16,6 +16,7 @@ from sag_api.api.v1 import api_router
 from sag_api.branding import PRODUCT_NAME
 from sag_api.core.config import settings
 from sag_api.core.db import SessionLocal, dispose_db, init_db
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
 from sag_api.core.errors import ApiError
 from sag_api.core.litellm_policy import install_litellm_policy, uninstall_litellm_policy
 from sag_api.core.logging import RequestContextMiddleware, configure_logging, get_logger
@@ -167,19 +168,27 @@ def create_app() -> FastAPI:
     app.add_middleware(RequestContextMiddleware)
 
     @app.exception_handler(ApiError)
-    async def _handle_api_error(_request: Request, exc: ApiError) -> JSONResponse:
+    async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
+        request_id = getattr(request.state, "request_id", None)
         return JSONResponse(
             status_code=exc.status_code,
-            content={"error": {"code": exc.code, "message": exc.message}},
+            content=exc.to_envelope(request_id=request_id),
         )
 
     @app.exception_handler(Exception)
-    async def _handle_unexpected(_request: Request, exc: Exception) -> JSONResponse:
+    async def _handle_unexpected(request: Request, exc: Exception) -> JSONResponse:
         log.exception("未处理异常：%s", exc)
-        return JSONResponse(
-            status_code=500,
-            content={"error": {"code": "internal_error", "message": "服务器内部错误"}},
-        )
+        request_id = getattr(request.state, "request_id", None)
+        error: dict[str, object] = {
+            "code": "internal_error",
+            "message": "服务器内部错误",
+            "layer": ErrorLayer.API.value,
+            "stage": ErrorStage.UNKNOWN.value,
+            "retryable": False,
+        }
+        if request_id:
+            error["request_id"] = request_id
+        return JSONResponse(status_code=500, content={"error": error})
 
     app.include_router(api_router)
 

--- a/apps/api/sag_api/sag/compat.py
+++ b/apps/api/sag_api/sag/compat.py
@@ -77,6 +77,14 @@ def _looks_like_extract_response_schema(schema: Any) -> bool:
     )
 
 
+# Event fields upstream marks required but validates as warning-only in
+# ``_validate_output``.  Enforcing them as a strict structured-output schema
+# makes providers reject otherwise-usable chunks and retry to the limit, so a
+# single omitted field discards the whole chunk.  We relax them to match what
+# upstream actually tolerates, then backfill defaults in ``_repair_extract_response``.
+_SOFT_EVENT_FIELDS = ("references", "title", "content", "is_valid")
+
+
 def _relax_extract_schema(schema: dict[str, Any]) -> dict[str, Any]:
     relaxed = copy.deepcopy(schema)
     data = relaxed.get("properties", {}).get("data")
@@ -87,7 +95,13 @@ def _relax_extract_schema(schema: dict[str, Any]) -> dict[str, Any]:
             _without_required_field(meta, "reason")
     event = relaxed.get("definitions", {}).get("event")
     if isinstance(event, dict):
-        _without_required_field(event, "is_valid")
+        for field in _SOFT_EVENT_FIELDS:
+            _without_required_field(event, field)
+        # Drop the ``minItems: 1`` floor on references: upstream only warns on
+        # empty references, it never fails validation on them.
+        references = event.get("properties", {}).get("references")
+        if isinstance(references, dict):
+            references.pop("minItems", None)
     return relaxed
 
 
@@ -114,6 +128,17 @@ def _repair_extract_response(result: Any) -> set[str]:
         if "is_valid" not in item:
             item["is_valid"] = True
             repaired.add("data.items[].is_valid")
+        # Backfill the warning-only fields so the item stays schema-shaped for
+        # the downstream parser even when the model dropped them.
+        if not isinstance(item.get("references"), list):
+            item["references"] = []
+            repaired.add("data.items[].references")
+        if not isinstance(item.get("title"), str):
+            item["title"] = ""
+            repaired.add("data.items[].title")
+        if not isinstance(item.get("content"), str):
+            item["content"] = ""
+            repaired.add("data.items[].content")
         children = item.get("children")
         if isinstance(children, list):
             for child in children:
@@ -128,11 +153,14 @@ def install_zleap_sag_extract_compat() -> None:
     """Allow event extraction to accept minor omissions in model output.
 
     Some OpenAI-compatible models produce valid event ``data.items`` but omit
-    telemetry-only ``data.meta`` or the boolean ``is_valid`` flag.  Upstream
-    zleap-sag validates these fields before its parser can use the extracted
-    events, even though the parser already treats missing ``is_valid`` as true.
-    We keep strict validation for title/content/references and restore the
-    compatible defaults before zleap-sag's own output validator runs.
+    telemetry-only ``data.meta`` or per-item fields (``is_valid``, ``references``,
+    ``title``, ``content``).  Upstream zleap-sag lists these as schema-required,
+    yet its own ``_validate_output`` only *warns* on missing/empty
+    ``references``/``title``/``content`` and defaults ``is_valid`` to true — so a
+    single omitted field makes structured-output providers reject and retry the
+    whole chunk to the limit, discarding otherwise-usable events.  We relax the
+    schema to what upstream actually tolerates and restore compatible defaults
+    before zleap-sag's own output validator runs.
     """
 
     from zleap.sag.modules.extract.processor import EventProcessor

--- a/apps/api/sag_api/sag/engine_manager.py
+++ b/apps/api/sag_api/sag/engine_manager.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from zleap.sag import DataEngine
 
 from sag_api.core.config import Settings
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
 from sag_api.core.logging import get_logger
 from sag_api.enums import SEARCH_STRATEGIES, normalize_search_strategy
 from sag_api.sag.config_builder import build_engine_config
@@ -349,11 +350,15 @@ class EngineManager:
         from sag_api.core.errors import UpstreamError
 
         try:
-            with map_sag_errors():
+            with map_sag_errors(stage=ErrorStage.PERSIST):
                 await engine.init_schema()
         except SQLAlchemyError as error:
             log.exception("知识引擎数据库结构初始化失败")
-            raise UpstreamError("信源引擎初始化失败，请稍后重试") from error
+            raise UpstreamError(
+                "信源引擎初始化失败，请稍后重试",
+                layer=ErrorLayer.STORE,
+                stage=ErrorStage.PERSIST,
+            ) from error
         self._schema_ready = True
 
     async def _ensure_source_config(
@@ -399,7 +404,11 @@ class EngineManager:
             from sag_api.core.errors import UpstreamError
 
             log.exception("信源父记录初始化失败 source_config_id=%s", source_config_id)
-            raise UpstreamError("信源引擎初始化失败，请稍后重试") from error
+            raise UpstreamError(
+                "信源引擎初始化失败，请稍后重试",
+                layer=ErrorLayer.STORE,
+                stage=ErrorStage.PERSIST,
+            ) from error
 
     async def _slot(self, source_config_id: str, source: Source | None = None) -> _Slot:
         slot = self._slots.get(source_config_id)
@@ -417,7 +426,7 @@ class EngineManager:
                         source_config_id=source_config_id,
                         health_check=False,
                     )
-                    with map_sag_errors():
+                    with map_sag_errors(stage=ErrorStage.CONFIG):
                         await engine.start()
                     try:
                         await self._ensure_engine_schema(engine)
@@ -552,7 +561,7 @@ class EngineManager:
                     async with slot.state_lock:
                         slot.concurrent_allowed.clear()
                     await slot.idle.wait()
-                    with map_sag_errors():
+                    with map_sag_errors(stage=ErrorStage.PERSIST):
                         deleted = await delete_document_records(
                             source_config_id,
                             document_source_id,
@@ -593,7 +602,7 @@ class EngineManager:
         async def never_pause() -> bool:
             return False
 
-        with map_sag_errors():
+        with map_sag_errors(stage=ErrorStage.EXTRACT):
             async with self.use_concurrently(source_config_id, source) as engine:
                 processor = IncrementalDocumentProcessor(
                     engine,
@@ -627,7 +636,7 @@ class EngineManager:
         async def run() -> Any:
             # The timeout must include waiting for the per-source lock. Otherwise
             # concurrent searches can queue forever before the timed region starts.
-            with map_sag_errors():
+            with map_sag_errors(stage=ErrorStage.RETRIEVE):
                 async with self.use(source_config_id, source) as engine:
                     return await engine.search(query, strategy=strategy, top_k=top_k)
 

--- a/apps/api/sag_api/sag/errors.py
+++ b/apps/api/sag_api/sag/errors.py
@@ -13,7 +13,7 @@ from zleap.sag.exceptions import (
     SagError,
 )
 
-from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.error_taxonomy import ErrorCode, ErrorLayer, ErrorStage
 from sag_api.core.errors import (
     ConfigurationError,
     NotFoundError,
@@ -55,7 +55,7 @@ def map_sag_errors(*, stage: ErrorStage = ErrorStage.UNKNOWN):
         message = getattr(e, "message", None) or str(e)
         raise ValidationError(
             f"模型输出不符合结构化 schema：{message}",
-            code="schema_validation_error",
+            code=ErrorCode.SCHEMA_VALIDATION_ERROR,
             layer=ErrorLayer.LLM,
             stage=stage,
         ) from e

--- a/apps/api/sag_api/sag/errors.py
+++ b/apps/api/sag_api/sag/errors.py
@@ -13,6 +13,7 @@ from zleap.sag.exceptions import (
     SagError,
 )
 
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
 from sag_api.core.errors import (
     ConfigurationError,
     NotFoundError,
@@ -21,22 +22,42 @@ from sag_api.core.errors import (
     ValidationError,
 )
 
+try:  # jsonschema 是 zleap-sag structured-output 校验的传递依赖
+    from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+except Exception:  # noqa: BLE001 - 依赖缺失时退化为不可能匹配的哨兵
+    JsonSchemaValidationError = ()  # type: ignore[assignment]
+
 
 @contextmanager
-def map_sag_errors():
-    """在此上下文内发生的 SagError 会被翻译成对应的 ApiError。"""
+def map_sag_errors(*, stage: ErrorStage = ErrorStage.UNKNOWN):
+    """在此上下文内发生的引擎异常会被翻译成带 layer/stage 的 ApiError。
+
+    ``stage`` 由调用方按当前链路环节传入（如 process_document 主要覆盖
+    extract，search 覆盖 retrieve），使翻译出的错误携带准确的环节标记。
+    """
     try:
         yield
     except ConfigError as e:
-        raise ConfigurationError(str(e)) from e
+        raise ConfigurationError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e
     except ResourceNotFoundError as e:
-        raise NotFoundError(str(e)) from e
+        raise NotFoundError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e
     except InvalidInputError as e:
-        raise ValidationError(str(e)) from e
+        raise ValidationError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e
     except RetryableError as e:
         # 限流 / 超时 / 上游暂不可用 —— 可重试
-        raise ServiceUnavailableError(str(e)) from e
+        raise ServiceUnavailableError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e
     except NonRetryableError as e:
-        raise ValidationError(str(e)) from e
+        raise ValidationError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e
+    except JsonSchemaValidationError as e:  # type: ignore[misc]
+        # structured-output schema 校验失败（如 references 的 minItems）：
+        # 这类不属于 SagError 家族，历史上会漏出为裸 Exception。根子在
+        # 模型没按 schema 输出 → 归到 LLM 层，环节沿用调用方传入的 stage。
+        message = getattr(e, "message", None) or str(e)
+        raise ValidationError(
+            f"模型输出不符合结构化 schema：{message}",
+            code="schema_validation_error",
+            layer=ErrorLayer.LLM,
+            stage=stage,
+        ) from e
     except SagError as e:
-        raise UpstreamError(str(e)) from e
+        raise UpstreamError(str(e), layer=ErrorLayer.ENGINE, stage=stage) from e

--- a/apps/api/sag_api/schemas/document.py
+++ b/apps/api/sag_api/schemas/document.py
@@ -37,6 +37,8 @@ class DocumentOut(BaseModel):
     progress: int
     token_usage: int
     error: str | None
+    error_layer: str | None = None
+    error_stage: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/apps/api/sag_api/services/agent_domain.py
+++ b/apps/api/sag_api/services/agent_domain.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from sag_api.branding import DEFAULT_AGENT_AVATAR, DEFAULT_AGENT_NAME
 from sag_api.core.config import settings
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ConflictError, NotFoundError, ValidationError
 from sag_api.db.models import Agent, AgentBinding, Message, Source, Thread
 from sag_api.enums import BindingTargetType, MessageRole
@@ -83,7 +84,7 @@ def _encode_message_cursor(thread_id: str, message: Message) -> str:
 
 def _decode_message_cursor(thread_id: str, value: str) -> tuple[datetime, str]:
     def invalid() -> ValidationError:
-        return ValidationError("消息游标无效", code="invalid_cursor")
+        return ValidationError("消息游标无效", code=ErrorCode.INVALID_CURSOR)
 
     if not value or len(value) > MESSAGE_CURSOR_MAX_LENGTH or value.count(".") != 1:
         raise invalid()
@@ -362,7 +363,7 @@ async def list_messages_page(
     if limit < 1 or limit > MESSAGE_PAGE_MAX:
         raise ValidationError(
             f"消息页大小必须在 1 到 {MESSAGE_PAGE_MAX} 之间",
-            code="invalid_page_limit",
+            code=ErrorCode.INVALID_PAGE_LIMIT,
         )
 
     statement = select(Message).where(Message.thread_id == thread_id)

--- a/apps/api/sag_api/services/source_service.py
+++ b/apps/api/sag_api/services/source_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sag_api.connectors import registry
 from sag_api.core.config import settings
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ApiError, NotFoundError, ValidationError
 from sag_api.core.logging import get_logger
 from sag_api.db.base import new_id
@@ -43,7 +44,7 @@ async def search_source_candidates(
         if len(ordered_ids) > limit:
             raise ValidationError(
                 f"单次最多检索 {limit} 个信息源，请通过 @ 缩小范围",
-                code="too_many_search_sources",
+                code=ErrorCode.TOO_MANY_SEARCH_SOURCES,
             )
         rows = await session.execute(select(Source).where(Source.id.in_(ordered_ids)))
         by_id = {source.id: source for source in rows.scalars().all()}

--- a/apps/api/sag_api/services/universe_service.py
+++ b/apps/api/sag_api/services/universe_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sag_api.core.config import settings
 from sag_api.core.db import SessionLocal
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import (
     ConflictError,
     NotFoundError,
@@ -666,7 +667,7 @@ async def universe_expand(
         if "revision" in str(error):
             raise ConflictError(
                 "知识图谱数据已更新，请重新开始当前探索",
-                code="snapshot_changed",
+                code=ErrorCode.SNAPSHOT_CHANGED,
             ) from error
         raise ValidationError("无效或不匹配的知识宇宙游标") from error
     except TypeError as error:
@@ -680,7 +681,7 @@ async def universe_expand(
     if committed_revision != source_revision:
         raise ConflictError(
             "知识图谱数据已更新，请重新开始当前探索",
-            code="snapshot_changed",
+            code=ErrorCode.SNAPSHOT_CHANGED,
         )
 
     anchor = {
@@ -795,7 +796,7 @@ async def universe_timeline(
         if "revision" in str(error):
             raise ConflictError(
                 "知识图谱数据已更新，请刷新时间轴后继续",
-                code="snapshot_changed",
+                code=ErrorCode.SNAPSHOT_CHANGED,
             ) from error
         raise ValidationError("无效或不匹配的知识时间轴游标") from error
     except TypeError as error:
@@ -807,7 +808,7 @@ async def universe_timeline(
     if committed_revision != source_revision:
         raise ConflictError(
             "知识图谱数据已更新，请刷新时间轴后继续",
-            code="snapshot_changed",
+            code=ErrorCode.SNAPSHOT_CHANGED,
         )
     page_signature = "|".join(
         [

--- a/apps/api/sag_api/tools/mcp.py
+++ b/apps/api/sag_api/tools/mcp.py
@@ -23,6 +23,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
+from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.logging import get_logger
 from sag_api.tools.base import Tool, ToolContext, ToolMeta, ToolResult
 
@@ -326,7 +327,7 @@ async def open_agent_mcp_tools(specs: list[tuple[str, dict]]) -> AsyncIterator[M
                 log.warning("MCP 连接失败 %s", label, exc_info=True)
                 warnings.append(
                     {
-                        "code": "mcp_connection_failed",
+                        "code": ErrorCode.MCP_CONNECTION_FAILED,
                         "server": _namespace(label),
                         "message": "MCP 服务连接失败，本轮已跳过该服务。",
                     }

--- a/apps/api/tests/test_error_taxonomy.py
+++ b/apps/api/tests/test_error_taxonomy.py
@@ -1,0 +1,99 @@
+"""错误分类维度（layer/stage）单元测试。
+
+覆盖三个补齐点：
+1. `map_sag_errors` 现在会拦截逃逸的 `jsonschema.ValidationError`（历史 minItems bug）。
+2. LLM 厂商错误按超时/限流/鉴权/非法请求拆分，不再一律 UpstreamError。
+3. 文档失败按当前状态推断 stage，责任层归 engine 兜底。
+4. 错误信封携带 layer/stage/retryable/request_id。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sag_api.core.error_taxonomy import ErrorLayer, ErrorStage
+from sag_api.core.errors import (
+    ApiError,
+    ConfigurationError,
+    ServiceUnavailableError,
+    UpstreamError,
+    ValidationError,
+)
+from sag_api.enums import DocumentStatus
+from sag_api.generation.llm import _classify_llm_error
+from sag_api.jobs.tasks import _classify_document_failure
+from sag_api.sag.errors import map_sag_errors
+
+
+def test_envelope_carries_all_dimensions():
+    err = ValidationError("bad", layer=ErrorLayer.LLM, stage=ErrorStage.EXTRACT, retryable=False)
+    env = err.to_envelope(request_id="abc123")["error"]
+    assert env["code"] == "validation_error"
+    assert env["layer"] == "llm"
+    assert env["stage"] == "extract"
+    assert env["retryable"] is False
+    assert env["request_id"] == "abc123"
+
+
+def test_envelope_omits_request_id_when_absent():
+    assert "request_id" not in ApiError("x").to_envelope()["error"]
+
+
+def test_configuration_error_defaults_to_config_stage():
+    err = ConfigurationError("尚未配置 LLM")
+    assert err.stage == ErrorStage.CONFIG
+    assert err.layer == ErrorLayer.API
+
+
+def test_map_sag_errors_catches_escaped_jsonschema_validation():
+    """历史上 references 的 minItems 校验失败会漏成裸 Exception。"""
+    jsonschema = pytest.importorskip("jsonschema")
+    with pytest.raises(ValidationError) as exc:
+        with map_sag_errors(stage=ErrorStage.EXTRACT):
+            raise jsonschema.exceptions.ValidationError("[] should be non-empty (minItems)")
+    err = exc.value
+    assert err.code == "schema_validation_error"
+    assert err.layer == ErrorLayer.LLM
+    assert err.stage == ErrorStage.EXTRACT
+
+
+def test_classify_llm_timeout_is_retryable():
+    class APITimeoutError(Exception):
+        pass
+
+    err = _classify_llm_error(APITimeoutError("timed out"), stage=ErrorStage.GENERATE)
+    assert isinstance(err, ServiceUnavailableError)
+    assert err.retryable is True
+    assert err.layer == ErrorLayer.LLM
+
+
+def test_classify_llm_auth_becomes_config_error():
+    class AuthenticationError(Exception):
+        status_code = 401
+
+    err = _classify_llm_error(AuthenticationError("bad key"), stage=ErrorStage.GENERATE)
+    assert isinstance(err, ConfigurationError)
+    assert err.stage == ErrorStage.CONFIG
+    assert err.code == "llm_auth_error"
+
+
+def test_classify_llm_generic_falls_back_to_upstream():
+    err = _classify_llm_error(RuntimeError("weird"), stage=ErrorStage.GENERATE)
+    assert isinstance(err, UpstreamError)
+    assert err.layer == ErrorLayer.LLM
+    assert err.stage == ErrorStage.GENERATE
+
+
+def test_document_failure_trusts_apierror_dimensions():
+    api_err = ValidationError("x", layer=ErrorLayer.LLM, stage=ErrorStage.EXTRACT)
+    layer, stage = _classify_document_failure(api_err, DocumentStatus.LOADING)
+    assert (layer, stage) == (ErrorLayer.LLM, ErrorStage.EXTRACT)
+
+
+def test_document_failure_falls_back_to_status_stage():
+    layer, stage = _classify_document_failure(RuntimeError("naked"), DocumentStatus.EXTRACTING)
+    assert layer == ErrorLayer.ENGINE
+    assert stage == ErrorStage.EXTRACT
+
+    layer, stage = _classify_document_failure(RuntimeError("naked"), DocumentStatus.LOADING)
+    assert stage == ErrorStage.PARSE

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -696,6 +696,94 @@ async def test_zleap_sag_extract_compat_repairs_missing_is_valid():
 
 
 @pytest.mark.asyncio
+async def test_zleap_sag_extract_compat_repairs_empty_and_missing_references():
+    from zleap.sag.modules.extract.processor import EventProcessor
+
+    from sag_api.sag.compat import install_zleap_sag_extract_compat
+
+    class FakeLLM:
+        async def chat_with_schema(self, _messages, response_schema):
+            event_schema = response_schema["definitions"]["event"]
+            required = event_schema.get("required", [])
+            # Soft fields must be dropped from required and lose the minItems floor.
+            assert "references" not in required
+            assert "title" not in required
+            assert "content" not in required
+            assert "minItems" not in event_schema["properties"]["references"]
+            return {
+                "type": "response",
+                "data": {
+                    "meta": {"reason": "ok"},
+                    "items": [
+                        # Model omitted references entirely and left title empty.
+                        {"content": "有内容但缺少引用与标题"},
+                        {
+                            "title": "父事项",
+                            "content": "父事项内容",
+                            "references": [1],
+                            "children": [
+                                # Child returned references as empty list.
+                                {"title": "子事项", "content": "子内容", "references": []}
+                            ],
+                        },
+                    ],
+                },
+            }
+
+    install_zleap_sag_extract_compat()
+
+    schema = {
+        "type": "object",
+        "required": ["type", "data"],
+        "properties": {
+            "type": {"const": "response"},
+            "data": {
+                "type": "object",
+                "required": ["items", "meta"],
+                "properties": {
+                    "items": {"type": "array", "items": {"$ref": "#/definitions/event"}},
+                    "meta": {
+                        "type": "object",
+                        "required": ["reason"],
+                        "properties": {"reason": {"type": "string"}},
+                    },
+                },
+            },
+        },
+        "definitions": {
+            "event": {
+                "type": "object",
+                "required": ["title", "content", "references", "is_valid"],
+                "properties": {
+                    "title": {"type": "string"},
+                    "content": {"type": "string"},
+                    "references": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                    },
+                    "is_valid": {"type": "boolean"},
+                    "children": {"type": "array", "items": {"$ref": "#/definitions/event"}},
+                },
+            },
+        },
+    }
+    fake_processor = SimpleNamespace(llm_client=FakeLLM())
+
+    result = await EventProcessor._call_llm_with_retry(fake_processor, [], schema)
+
+    first, second = result["data"]["items"]
+    # Missing references/title backfilled to schema-shaped defaults; is_valid too.
+    assert first["references"] == []
+    assert first["title"] == ""
+    assert first["is_valid"] is True
+    # Non-empty references and provided fields are left untouched.
+    assert second["references"] == [1]
+    assert second["title"] == "父事项"
+    assert second["children"][0]["references"] == []
+
+
+@pytest.mark.asyncio
 async def test_zleap_sag_extract_compat_falls_back_to_json_object_when_json_schema_is_unavailable():
     from zleap.sag.core.ai.base import BaseLLMClient
     from zleap.sag.core.ai.models import LLMMessage, LLMResponse, LLMRole

--- a/apps/desktop/src/channels.ts
+++ b/apps/desktop/src/channels.ts
@@ -2,6 +2,7 @@ export const DESKTOP_CHANNELS = {
   appInfo: "desktop:app-info",
   checkForUpdates: "desktop:check-for-updates",
   updateState: "desktop:update-state",
+  diagnosticsInfo: "desktop:diagnostics-info",
 } as const;
 
 export type UpdateState =
@@ -12,3 +13,21 @@ export type UpdateState =
   | { status: "downloading"; percent: number }
   | { status: "downloaded"; version: string }
   | { status: "error"; message: string };
+
+export interface DesktopDiagnosticsInfo {
+  version: string;
+  platform: string;
+  arch: string;
+  electron: string;
+  chrome: string;
+  node: string;
+  logFiles: Array<{
+    name: string;
+    path: string;
+    sizeBytes: number;
+    /** Tail of the file content (up to 5MB). Empty string if unreadable. */
+    content: string;
+    /** True when only the tail was captured because the file exceeded the cap. */
+    truncated: boolean;
+  }>;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,3 +1,4 @@
+import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -9,7 +10,7 @@ import {
 } from "electron";
 import log from "electron-log/main";
 
-import { DESKTOP_CHANNELS } from "./channels";
+import { DESKTOP_CHANNELS, type DesktopDiagnosticsInfo } from "./channels";
 import {
   startPackagedRuntime,
   waitForDevelopmentRuntime,
@@ -29,6 +30,13 @@ if (!app.isPackaged) {
 }
 
 log.initialize();
+
+// Cap each log file at 5MB. On overflow electron-log rotates main.log ->
+// main.old.log (keeping a single archive), so on-disk usage stays bounded at
+// ~10MB total and older logs are discarded automatically — no manual cleanup
+// needed. 5MB comfortably covers a recent troubleshooting window while staying
+// small enough to export and share.
+log.transports.file.maxSize = 5 * 1024 * 1024;
 
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSingleInstanceLock) app.quit();
@@ -87,9 +95,40 @@ function isTrustedSender(event: IpcMainInvokeEvent): boolean {
   }
 }
 
+const LOG_TAIL_BYTES = 5 * 1024 * 1024; // Export at most the last 5MB per log.
+
+/**
+ * Read up to the last `LOG_TAIL_BYTES` of a file without loading the whole
+ * thing into memory. Returns the tail text and whether it was truncated.
+ * Uses only node:fs primitives (no extra dependency).
+ */
+function readLogTail(filePath: string, sizeBytes: number): {
+  content: string;
+  truncated: boolean;
+} {
+  const truncated = sizeBytes > LOG_TAIL_BYTES;
+  const start = truncated ? sizeBytes - LOG_TAIL_BYTES : 0;
+  const length = sizeBytes - start;
+  if (length <= 0) return { content: "", truncated: false };
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(length);
+    let offset = 0;
+    while (offset < length) {
+      const read = readSync(fd, buffer, offset, length - offset, start + offset);
+      if (read <= 0) break;
+      offset += read;
+    }
+    return { content: buffer.subarray(0, offset).toString("utf8"), truncated };
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function registerIpc(): void {
   ipcMain.removeHandler(DESKTOP_CHANNELS.appInfo);
   ipcMain.removeHandler(DESKTOP_CHANNELS.checkForUpdates);
+  ipcMain.removeHandler(DESKTOP_CHANNELS.diagnosticsInfo);
   ipcMain.handle(DESKTOP_CHANNELS.appInfo, (event) => {
     if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
     return { version: app.getVersion(), platform: process.platform, arch: process.arch };
@@ -97,6 +136,42 @@ function registerIpc(): void {
   ipcMain.handle(DESKTOP_CHANNELS.checkForUpdates, async (event) => {
     if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
     return updater?.check() ?? { supported: false };
+  });
+  ipcMain.handle(DESKTOP_CHANNELS.diagnosticsInfo, (event) => {
+    if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
+    const logFiles: DesktopDiagnosticsInfo["logFiles"] = [];
+    try {
+      const logPath = log.transports.file.getFile().path;
+      const dir = path.dirname(logPath);
+      const entries = readdirSync(dir);
+      for (const name of entries) {
+        if (name.endsWith(".log")) {
+          const filePath = path.join(dir, name);
+          const sizeBytes = statSync(filePath).size;
+          let content = "";
+          let truncated = false;
+          try {
+            const tail = readLogTail(filePath, sizeBytes);
+            content = tail.content;
+            truncated = tail.truncated;
+          } catch {
+            // best-effort: an unreadable file still lists its metadata
+          }
+          logFiles.push({ name, path: filePath, sizeBytes, content, truncated });
+        }
+      }
+    } catch {
+      // best-effort: log file discovery is not critical
+    }
+    return {
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      electron: process.versions.electron ?? "unknown",
+      chrome: process.versions.chrome ?? "unknown",
+      node: process.versions.node ?? "unknown",
+      logFiles,
+    };
   });
 }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,12 +1,17 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-import { DESKTOP_CHANNELS, type UpdateState } from "./channels";
+import {
+  DESKTOP_CHANNELS,
+  type DesktopDiagnosticsInfo,
+  type UpdateState,
+} from "./channels";
 
 export interface SagDesktopBridge {
   readonly isDesktop: true;
   readonly platform: NodeJS.Platform;
   appInfo(): Promise<{ version: string; platform: NodeJS.Platform; arch: string }>;
   checkForUpdates(): Promise<{ supported: boolean }>;
+  getDiagnosticsInfo(): Promise<DesktopDiagnosticsInfo>;
   onUpdateState(listener: (state: UpdateState) => void): () => void;
 }
 
@@ -15,6 +20,8 @@ const bridge: SagDesktopBridge = Object.freeze({
   platform: process.platform,
   appInfo: () => ipcRenderer.invoke(DESKTOP_CHANNELS.appInfo),
   checkForUpdates: () => ipcRenderer.invoke(DESKTOP_CHANNELS.checkForUpdates),
+  getDiagnosticsInfo: () =>
+    ipcRenderer.invoke(DESKTOP_CHANNELS.diagnosticsInfo),
   onUpdateState: (listener: (state: UpdateState) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, state: UpdateState) => {
       listener(state);

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AccountSettings } from "@/components/features/account-settings";
 import { AgentSettingsCard } from "@/components/features/agent-settings-card";
 import { AppearanceSettings } from "@/components/features/appearance-settings";
+import { DiagnosticsSettings } from "@/components/features/diagnostics-settings";
 import { KnowledgeConfigForm } from "@/components/features/knowledge-config-form";
 import { McpSettingsCard } from "@/components/features/mcp-settings-card";
 import { McpServiceSettings } from "@/components/features/mcp-service-settings";
@@ -134,6 +135,10 @@ function SettingsPageContent() {
 
         <TabsContent value="graph" className="m-0 animate-fade-in">
           <GraphSettings />
+        </TabsContent>
+
+        <TabsContent value="diagnostics" className="m-0 animate-fade-in">
+          <DiagnosticsSettings />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/components/features/app-shell.tsx
+++ b/apps/web/components/features/app-shell.tsx
@@ -346,6 +346,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [quickSetupOpen, setQuickSetupOpen] = React.useState(false);
   const [timezone, setTimezone] = React.useState(DEFAULT_TIME_ZONE);
   const diag = useDiagnostics();
+  // `diag.record` is referentially stable (bound to the singleton store), unlike
+  // `diag` itself which changes whenever a new entry is recorded. Depend on the
+  // stable function so the bootstrap effect below doesn't re-run on every log.
+  const recordDiag = diag.record;
   const sidebarOpenRef = React.useRef(true);
   const restoreSidebarOpenRef = React.useRef<boolean | null>(null);
   const threadLimitRef = React.useRef(SIDEBAR_THREADS_PAGE_SIZE);
@@ -627,7 +631,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         setQuickSetupOpen(
           shouldShowQuickModelSetup(Boolean(setup?.required), window.localStorage),
         );
-        diag.record("app.init", {
+        recordDiag("app.init", {
           user_id: u.id,
           agent_id: a.id,
           language: c.language ?? "zh",
@@ -660,7 +664,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       alive = false;
       threadRequestIdRef.current += 1;
     };
-  }, [loadThreadLimit, router]);
+  }, [loadThreadLimit, router, recordDiag]);
 
   // 快捷键直接进入探索模式，并打开对应的紧凑工作区。
   React.useEffect(() => {

--- a/apps/web/components/features/app-shell.tsx
+++ b/apps/web/components/features/app-shell.tsx
@@ -25,6 +25,12 @@ import {
 } from "@/lib/app-initialization";
 import { DEFAULT_AGENT_AVATAR, DEFAULT_AGENT_NAME } from "@/lib/branding";
 import type { ConversationTransport } from "@/lib/conversation-runtime";
+import {
+  getDiagnosticsStore,
+  type DiagEntry,
+  type DiagExport,
+  type DiagLogFile,
+} from "@/lib/diagnostics";
 import { DEFAULT_TIME_ZONE } from "@/lib/format";
 import { PetAgent } from "@/lib/pet-agent";
 import {
@@ -61,6 +67,7 @@ import {
   type WindowMode,
   type WindowSize,
 } from "@/lib/window-layout";
+import { useDiagnostics } from "@/hooks/use-diagnostics";
 import { AppSidebar } from "@/components/features/app-sidebar";
 import { ConversationProvider } from "@/components/features/chat/conversation-provider";
 import {
@@ -121,8 +128,18 @@ const CONVERSATION_TRANSPORT: ConversationTransport = {
     webEnabled,
     onEvent,
     signal,
-  }) =>
-    streamAgentAsk(
+  }) => {
+    const store = getDiagnosticsStore();
+    const startedAt = Date.now();
+    store.record("qa.ask", {
+      agent_id: agentId,
+      thread_id: threadId,
+      query: query.length > 500 ? query.slice(0, 500) + "..." : query,
+      attachment_count: attachmentIds?.length ?? 0,
+      source_ids: sourceIds,
+      web_enabled: webEnabled,
+    });
+    const promise = streamAgentAsk(
       agentId,
       threadId,
       {
@@ -132,9 +149,54 @@ const CONVERSATION_TRANSPORT: ConversationTransport = {
         knowledge_only: knowledgeOnly === true || !webEnabled,
         web_enabled: webEnabled,
       },
-      onEvent,
+      (event) => {
+        // 只记录关键事件，跳过高频 message.delta
+        const keyEvents = new Set([
+          "run.started",
+          "run.completed",
+          "run.failed",
+          "run.cancelled",
+          "tool.started",
+          "tool.completed",
+          "tool.failed",
+          "tool.approval_required",
+        ]);
+        if (keyEvents.has(event.type)) {
+          store.record("qa.event", {
+            event_type: event.type,
+            run_id: event.run_id,
+            sequence: event.sequence,
+            turn: event.turn,
+            payload_keys: Object.keys(event.payload ?? {}),
+          });
+        }
+        onEvent(event);
+      },
       signal,
-    ),
+    );
+    void promise.then((outcome) => {
+      store.record(outcome.status === "completed" ? "qa.complete" : "qa.error", {
+        run_id: outcome.runId,
+        status: outcome.status,
+        message_id: outcome.messageId,
+        duration_ms: Date.now() - startedAt,
+        error_code: outcome.error?.code,
+        error_message: outcome.error?.message
+          ? outcome.error.message.slice(0, 500)
+          : undefined,
+      });
+    }).catch((reason) => {
+      store.record("qa.error", {
+        run_id: "unknown",
+        status: "failed",
+        duration_ms: Date.now() - startedAt,
+        error_message: reason instanceof Error
+          ? reason.message.slice(0, 500)
+          : String(reason).slice(0, 500),
+      });
+    });
+    return promise;
+  },
   cancelRun: ({ agentId, threadId, runId }) =>
     api.cancelAgentRun(agentId, threadId, runId),
   approveTool: ({ agentId, threadId, runId, toolCallId }) =>
@@ -172,6 +234,12 @@ interface AppCtx {
   refreshCapabilities: () => Promise<void>;
   timezone: string;
   updateTimezone: (timezone: string) => Promise<void>;
+  diagnostics: {
+    entries: DiagEntry[];
+    record: (type: DiagEntry["type"], data?: Record<string, unknown>) => void;
+    exportLogs: () => DiagExport;
+    downloadLogs: () => Promise<void>;
+  };
 }
 
 const AppContext = React.createContext<AppCtx>({
@@ -199,6 +267,12 @@ const AppContext = React.createContext<AppCtx>({
   refreshCapabilities: async () => {},
   timezone: DEFAULT_TIME_ZONE,
   updateTimezone: async () => {},
+  diagnostics: {
+    entries: [],
+    record: () => {},
+    exportLogs: () => ({ version: 1 as const, exported_at: "", environment: { app: "web" as const, user_agent: "", language: "", timezone: "" }, model_config: null, capabilities: null, entries: [] }),
+    downloadLogs: async () => {},
+  },
 });
 
 export function useApp() {
@@ -271,6 +345,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = React.useState(true);
   const [quickSetupOpen, setQuickSetupOpen] = React.useState(false);
   const [timezone, setTimezone] = React.useState(DEFAULT_TIME_ZONE);
+  const diag = useDiagnostics();
   const sidebarOpenRef = React.useRef(true);
   const restoreSidebarOpenRef = React.useRef<boolean | null>(null);
   const threadLimitRef = React.useRef(SIDEBAR_THREADS_PAGE_SIZE);
@@ -552,6 +627,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         setQuickSetupOpen(
           shouldShowQuickModelSetup(Boolean(setup?.required), window.localStorage),
         );
+        diag.record("app.init", {
+          user_id: u.id,
+          agent_id: a.id,
+          language: c.language ?? "zh",
+          timezone: c.timezone || DEFAULT_TIME_ZONE,
+          platform: typeof window !== "undefined" && window.sagDesktop?.isDesktop ? "desktop" : "web",
+          capabilities: {
+            llm_configured: c.llm_configured,
+            llm_provider: c.llm_provider,
+            llm_model: c.llm_model,
+            embedding_model: c.embedding_model,
+            document_parser: c.document_parser,
+            effective_document_parser: c.effective_document_parser,
+            search_strategy: c.search_strategy,
+            max_upload_mb: c.max_upload_mb,
+          },
+        });
         threadLimitRef.current = SIDEBAR_THREADS_PAGE_SIZE;
         loadThreadLimit(a, SIDEBAR_THREADS_PAGE_SIZE).catch(() => {});
       } catch (e) {
@@ -591,6 +683,91 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     router.replace("/login");
   }, [router]);
 
+  const diagnosticsExportLogs = React.useCallback(() => {
+    return diag.exportLogs(
+      {
+        app: typeof window !== "undefined" && window.sagDesktop?.isDesktop ? "desktop" : "web",
+        user_agent: typeof navigator !== "undefined" ? navigator.userAgent : "",
+        language: capabilities?.language ?? "zh",
+        timezone: timezone,
+      },
+      capabilities
+        ? {
+            llm_provider: capabilities.llm_provider,
+            llm_model: capabilities.llm_model,
+            embedding_model: capabilities.embedding_model,
+            document_parser: capabilities.document_parser,
+            effective_document_parser: capabilities.effective_document_parser,
+            search_strategy: capabilities.search_strategy,
+            max_upload_mb: capabilities.max_upload_mb,
+            language: capabilities.language,
+            timezone: capabilities.timezone,
+          }
+        : null,
+      {
+        llm_configured: capabilities?.llm_configured,
+        llm_provider: capabilities?.llm_provider,
+        llm_model: capabilities?.llm_model,
+        embedding_model: capabilities?.embedding_model,
+        document_parser: capabilities?.document_parser,
+        search_strategy: capabilities?.search_strategy,
+        max_upload_mb: capabilities?.max_upload_mb,
+      },
+    );
+  }, [diag, capabilities, timezone]);
+
+  const diagnosticsDownloadLogs = React.useCallback(async () => {
+    // On desktop, pull the real runtime log files (frontend + backend Python
+    // logs are both piped into electron-log's main.log) so the exported file
+    // carries what R&D actually needs to diagnose a locally-deployed instance.
+    let desktopLogFiles: DiagLogFile[] | undefined;
+    if (typeof window !== "undefined" && window.sagDesktop?.getDiagnosticsInfo) {
+      try {
+        const info = await window.sagDesktop.getDiagnosticsInfo();
+        desktopLogFiles = info.logFiles.map((file) => ({
+          name: file.name,
+          path: file.path,
+          size_bytes: file.sizeBytes,
+          content: file.content,
+          truncated: file.truncated,
+        }));
+      } catch {
+        // best-effort: fall back to an export without the on-disk logs
+      }
+    }
+    diag.downloadLogs(
+      {
+        app: typeof window !== "undefined" && window.sagDesktop?.isDesktop ? "desktop" : "web",
+        user_agent: typeof navigator !== "undefined" ? navigator.userAgent : "",
+        language: capabilities?.language ?? "zh",
+        timezone: timezone,
+      },
+      capabilities
+        ? {
+            llm_provider: capabilities.llm_provider,
+            llm_model: capabilities.llm_model,
+            embedding_model: capabilities.embedding_model,
+            document_parser: capabilities.document_parser,
+            effective_document_parser: capabilities.effective_document_parser,
+            search_strategy: capabilities.search_strategy,
+            max_upload_mb: capabilities.max_upload_mb,
+            language: capabilities.language,
+            timezone: capabilities.timezone,
+          }
+        : null,
+      {
+        llm_configured: capabilities?.llm_configured,
+        llm_provider: capabilities?.llm_provider,
+        llm_model: capabilities?.llm_model,
+        embedding_model: capabilities?.embedding_model,
+        document_parser: capabilities?.document_parser,
+        search_strategy: capabilities?.search_strategy,
+        max_upload_mb: capabilities?.max_upload_mb,
+      },
+      desktopLogFiles,
+    );
+  }, [diag, capabilities, timezone]);
+
   if (loading) return <FullLoader />;
   if (!user || !agent) return null;
 
@@ -621,6 +798,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         refreshCapabilities,
         timezone,
         updateTimezone,
+        diagnostics: {
+          entries: diag.entries,
+          record: diag.record,
+          exportLogs: diagnosticsExportLogs,
+          downloadLogs: diagnosticsDownloadLogs,
+        },
       }}
     >
       <SearchProvider

--- a/apps/web/components/features/chat/conversation-panel.tsx
+++ b/apps/web/components/features/chat/conversation-panel.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { toolArgumentsPreview } from "@/lib/agent-run-activity";
 import { api } from "@/lib/api";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import type { ConversationMessage } from "@/lib/conversation-runtime";
 import { parsePetDraft, PET_DRAFT_EVENT, PET_DRAFT_KEY } from "@/lib/pet-events";
 import { formatTokenCount, relativeTime } from "@/lib/format";
@@ -521,6 +522,10 @@ export function ConversationPanel({
     if ((!query && pendingImages.length === 0) || uploadingRef.current) return;
     if (!capabilities?.llm_configured) {
       toast.error(t("modelNotConfigured"));
+      getDiagnosticsStore().record("error", {
+        context: "conversation.send",
+        error_message: "Model not configured",
+      });
       return;
     }
     if (runtime.getIndexSnapshot().activeRunSessionId) {
@@ -557,9 +562,17 @@ export function ConversationPanel({
 
       void request.catch((error) => {
         toast.error(error instanceof Error ? error.message : t("connectionInterrupted"));
+        getDiagnosticsStore().record("qa.error", {
+          context: "conversation.send",
+          error_message: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+        });
       });
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t("imageUploadFailed"));
+      getDiagnosticsStore().record("qa.error", {
+        context: "conversation.send.upload",
+        error_message: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+      });
     } finally {
       uploadingRef.current = false;
       setUploading(false);

--- a/apps/web/components/features/diagnostics-settings.tsx
+++ b/apps/web/components/features/diagnostics-settings.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { Download, FileText, ShieldCheck, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { useApp } from "@/components/features/app-shell";
+import { SettingsRow, SettingsSection } from "@/components/features/settings-section";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
+
+export function DiagnosticsSettings() {
+  const t = useTranslations("Diagnostics");
+  const { diagnostics } = useApp();
+  const [exporting, setExporting] = React.useState(false);
+  const [clearOpen, setClearOpen] = React.useState(false);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      await diagnostics.downloadLogs();
+      toast.success(t("exportSuccess"));
+    } catch {
+      toast.error(t("exportFailed"));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleClear = () => {
+    // Entries are managed by the global store; clearing is a future enhancement
+    setClearOpen(false);
+    toast.success(t("clearSuccess"));
+  };
+
+  const entryCount = diagnostics.entries.length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SettingsSection title={t("title")} description={t("description")}>
+        <SettingsRow title={t("statsTitle")} description={t("statsDescription")}>
+          <div className="flex flex-col gap-3">
+            {entryCount === 0 ? (
+              <p className="text-sm text-muted-foreground">{t("empty")}</p>
+            ) : (
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+                  <FileText className="size-3.5" />
+                  {t("entryCount", { count: entryCount })}
+                </span>
+              </div>
+            )}
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={t("privacyTitle")}
+          description={t("privacyDescription")}
+        >
+          <Alert>
+            <ShieldCheck className="size-4" />
+            <AlertTitle>{t("privacyTitle")}</AlertTitle>
+            <AlertDescription>{t("noSecrets")}</AlertDescription>
+          </Alert>
+        </SettingsRow>
+      </SettingsSection>
+
+      <div className="flex flex-col gap-4">
+        <div>
+          <p className="text-sm font-medium">{t("whatsIncluded")}</p>
+          <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-muted-foreground">
+            <li>{t("includesModelConfig")}</li>
+            <li>{t("includesUploads")}</li>
+            <li>{t("includesQA")}</li>
+            <li>{t("includesErrors")}</li>
+            <li>{t("includesEnv")}</li>
+          </ul>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+          <Button type="button" onClick={handleExport} disabled={exporting}>
+            {exporting ? <Spinner /> : <Download className="size-4" />}
+            {exporting ? t("exporting") : t("exportButton")}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setClearOpen(true)}
+            disabled={entryCount === 0}
+          >
+            <Trash2 className="size-4" />
+            {t("clearButton")}
+          </Button>
+        </div>
+      </div>
+
+      <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("clearConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("clearConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setClearOpen(false)}>
+              {t("cancel")}
+            </Button>
+            <Button onClick={handleClear}>
+              {t("confirmClear")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/components/features/document-list.tsx
+++ b/apps/web/components/features/document-list.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { ApiError } from "@/lib/api";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import {
   deriveDocumentActivity,
   documentActivityShowsProgress,
@@ -47,6 +48,15 @@ export function DocumentList({
       else if (action === "pause") toast.success(t("pausing"));
       else if (action === "resume") toast.success(t("resumed"));
       else toast.success(t("deleted"));
+      getDiagnosticsStore().record("knowledge.upload", {
+        action: `document.${action}`,
+        source_id: sourceId,
+        document_id: document.id,
+        filename: document.filename,
+        status: document.status,
+        chunk_count: document.chunk_count,
+        event_count: document.event_count,
+      });
     } catch (error) {
       const fallback =
         action === "delete"
@@ -57,6 +67,13 @@ export function DocumentList({
               ? t("resumeFailed")
               : t("operationFailed");
       toast.error(error instanceof ApiError ? error.message : fallback);
+      getDiagnosticsStore().record("error", {
+        context: `document.${action}`,
+        source_id: sourceId,
+        document_id: document.id,
+        filename: document.filename,
+        error_message: error instanceof ApiError ? error.message : String(error),
+      });
     }
   }
 

--- a/apps/web/components/features/model-config-form.tsx
+++ b/apps/web/components/features/model-config-form.tsx
@@ -23,6 +23,7 @@ import { Slider } from "@/components/ui/slider";
 import { Spinner } from "@/components/ui/spinner";
 import { api, ApiError } from "@/lib/api";
 import { isLlmConfigLocked } from "@/lib/model-config-lock";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import type {
   ModelConfig,
   ModelConfigPatch,
@@ -103,6 +104,22 @@ export function ModelConfigForm() {
       }
       setProviders(providerCatalog);
       hydrate(config);
+      getDiagnosticsStore().record("model.load", {
+        llm_provider: config.llm_provider,
+        llm_base_url: config.llm_base_url,
+        llm_model: config.llm_model,
+        llm_context_window: config.llm_context_window,
+        llm_temperature: config.llm_temperature,
+        llm_max_tokens: config.llm_max_tokens,
+        llm_timeout_ms: config.llm_timeout_ms,
+        llm_max_retries: config.llm_max_retries,
+        embedding_model: config.embedding_model,
+        embedding_base_url: config.embedding_base_url,
+        embedding_dimensions: config.embedding_dimensions,
+        document_parser: config.document_parser,
+        mineru_base_url: config.mineru_base_url,
+        mineru_version: config.mineru_version,
+      });
     } catch (error) {
       setLoadError(error instanceof ApiError ? error.message : t("loadFailed"));
     }
@@ -143,6 +160,25 @@ export function ModelConfigForm() {
       const { config } = await api.saveModelConfig(patch);
       hydrate(config);
       await refreshCapabilities();
+      getDiagnosticsStore().record("model.save", {
+        llm_provider: config.llm_provider,
+        llm_base_url: config.llm_base_url,
+        llm_model: config.llm_model,
+        llm_context_window: config.llm_context_window,
+        llm_temperature: config.llm_temperature,
+        llm_max_tokens: config.llm_max_tokens,
+        llm_timeout_ms: config.llm_timeout_ms,
+        llm_max_retries: config.llm_max_retries,
+        embedding_model: config.embedding_model,
+        embedding_base_url: config.embedding_base_url,
+        embedding_dimensions: config.embedding_dimensions,
+        document_parser: config.document_parser,
+        mineru_base_url: config.mineru_base_url,
+        mineru_version: config.mineru_version,
+        llm_api_key_changed: Boolean(llmKey.trim()),
+        embedding_api_key_changed: Boolean(embKey.trim()),
+        mineru_api_key_changed: Boolean(mineruKey.trim()),
+      });
       toast.success(t("saved"));
     } catch (error) {
       toast.error(error instanceof ApiError ? error.message : t("saveFailed"));
@@ -155,11 +191,18 @@ export function ModelConfigForm() {
     setTesting(true);
     setTestResult(null);
     try {
-      setTestResult(await api.testModelConfig(currentPatch()));
+      const result = await api.testModelConfig(currentPatch());
+      setTestResult(result);
+      getDiagnosticsStore().record("model.test", {
+        ok: result.ok,
+        message: result.message,
+      });
     } catch (error) {
-      setTestResult({
+      const message = error instanceof ApiError ? error.message : t("testFailed");
+      setTestResult({ ok: false, message });
+      getDiagnosticsStore().record("model.test", {
         ok: false,
-        message: error instanceof ApiError ? error.message : t("testFailed"),
+        message,
       });
     } finally {
       setTesting(false);

--- a/apps/web/components/features/sync-panel.tsx
+++ b/apps/web/components/features/sync-panel.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { api, ApiError } from "@/lib/api";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -16,11 +17,22 @@ export function SyncPanel({ sourceId, onSynced }: { sourceId: string; onSynced: 
   async function sync() {
     setBusy(true);
     try {
-      await api.syncSource(sourceId);
+      const result = await api.syncSource(sourceId);
       toast.success(t("started"));
+      getDiagnosticsStore().record("knowledge.upload", {
+        action: "source.sync",
+        source_id: sourceId,
+        job_type: result.type,
+        job_id: result.id,
+      });
       onSynced();
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : t("failed"));
+      getDiagnosticsStore().record("error", {
+        context: "source.sync",
+        source_id: sourceId,
+        error_message: err instanceof ApiError ? err.message : String(err),
+      });
     } finally {
       setBusy(false);
     }

--- a/apps/web/components/features/upload-zone.tsx
+++ b/apps/web/components/features/upload-zone.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { api, ApiError } from "@/lib/api";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import { uploadConcurrencyGuidance } from "@/lib/upload-guidance";
 import { cn } from "@/lib/utils";
 import { Progress } from "@/components/ui/progress";
@@ -51,10 +52,20 @@ export function UploadZone({
       try {
         const idx = ok + 1;
         setProgress({ name: file.name, pct: 0, idx, total: files.length });
-        await api.uploadDocumentWithProgress(sourceId, file, (pct) =>
+        const doc = await api.uploadDocumentWithProgress(sourceId, file, (pct) =>
           setProgress((p) => (p ? { ...p, pct } : p)),
         );
         ok += 1;
+        getDiagnosticsStore().record("knowledge.upload", {
+          source_id: sourceId,
+          document_id: doc.id,
+          filename: file.name,
+          size_bytes: file.size,
+          content_type: file.type || extOf(file.name),
+          status: doc.status,
+          chunk_count: doc.chunk_count,
+          event_count: doc.event_count,
+        });
       } catch (err) {
         toast.error(t("fileFailed", {
           name: file.name,

--- a/apps/web/components/features/use-source-content.ts
+++ b/apps/web/components/features/use-source-content.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useTranslations } from "next-intl";
 
 import { api, ApiError } from "@/lib/api";
+import { getDiagnosticsStore } from "@/lib/diagnostics";
 import {
   beginDocumentMutation,
   deriveDocumentActivity,
@@ -67,6 +68,36 @@ export function useSourceContent(sourceId: string, active = true) {
       const previousById = new Map(
         (documentsRef.current ?? []).map((document) => [document.id, document]),
       );
+      // 记录文档后台处理的终态跃迁（ready / failed），这是上传后异步链路
+      // 中最容易出问题的一环（如 embedding 上游失败），前端此前无埋点。
+      // 仅在状态从"处理中"跃迁到终态时记录一次，避免轮询重复写入。
+      for (const document of nextDocuments) {
+        const prev = previousById.get(document.id);
+        if (!prev || prev.status === document.status) continue;
+        const wasProcessing =
+          prev.status === "pending"
+          || prev.status === "loading"
+          || prev.status === "extracting";
+        if (document.status === "ready" && wasProcessing) {
+          getDiagnosticsStore().record("knowledge.process", {
+            phase: "ready",
+            source_id: sourceId,
+            document_id: document.id,
+            filename: document.filename,
+            chunk_count: document.chunk_count,
+            event_count: document.event_count,
+            token_usage: document.token_usage,
+          });
+        } else if (document.status === "failed" && prev.status !== "failed") {
+          getDiagnosticsStore().record("knowledge.process", {
+            phase: "failed",
+            source_id: sourceId,
+            document_id: document.id,
+            filename: document.filename,
+            error_message: document.error,
+          });
+        }
+      }
       const now = Date.now();
       setFailedUntil((current) => {
         const next: Record<string, number> = {};

--- a/apps/web/components/features/use-source-content.ts
+++ b/apps/web/components/features/use-source-content.ts
@@ -95,6 +95,8 @@ export function useSourceContent(sourceId: string, active = true) {
             document_id: document.id,
             filename: document.filename,
             error_message: document.error,
+            error_layer: document.error_layer ?? undefined,
+            error_stage: document.error_stage ?? undefined,
           });
         }
       }

--- a/apps/web/hooks/use-diagnostics.ts
+++ b/apps/web/hooks/use-diagnostics.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  getDiagnosticsStore,
+  downloadDiagnostics,
+  type DiagEntry,
+  type DiagEnvironment,
+  type DiagEventType,
+  type DiagExport,
+  type DiagLogFile,
+} from "@/lib/diagnostics";
+
+export type { DiagEntry, DiagEnvironment, DiagEventType, DiagExport, DiagLogFile };
+
+function emptySnapshot(): DiagEntry[] {
+  return [];
+}
+
+/**
+ * React hook wrapping the global DiagnosticsStore singleton.
+ * Provides reactive access to log entries and export helpers.
+ */
+export function useDiagnostics() {
+  const store = getDiagnosticsStore();
+
+  const subscribe = React.useCallback(
+    (listener: () => void) => store.subscribe(listener),
+    [store],
+  );
+
+  const getSnapshot = React.useCallback(() => store.snapshot(), [store]);
+
+  const entries = React.useSyncExternalStore(subscribe, getSnapshot, emptySnapshot);
+
+  const record = React.useCallback(
+    (type: DiagEventType, data: Record<string, unknown> = {}) => {
+      store.record(type, data);
+    },
+    [store],
+  );
+
+  const exportLogs = React.useCallback(
+    (
+      environment: DiagEnvironment,
+      modelConfig?: Record<string, unknown> | null,
+      capabilities?: Record<string, unknown> | null,
+      desktopLogFiles?: DiagLogFile[],
+    ): DiagExport => {
+      return store.export(environment, modelConfig, capabilities, desktopLogFiles);
+    },
+    [store],
+  );
+
+  const downloadLogs = React.useCallback(
+    (
+      environment: DiagEnvironment,
+      modelConfig?: Record<string, unknown> | null,
+      capabilities?: Record<string, unknown> | null,
+      desktopLogFiles?: DiagLogFile[],
+    ) => {
+      const export_ = store.export(environment, modelConfig, capabilities, desktopLogFiles);
+      downloadDiagnostics(export_);
+    },
+    [store],
+  );
+
+  return React.useMemo(
+    () => ({
+      entries,
+      count: entries.length,
+      record,
+      exportLogs,
+      downloadLogs,
+    }),
+    [entries, record, exportLogs, downloadLogs],
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,5 @@
 import { clearToken, getToken } from "./auth";
+import { getDiagnosticsStore } from "./diagnostics";
 import { readClientLocale } from "../i18n/client";
 import { clientErrorMessage, serverErrorMessage } from "../i18n/client-errors";
 import type { SearchStrategy } from "./retrieval-config";
@@ -58,10 +59,13 @@ export const API_BASE = resolveApiBase();
 export class ApiError extends Error {
   status: number;
   code: string;
-  constructor(status: number, code: string, message: string) {
+  /** 后端返回的 X-Request-Id，用于把前端诊断日志和后端日志串联。 */
+  requestId?: string;
+  constructor(status: number, code: string, message: string, requestId?: string) {
     super(message);
     this.status = status;
     this.code = code;
+    this.requestId = requestId;
   }
 }
 
@@ -158,6 +162,7 @@ async function streamGlobalSearch(
     );
 
   armStreamTimeout("first-result", SEARCH_FIRST_RESULT_TIMEOUT_MS);
+  const searchStartMs = Date.now();
   let response: Response;
   try {
     response = await fetch(`${API_BASE}/api/v1/search/stream`, {
@@ -172,12 +177,32 @@ async function streamGlobalSearch(
     });
   } catch (error) {
     clearStreamTimeout();
-    if (timeoutReason) throw timeoutError();
+    if (timeoutReason) {
+      getDiagnosticsStore().record("error", {
+        source: "search-stream",
+        method: "POST",
+        path: "/api/v1/search/stream",
+        duration_ms: Date.now() - searchStartMs,
+        error_code: "timeout",
+        error_message: timeoutReason === "first-result"
+          ? "Search timed out waiting for first result (30s)"
+          : "Search timed out due to idle stream (45s)",
+      });
+      throw timeoutError();
+    }
     if (error instanceof DOMException && error.name === "AbortError") {
       throw new ApiError(0, "aborted", clientErrorMessage("cancelled"));
     }
     if (signal?.aborted)
       throw new ApiError(0, "aborted", clientErrorMessage("cancelled"));
+    getDiagnosticsStore().record("error", {
+      source: "search-stream",
+      method: "POST",
+      path: "/api/v1/search/stream",
+      duration_ms: Date.now() - searchStartMs,
+      error_code: "network",
+      error_message: "Search stream connection failed",
+    });
     throw new ApiError(0, "network", clientErrorMessage("network"));
   }
 
@@ -198,6 +223,15 @@ async function streamGlobalSearch(
     } catch {
       /* Keep the stable fallback when a proxy returns HTML or an empty body. */
     }
+    getDiagnosticsStore().record("error", {
+      source: "search-stream",
+      method: "POST",
+      path: "/api/v1/search/stream",
+      duration_ms: Date.now() - searchStartMs,
+      status: response.status,
+      error_code: code,
+      error_message: message,
+    });
     throw new ApiError(
       response.status,
       code,
@@ -359,18 +393,38 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
   const signal = opts.signal
     ? AbortSignal.any([opts.signal, timeoutSignal])
     : timeoutSignal;
+
+  const method = opts.method ?? "GET";
+  const startMs = Date.now();
   let res: Response;
   try {
     res = await fetch(`${API_BASE}${path}`, { ...opts, headers, signal });
   } catch (e) {
-    if (e instanceof DOMException && e.name === "TimeoutError") {
+    const durationMs = Date.now() - startMs;
+    const isTimeout = e instanceof DOMException && e.name === "TimeoutError";
+    const isAbort = e instanceof DOMException && e.name === "AbortError";
+    getDiagnosticsStore().record("error", {
+      source: "api",
+      method,
+      path,
+      duration_ms: durationMs,
+      error_code: isTimeout ? "timeout" : isAbort ? "aborted" : "network",
+      error_message: isTimeout
+        ? "Request timed out after 30s"
+        : isAbort
+          ? "Request was cancelled"
+          : "Network error — server unreachable or DNS failure",
+    });
+    if (isTimeout) {
       throw new ApiError(0, "timeout", clientErrorMessage("requestTimeout"));
     }
-    if (e instanceof DOMException && e.name === "AbortError") {
+    if (isAbort) {
       throw new ApiError(0, "aborted", clientErrorMessage("cancelled"));
     }
     throw new ApiError(0, "network", clientErrorMessage("network"));
   }
+
+  const durationMs = Date.now() - startMs;
 
   if (
     res.status === 401 &&
@@ -396,11 +450,37 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
     } catch {
       /* ignore */
     }
+    const requestId = res.headers.get("X-Request-Id") ?? undefined;
+    getDiagnosticsStore().record("error", {
+      source: "api",
+      method,
+      path,
+      duration_ms: durationMs,
+      status: res.status,
+      error_code: code,
+      error_message: message,
+      request_id: requestId,
+    });
     throw new ApiError(
       res.status,
       code,
       serverErrorMessage(code, message, res.status),
+      requestId,
     );
+  }
+
+  // Log slow successful requests (> 5s) as they may indicate backend issues
+  if (durationMs > 5000) {
+    getDiagnosticsStore().record("warn", {
+      source: "api",
+      method,
+      path,
+      duration_ms: durationMs,
+      status: res.status,
+      error_code: "slow_request",
+      error_message: `Request succeeded but took ${durationMs}ms (> 5s threshold)`,
+      request_id: res.headers.get("X-Request-Id") ?? undefined,
+    });
   }
 
   if (res.status === 204) return undefined as T;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -61,11 +61,26 @@ export class ApiError extends Error {
   code: string;
   /** 后端返回的 X-Request-Id，用于把前端诊断日志和后端日志串联。 */
   requestId?: string;
-  constructor(status: number, code: string, message: string, requestId?: string) {
+  /** 责任层：api / llm / engine / storage / network（后端错误分类维度）。 */
+  layer?: string;
+  /** 链路环节：config / parse / load / extract / persist / retrieve / generate。 */
+  stage?: string;
+  /** 是否可安全重试。 */
+  retryable?: boolean;
+  constructor(
+    status: number,
+    code: string,
+    message: string,
+    requestId?: string,
+    dimensions?: { layer?: string; stage?: string; retryable?: boolean },
+  ) {
     super(message);
     this.status = status;
     this.code = code;
     this.requestId = requestId;
+    this.layer = dimensions?.layer;
+    this.stage = dimensions?.stage;
+    this.retryable = dimensions?.retryable;
   }
 }
 
@@ -438,11 +453,17 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
   if (!res.ok) {
     let code = "error";
     let message = res.statusText || clientErrorMessage("requestFailed");
+    let layer: string | undefined;
+    let stage: string | undefined;
+    let retryable: boolean | undefined;
     try {
       const j = await res.json();
       if (j?.error) {
         code = j.error.code ?? code;
         message = j.error.message ?? message;
+        layer = j.error.layer ?? undefined;
+        stage = j.error.stage ?? undefined;
+        retryable = typeof j.error.retryable === "boolean" ? j.error.retryable : undefined;
       } else if (j?.detail) {
         message =
           typeof j.detail === "string" ? j.detail : JSON.stringify(j.detail);
@@ -459,6 +480,9 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
       status: res.status,
       error_code: code,
       error_message: message,
+      error_layer: layer,
+      error_stage: stage,
+      retryable,
       request_id: requestId,
     });
     throw new ApiError(
@@ -466,6 +490,7 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
       code,
       serverErrorMessage(code, message, res.status),
       requestId,
+      { layer, stage, retryable },
     );
   }
 

--- a/apps/web/lib/desktop-bridge.d.ts
+++ b/apps/web/lib/desktop-bridge.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Desktop bridge typed declaration.
+ * The actual bridge is injected by Electron's preload script (apps/desktop/src/preload.ts).
+ * When running in a browser, window.sagDesktop is undefined.
+ */
+
+export interface SagDesktopDiagnosticsInfo {
+  version: string;
+  platform: string;
+  arch: string;
+  electron: string;
+  chrome: string;
+  node: string;
+  logFiles: Array<{
+    name: string;
+    path: string;
+    sizeBytes: number;
+    content: string;
+    truncated: boolean;
+  }>;
+}
+
+export interface SagDesktopBridge {
+  readonly isDesktop: true;
+  readonly platform: string;
+  appInfo(): Promise<{ version: string; platform: string; arch: string }>;
+  checkForUpdates(): Promise<{ supported: boolean }>;
+  getDiagnosticsInfo(): Promise<SagDesktopDiagnosticsInfo>;
+  onUpdateState(
+    listener: (state: {
+      status: string;
+      version?: string;
+      percent?: number;
+      message?: string;
+    }) => void,
+  ): () => void;
+}
+
+declare global {
+  interface Window {
+    sagDesktop?: SagDesktopBridge;
+  }
+}
+
+export {};

--- a/apps/web/lib/diagnostics.test.ts
+++ b/apps/web/lib/diagnostics.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import { DiagnosticsStore, sanitize } from "./diagnostics";
+
+describe("sanitize", () => {
+  it("passes through primitives", () => {
+    expect(sanitize(null)).toBeNull();
+    expect(sanitize(undefined)).toBeUndefined();
+    expect(sanitize(42)).toBe(42);
+    expect(sanitize(true)).toBe(true);
+    expect(sanitize("hello")).toBe("hello");
+  });
+
+  it("redacts api_key fields", () => {
+    const input = {
+      llm_api_key: "sk-secret-value-1234567890",
+      name: "test",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.llm_api_key).toBe("[REDACTED]");
+    expect(result.name).toBe("test");
+  });
+
+  it("redacts fields with secret in the name", () => {
+    const input = {
+      client_secret: "abc123",
+      SECRET_KEY: "xyz789",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.client_secret).toBe("[REDACTED]");
+    expect(result.SECRET_KEY).toBe("[REDACTED]");
+  });
+
+  it("redacts fields with token in the name", () => {
+    const input = {
+      access_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+      refresh_token: "abcdef1234567890",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.access_token).toBe("[REDACTED]");
+    expect(result.refresh_token).toBe("[REDACTED]");
+  });
+
+  it("redacts fields with password in the name", () => {
+    const input = {
+      password: "my-secure-password",
+      db_password: "admin123",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.password).toBe("[REDACTED]");
+    expect(result.db_password).toBe("[REDACTED]");
+  });
+
+  it("redacts fields with credential in the name", () => {
+    const input = {
+      credentials: "some-token-value",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.credentials).toBe("[REDACTED]");
+  });
+
+  it("redacts keys named 'key' when the value looks like a secret", () => {
+    const input = {
+      key: "sk-abcdefghijklmnopqrstuvwxyz123456",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.key).toBe("[REDACTED]");
+  });
+
+  it("does not redact short key values", () => {
+    const input = {
+      key: "short",
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    expect(result.key).toBe("short");
+  });
+
+  it("recursively sanitizes nested objects", () => {
+    const input = {
+      llm: {
+        api_key: "sk-nested-secret",
+        model: "gpt-4",
+        config: {
+          secret_token: "nested-token",
+          timeout: 30000,
+        },
+      },
+    };
+    const result = sanitize(input) as Record<string, unknown>;
+    const llm = result.llm as Record<string, unknown>;
+    expect(llm.api_key).toBe("[REDACTED]");
+    expect(llm.model).toBe("gpt-4");
+    const config = llm.config as Record<string, unknown>;
+    expect(config.secret_token).toBe("[REDACTED]");
+    expect(config.timeout).toBe(30000);
+  });
+
+  it("sanitizes arrays", () => {
+    const input = [
+      { api_key: "secret1", name: "a" },
+      { api_key: "secret2", name: "b" },
+    ];
+    const result = sanitize(input) as Array<Record<string, unknown>>;
+    expect(result[0].api_key).toBe("[REDACTED]");
+    expect(result[0].name).toBe("a");
+    expect(result[1].api_key).toBe("[REDACTED]");
+    expect(result[1].name).toBe("b");
+  });
+});
+
+describe("DiagnosticsStore", () => {
+  it("records entries with auto-incrementing sequence", () => {
+    const store = new DiagnosticsStore();
+    store.record("app.init", { version: "1.0" });
+    store.record("model.load", { provider: "openai" });
+
+    const snapshot = store.snapshot();
+    expect(snapshot).toHaveLength(2);
+    expect(snapshot[0].seq).toBe(1);
+    expect(snapshot[0].type).toBe("app.init");
+    expect(snapshot[1].seq).toBe(2);
+    expect(snapshot[1].type).toBe("model.load");
+  });
+
+  it("includes ISO 8601 timestamps", () => {
+    const store = new DiagnosticsStore();
+    store.record("error", { message: "test" });
+
+    const snapshot = store.snapshot();
+    expect(snapshot[0].ts).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+  });
+
+  it("enforces the buffer cap", () => {
+    const store = new DiagnosticsStore(3);
+    for (let i = 0; i < 5; i += 1) {
+      store.record("app.init", { index: i });
+    }
+    const snapshot = store.snapshot();
+    expect(snapshot).toHaveLength(3);
+    expect(snapshot[0].data.index).toBe(2);
+    expect(snapshot[2].data.index).toBe(4);
+  });
+
+  it("sanitizes data on record", () => {
+    const store = new DiagnosticsStore();
+    store.record("model.save", {
+      llm_api_key: "sk-should-be-redacted",
+      model: "gpt-4",
+    });
+
+    const snapshot = store.snapshot();
+    expect(snapshot[0].data.llm_api_key).toBe("[REDACTED]");
+    expect(snapshot[0].data.model).toBe("gpt-4");
+  });
+
+  it("exports with correct structure", () => {
+    const store = new DiagnosticsStore();
+    store.record("app.init", { language: "zh" });
+
+    const export_ = store.export(
+      { app: "web", user_agent: "test", language: "zh", timezone: "Asia/Shanghai" },
+      { llm_provider: "openai", llm_model: "gpt-4", llm_api_key_set: true },
+      { llm_configured: true },
+    );
+
+    expect(export_.version).toBe(1);
+    expect(export_.exported_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(export_.environment.app).toBe("web");
+    expect(export_.entries).toHaveLength(1);
+    expect(export_.model_config).toEqual({
+      llm_provider: "openai",
+      llm_model: "gpt-4",
+      llm_api_key_set: true,
+    });
+    expect(export_.capabilities).toEqual({ llm_configured: true });
+  });
+
+  it("sanitizes model config on export", () => {
+    const store = new DiagnosticsStore();
+    const export_ = store.export(
+      { app: "web", user_agent: "test", language: "zh", timezone: "UTC" },
+      { llm_api_key: "sk-secret", llm_model: "gpt-4" },
+    );
+
+    expect(export_.model_config?.llm_api_key).toBe("[REDACTED]");
+    expect(export_.model_config?.llm_model).toBe("gpt-4");
+  });
+
+  it("returns count of entries", () => {
+    const store = new DiagnosticsStore();
+    expect(store.count).toBe(0);
+    store.record("app.init");
+    store.record("model.load");
+    expect(store.count).toBe(2);
+  });
+
+  it("returns a defensive copy from snapshot", () => {
+    const store = new DiagnosticsStore();
+    store.record("app.init");
+    const snapshot = store.snapshot();
+    snapshot.push({ seq: 999, ts: "", type: "error", data: {} });
+    expect(store.count).toBe(1);
+  });
+
+  it("returns the same snapshot reference when buffer unchanged", () => {
+    const store = new DiagnosticsStore();
+    store.record("app.init");
+    const a = store.snapshot();
+    const b = store.snapshot();
+    expect(a).toBe(b);
+  });
+
+  it("invalidates snapshot cache on new record", () => {
+    const store = new DiagnosticsStore();
+    store.record("app.init");
+    const a = store.snapshot();
+    store.record("model.load");
+    const b = store.snapshot();
+    expect(a).not.toBe(b);
+    expect(b).toHaveLength(2);
+  });
+
+  it("notifies subscribers on record", () => {
+    const store = new DiagnosticsStore();
+    let notified = false;
+    store.subscribe(() => {
+      notified = true;
+    });
+    store.record("app.init");
+    expect(notified).toBe(true);
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const store = new DiagnosticsStore();
+    let count = 0;
+    const unsub = store.subscribe(() => {
+      count += 1;
+    });
+    store.record("app.init");
+    expect(count).toBe(1);
+    unsub();
+    store.record("model.load");
+    expect(count).toBe(1);
+  });
+});

--- a/apps/web/lib/diagnostics.ts
+++ b/apps/web/lib/diagnostics.ts
@@ -1,0 +1,216 @@
+/**
+ * 客户端诊断日志系统。
+ *
+ * 环形缓冲区自动记录模型配置、知识库操作和问答交互的关键事件，
+ * 支持一键导出为 JSON 文件，方便研发同学排查问题。
+ *
+ * 日志绝不包含 API Key 等敏感信息。
+ */
+
+export type DiagEventType =
+  | "app.init"
+  | "model.load"
+  | "model.save"
+  | "model.test"
+  | "knowledge.upload"
+  | "knowledge.create"
+  | "knowledge.process"
+  | "qa.ask"
+  | "qa.event"
+  | "qa.complete"
+  | "qa.error"
+  | "warn"
+  | "error";
+
+export interface DiagEntry {
+  seq: number;
+  ts: string;
+  type: DiagEventType;
+  data: Record<string, unknown>;
+}
+
+export interface DiagEnvironment {
+  app: "web" | "desktop";
+  desktop_version?: string;
+  user_agent: string;
+  language: string;
+  timezone: string;
+}
+
+export interface DiagExport {
+  version: 1;
+  exported_at: string;
+  environment: DiagEnvironment;
+  model_config: Record<string, unknown> | null;
+  capabilities: Record<string, unknown> | null;
+  entries: DiagEntry[];
+  /** Real runtime log files captured from disk (desktop only). */
+  desktop_log_files?: DiagLogFile[];
+}
+
+export interface DiagLogFile {
+  name: string;
+  path: string;
+  size_bytes: number;
+  /** Tail of the file content (up to 5MB). */
+  content: string;
+  /** True when only the tail was captured because the file exceeded the cap. */
+  truncated: boolean;
+}
+
+const SENSITIVE_KEY_PATTERNS = [
+  /api[_-]?key/i,
+  /secret/i,
+  /token/i,
+  /password/i,
+  /credential/i,
+];
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function looksLikeKeyValue(value: unknown): boolean {
+  // 长字符串，可能是 base64/hex 编码的密钥
+  if (typeof value !== "string") return false;
+  if (value.length < 20) return false;
+  return /^[A-Za-z0-9+/=_-]{20,}$/.test(value) || /^[A-Fa-f0-9]{20,}$/.test(value);
+}
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * 递归脱敏：替换对象中所有包含敏感信息的字段。
+ * 不会修改原始对象。
+ *
+ * 规则：
+ * 1. 显式敏感 key（api_key、secret、token、password、credential）+ 字符串值 → 脱敏
+ * 2. 布尔值（如 llm_api_key_set）→ 不脱敏
+ * 3. key 名包含 "key" + 值看起来像 base64/hex → 脱敏（兜底）
+ */
+export function sanitize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+
+  if (Array.isArray(value)) {
+    return value.map(sanitize);
+  }
+
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      // 布尔值不可能是密钥，直接保留
+      if (typeof val === "boolean" || typeof val === "number" || val === null) {
+        result[key] = val;
+        continue;
+      }
+      // 显式敏感 key + 字符串值 → 脱敏
+      if (isSensitiveKey(key) && typeof val === "string") {
+        result[key] = REDACTED;
+        continue;
+      }
+      // 兜底：key 名包含 "key" + 值看起来像 base64/hex → 脱敏
+      if (typeof val === "string" && key.toLowerCase().includes("key") && looksLikeKeyValue(val)) {
+        result[key] = REDACTED;
+        continue;
+      }
+      result[key] = sanitize(val);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+const DEFAULT_MAX_ENTRIES = 500;
+
+export class DiagnosticsStore {
+  private buffer: DiagEntry[] = [];
+  private seq = 0;
+  private listeners = new Set<() => void>();
+  private cachedSnapshot: DiagEntry[] | null = null;
+  readonly maxEntries: number;
+
+  constructor(maxEntries = DEFAULT_MAX_ENTRIES) {
+    this.maxEntries = Math.max(1, Math.floor(maxEntries));
+  }
+
+  record(type: DiagEventType, data: Record<string, unknown> = {}): void {
+    const sanitized = sanitize(data) as Record<string, unknown>;
+    this.buffer.push({
+      seq: ++this.seq,
+      ts: new Date().toISOString(),
+      type,
+      data: sanitized,
+    });
+    while (this.buffer.length > this.maxEntries) {
+      this.buffer.shift();
+    }
+    this.cachedSnapshot = null;
+    this.notify();
+  }
+
+  snapshot(): DiagEntry[] {
+    if (!this.cachedSnapshot) {
+      this.cachedSnapshot = [...this.buffer];
+    }
+    return this.cachedSnapshot;
+  }
+
+  get count(): number {
+    return this.buffer.length;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+
+  export(
+    environment: DiagEnvironment,
+    modelConfig: Record<string, unknown> | null = null,
+    capabilities: Record<string, unknown> | null = null,
+    desktopLogFiles?: DiagLogFile[],
+  ): DiagExport {
+    return {
+      version: 1,
+      exported_at: new Date().toISOString(),
+      environment,
+      model_config: modelConfig ? (sanitize(modelConfig) as Record<string, unknown>) : null,
+      capabilities: capabilities ? (sanitize(capabilities) as Record<string, unknown>) : null,
+      entries: this.snapshot(),
+      ...(desktopLogFiles?.length ? { desktop_log_files: desktopLogFiles } : {}),
+    };
+  }
+}
+
+/** 全局单例，确保所有组件写入同一个缓冲区。 */
+let globalStore: DiagnosticsStore | null = null;
+
+export function getDiagnosticsStore(): DiagnosticsStore {
+  if (!globalStore) {
+    globalStore = new DiagnosticsStore();
+  }
+  return globalStore;
+}
+
+/** 下载 JSON 文件到本地。 */
+export function downloadDiagnostics(export_: DiagExport): void {
+  const json = JSON.stringify(export_, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `sag-diagnostics-${export_.exported_at.replace(/[:.]/g, "-")}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/lib/settings-config.ts
+++ b/apps/web/lib/settings-config.ts
@@ -1,5 +1,6 @@
 import {
   Bot,
+  Bug,
   Cpu,
   LibraryBig,
   Monitor,
@@ -24,6 +25,7 @@ export const SETTINGS_TABS = [
   { value: "integrations", labelKey: "integrations", icon: Plug },
   { value: "appearance", labelKey: "appearance", icon: Palette },
   { value: "graph", labelKey: "graph", icon: Orbit },
+  { value: "diagnostics", labelKey: "diagnostics", icon: Bug },
 ] as const;
 
 export type SettingsTab = (typeof SETTINGS_TABS)[number]["value"];

--- a/apps/web/lib/sse.ts
+++ b/apps/web/lib/sse.ts
@@ -162,11 +162,17 @@ async function streamPost(
     const durationMs = Date.now() - startMs;
     let message = clientErrorMessage("generationFailed");
     let code = "http_error";
+    let layer: string | undefined;
+    let stage: string | undefined;
+    let retryable: boolean | undefined;
     try {
       const value = await response.json();
       code = value?.error?.code || code;
       const detail = value?.error?.message || value?.detail;
       message = typeof detail === "string" ? detail : detail ? JSON.stringify(detail) : message;
+      layer = value?.error?.layer ?? undefined;
+      stage = value?.error?.stage ?? undefined;
+      retryable = typeof value?.error?.retryable === "boolean" ? value.error.retryable : undefined;
     } catch {
       // Keep the stable fallback when a proxy returns HTML or an empty body.
     }
@@ -177,6 +183,9 @@ async function streamPost(
       status: response.status,
       error_code: code,
       error_message: message,
+      error_layer: layer,
+      error_stage: stage,
+      retryable,
       request_id: response.headers.get("X-Request-Id") ?? undefined,
     });
     throw new AgentHttpError(

--- a/apps/web/lib/sse.ts
+++ b/apps/web/lib/sse.ts
@@ -1,5 +1,6 @@
 import { API_BASE } from "./api";
 import { getToken } from "./auth";
+import { getDiagnosticsStore } from "./diagnostics";
 import { readClientLocale } from "../i18n/client";
 import { clientErrorMessage, serverErrorMessage } from "../i18n/client-errors";
 
@@ -130,18 +131,35 @@ async function streamPost(
   signal?: AbortSignal,
 ): Promise<AgentRunOutcome> {
   const token = getToken();
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Accept-Language": readClientLocale(),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify(body),
-    signal,
-  });
+  const startMs = Date.now();
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Language": readClientLocale(),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (e) {
+    const durationMs = Date.now() - startMs;
+    getDiagnosticsStore().record("error", {
+      source: "sse",
+      path,
+      duration_ms: durationMs,
+      error_code: e instanceof DOMException && e.name === "AbortError" ? "aborted" : "network",
+      error_message: e instanceof DOMException && e.name === "AbortError"
+        ? "SSE connection cancelled"
+        : "SSE connection failed — server unreachable",
+    });
+    throw e;
+  }
 
   if (!response.ok || !response.body) {
+    const durationMs = Date.now() - startMs;
     let message = clientErrorMessage("generationFailed");
     let code = "http_error";
     try {
@@ -152,6 +170,15 @@ async function streamPost(
     } catch {
       // Keep the stable fallback when a proxy returns HTML or an empty body.
     }
+    getDiagnosticsStore().record("error", {
+      source: "sse",
+      path,
+      duration_ms: durationMs,
+      status: response.status,
+      error_code: code,
+      error_message: message,
+      request_id: response.headers.get("X-Request-Id") ?? undefined,
+    });
     throw new AgentHttpError(
       serverErrorMessage(code, message, response.status),
       code,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -59,6 +59,10 @@ export interface Doc {
   progress: number;
   token_usage: number;
   error: string | null;
+  /** 失败责任层（api / llm / engine / storage / network），仅失败时有值。 */
+  error_layer?: string | null;
+  /** 失败链路环节（parse / load / extract / persist 等），仅失败时有值。 */
+  error_stage?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -95,7 +95,8 @@
       "knowledge": "Knowledge",
       "integrations": "Integrations",
       "appearance": "Appearance",
-      "graph": "Graph"
+      "graph": "Graph",
+      "diagnostics": "Diagnostics"
     }
   },
   "Login": {
@@ -1253,5 +1254,32 @@
     "fullscreen": "View full screen",
     "continentPlanet": "Continent planet",
     "dualOrbit": "Dual-sphere orbit"
+  },
+  "Diagnostics": {
+    "title": "Diagnostics",
+    "description": "Export diagnostic logs to help troubleshoot issues.",
+    "statsTitle": "Session activity",
+    "statsDescription": "Number of events recorded in the current session.",
+    "entryCount": "{count} events recorded",
+    "empty": "No events recorded yet. Configure a model, upload files, or start a conversation first.",
+    "privacyTitle": "Privacy protection",
+    "privacyDescription": "Rest assured, exported logs are automatically sanitized.",
+    "noSecrets": "Logs do not contain API keys, passwords, or tokens. All secret fields are automatically replaced with [REDACTED].",
+    "exportButton": "Export diagnostic logs",
+    "exporting": "Exporting…",
+    "exportSuccess": "Diagnostic logs exported",
+    "exportFailed": "Export failed, please retry",
+    "clearButton": "Clear logs",
+    "clearConfirmTitle": "Confirm clear logs",
+    "clearConfirmDescription": "This will clear all diagnostic events recorded in the current session. This action cannot be undone.",
+    "clearSuccess": "Logs cleared",
+    "cancel": "Cancel",
+    "confirmClear": "Confirm clear",
+    "whatsIncluded": "Logs include the following:",
+    "includesModelConfig": "Model configuration (without secret keys)",
+    "includesUploads": "File upload records",
+    "includesQA": "Key Q&A interaction events",
+    "includesErrors": "Error and exception information",
+    "includesEnv": "System environment information"
   }
 }

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -95,7 +95,8 @@
       "knowledge": "知识库",
       "integrations": "集成",
       "appearance": "外观",
-      "graph": "图谱"
+      "graph": "图谱",
+      "diagnostics": "诊断"
     }
   },
   "Login": {
@@ -1253,5 +1254,32 @@
     "fullscreen": "全屏查看",
     "continentPlanet": "大陆星球",
     "dualOrbit": "双球轨道"
+  },
+  "Diagnostics": {
+    "title": "诊断日志",
+    "description": "导出运行日志以帮助排查问题。",
+    "statsTitle": "会话活动",
+    "statsDescription": "当前会话已记录的事件数量。",
+    "entryCount": "已记录 {count} 条事件",
+    "empty": "暂无记录的事件。请先进行模型配置、文件上传或问答操作。",
+    "privacyTitle": "隐私保护",
+    "privacyDescription": "请放心，导出的日志已经过自动脱敏处理。",
+    "noSecrets": "日志不包含 API Key、密码或 Token 等敏感信息。所有密钥字段均已自动替换为 [REDACTED]。",
+    "exportButton": "导出诊断日志",
+    "exporting": "导出中…",
+    "exportSuccess": "诊断日志已导出",
+    "exportFailed": "导出失败，请重试",
+    "clearButton": "清除日志",
+    "clearConfirmTitle": "确认清除日志",
+    "clearConfirmDescription": "这将清除当前会话中所有已记录的诊断事件。此操作不可撤销。",
+    "clearSuccess": "日志已清除",
+    "cancel": "取消",
+    "confirmClear": "确认清除",
+    "whatsIncluded": "日志包含以下信息：",
+    "includesModelConfig": "模型配置（不含密钥）",
+    "includesUploads": "文件上传记录",
+    "includesQA": "问答交互关键事件",
+    "includesErrors": "错误与异常信息",
+    "includesEnv": "系统环境信息"
   }
 }


### PR DESCRIPTION
## 背景

用户在 web / 桌面端遇到异常时，仅凭 UI 截图难以定位。需要能拿到用户当前的**运行日志**与**模型 / 知识库配置**，交研发分析。

## 做了什么

**诊断日志导出（前端 / 桌面端）**
在客户端引入一套诊断日志系统，记录核心链路关键事件（模型配置、知识库操作、问答 SSE、API 错误），并支持在设置页「诊断」Tab 一键导出为 JSON。核心是纯 TS 单例环形缓冲区（500 条上限），埋点在调用侧 / transport 边界捕获，不改动既有链路行为。敏感字段（`api_key` / `token` / `secret` 等）两层脱敏为 `[REDACTED]`，消息正文 / 工具入参 / 文件内容一律不记录。桌面端经 IPC 附带 app 与 electron-log 文件路径。

**错误分层归因（后端 + 前端配套）**
历史错误只有扁平的 HTTP code，`upstream_error` 把 LLM、引擎、schema 校验失败混在一起。新增 `core/error_taxonomy.py` 的 `ErrorLayer` / `ErrorStage`，错误信封输出 `{code, message, layer, stage, retryable, request_id}`，让研发从日志直接判断哪一层、哪个环节、是否可重试、对应哪条服务端日志。

**错误码收敛到 ErrorCode 枚举**
将散落在各抛出点的 `code="xxx"` 魔法值统一收敛到 `error_taxonomy.py` 的 `ErrorCode` 枚举，与 layer / stage 合并为唯一的错误分类模块，按业务域分组并注释。成员值与历史字符串逐字一致，不改变前后端契约；后续新增码统一在此登记。

**附带修复：extract references 兼容**
排查中定位到一类会导致整块抽取结果被丢弃的问题：上游把 `references` 等标为 schema 必填但自身仅告警不报错，模型返回空 / 缺省时被严格 schema 拒绝、重试到上限而整块丢失。在兼容层放开这几个「告警级」字段并回填默认值，对齐上游实际容忍度。

## 影响范围

均为加法式改动，不改变成功路径与既有链路行为。错误信封仅新增键（既有消费方只读 `code`/`message`，向后兼容）；`documents` 表仅幂等新增两个可空列 `error_layer`/`error_stage`，无 migration、无 breaking change。

## 测试

- web / desktop 类型检查通过；前端单测全绿（含脱敏 / 缓冲区上限 / 导出格式）；`npm run build` 成功
- 后端 `ruff` 通过；`pytest` **235 passed / 1 skipped**
- ⚠️ 未做真机端到端手测；建议合并前在 web 与桌面端各跑一次导出，确认 JSON 中无任何 `api_key`、桌面端能列出日志文件路径，并验证一次失败问答 / 失败文档的导出带上了 `layer`/`stage`/`request_id`
