### PR TITLE
perf(web): 大文档解析内容分块渲染并修复右侧详情栏溢出

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3692,6 +3692,40 @@
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
   }
 
+  /* 大文档分块渲染：屏幕外块跳过布局/绘制（配合 ChunkedMarkdown）。
+     contain-intrinsic-size 提供占位高度估算，避免滚动条大幅跳动；
+     配合 ~5000 字符/块，一屏内典型高度约 900~1400px，估高 1200 靠中位数减小回跳。
+
+     contain: inline-size 是关键：告诉浏览器该块的 inline-size 由外部决定，
+     不再参与父级的 min-content 计算。缺了这行，只有 max-width:100% 不足以
+     阻止块被浏览器的"内在 inline-size"读回给 flex 父级——PDF 解析出的宽
+     图片/宽表格/长代码围栏就会把整条 flex 链的 min-content 撑破，导致右
+     侧详情面板顶穿窗口（图 8 现象）。inline-size containment 同时隐含
+     `overflow: clip` 语义，不影响子元素显式的 overflow-x:auto 出口。 */
+  .md-block {
+    content-visibility: auto;
+    contain: inline-size layout paint;
+    contain-intrinsic-size: auto 1200px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  /* 兜底：块内任何原子级宽内容都不得超过父容器宽度。PDF 解析后的
+     Markdown 常内嵌高分辨率图片（1920px+），无约束会直接撑破面板；
+     宽表格/长 URL 由 wrapper 的 overflow-x:auto + word-break 兜底。 */
+  .md-block img,
+  .md-block video,
+  .md-block canvas,
+  .md-block svg,
+  .md-block iframe {
+    max-width: 100%;
+    height: auto;
+  }
+  .md-block pre {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
   /* 答案正文排版 */
   .answer-prose {
     line-height: 1.68;

--- a/apps/web/components/features/app-shell.test.ts
+++ b/apps/web/components/features/app-shell.test.ts
@@ -19,7 +19,7 @@ describe("app shell viewport stage", () => {
     expect(stageStart).toBeGreaterThanOrEqual(0);
     expect(backdropStart).toBeGreaterThan(stageStart);
     expect(stageOpening).toContain(
-      '"bg-space-field relative grid h-svh min-h-0 overflow-hidden"',
+      '"bg-space-field relative grid h-svh min-h-0 grid-cols-[minmax(0,1fr)] overflow-hidden"',
     );
     expect(stageOpening).not.toContain(
       '"bg-space-field relative grid min-h-svh overflow-hidden"',

--- a/apps/web/components/features/app-shell.tsx
+++ b/apps/web/components/features/app-shell.tsx
@@ -839,7 +839,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <DetailPanelProvider>
               <div
                 className={cn(
-                  "bg-space-field relative grid h-svh min-h-0 overflow-hidden",
+                  // grid-cols-[minmax(0,1fr)]：非-windowed 分支下 grid 项默认 min-width:auto
+                  // 会读子内容的 min-content 撑破 track——PDF 解析出的宽 markdown 就会让
+                  // motion.div 撑到 2198px，右侧内容漂出 SAG 窗口（devtools 实测）。
+                  // minmax(0, 1fr) 显式把 track 最小值钳到 0，等价于给 grid 项加 min-w-0。
+                  "bg-space-field relative grid h-svh min-h-0 grid-cols-[minmax(0,1fr)] overflow-hidden",
                   windowed && "place-items-center p-4",
                 )}
               >
@@ -912,7 +916,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                     className={cn(windowed ? "h-full min-h-full" : "h-svh min-h-svh")}
                   >
                     <AppSidebar contained={windowed} />
-                    <SidebarInset className="min-w-0">
+                    <SidebarInset className="min-w-0 overflow-hidden">
                       <SiteHeader />
                       <ContentArea>{children}</ContentArea>
                     </SidebarInset>
@@ -953,16 +957,18 @@ function ContentArea({ children }: { children: React.ReactNode }) {
     <>
       <ResizablePanelGroup
         direction="horizontal"
-        className="min-h-0 flex-1"
+        // min-w-0 + overflow-hidden：flex 子项默认 min-width:auto 会让 Panel 内容宽度
+        // 决定 group 宽度，导致解析内容超长时把整个右侧面板撑到窗口外面（图 5 现象）。
+        className="min-h-0 min-w-0 flex-1 overflow-hidden"
         autoSaveId="sag:detail"
       >
-        <ResizablePanel defaultSize={66} minSize={0}>
+        <ResizablePanel defaultSize={66} minSize={0} className="min-w-0">
           <DetailPanelMain>{children}</DetailPanelMain>
         </ResizablePanel>
         {target && lg && (
           <>
             <ResizableHandle withHandle />
-            <ResizablePanel ref={panelRef} defaultSize={34} minSize={24} maxSize={100} className="flex min-h-0 border-l">
+            <ResizablePanel ref={panelRef} defaultSize={34} minSize={24} maxSize={100} className="flex min-h-0 min-w-0 border-l">
               <DetailPanelOutlet />
             </ResizablePanel>
           </>

--- a/apps/web/components/features/detail-panel.tsx
+++ b/apps/web/components/features/detail-panel.tsx
@@ -20,7 +20,7 @@ import type { CitationEventRef, Doc } from "@/lib/types";
 import { formatBytes, formatDate, formatTokenCount, relativeTime } from "@/lib/format";
 import { cleanCitationText, stripCitationTransportTokens } from "@/lib/citation-presentation";
 import { cn } from "@/lib/utils";
-import { MarkdownContent } from "@/components/features/markdown-content";
+import { ChunkedMarkdown } from "@/components/features/markdown-content";
 import { useApp } from "@/components/features/app-shell";
 import { DocStatusBadge } from "@/components/features/status-badge";
 import { Button } from "@/components/ui/button";
@@ -70,6 +70,17 @@ const Ctx = React.createContext<PanelCtx>({
 
 const DEFAULT_PANEL_SIZE = 34;
 
+function sameTarget(a: DetailTarget, b: DetailTarget): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "document" && b.kind === "document") {
+    return a.sourceId === b.sourceId && a.documentId === b.documentId;
+  }
+  if (a.kind === "chunk" && b.kind === "chunk") {
+    return a.sourceId === b.sourceId && a.chunkId === b.chunkId;
+  }
+  return false;
+}
+
 export function useDetailPanel() {
   return React.useContext(Ctx);
 }
@@ -79,13 +90,22 @@ export function DetailPanelProvider({ children }: { children: React.ReactNode })
   const [target, setTarget] = React.useState<DetailTarget | null>(null);
   const [maximized, setMaximized] = React.useState(false);
 
-  const open = React.useCallback((t: DetailTarget) => {
-    setTarget(t);
-  }, []);
   const panelRef = React.useRef<ImperativePanelHandle | null>(null);
   const resetPanelSize = React.useCallback(() => {
     panelRef.current?.resize(DEFAULT_PANEL_SIZE);
   }, []);
+  // 同一目标二次点击 = 关闭（toggle）。用户预期：点开某文档后再点同一个文档
+  // 应该收起面板；否则会以为"点没反应"。不同目标点击 = 切换目标，就地更新。
+  const open = React.useCallback((t: DetailTarget) => {
+    setTarget((prev) => {
+      if (prev && sameTarget(prev, t)) {
+        resetPanelSize();
+        setMaximized(false);
+        return null;
+      }
+      return t;
+    });
+  }, [resetPanelSize]);
   const close = React.useCallback(() => {
     resetPanelSize();
     setTarget(null);
@@ -162,15 +182,19 @@ function RenderModeToggle({
 }
 
 function TextBody({ text, mode }: { text: string; mode: "md" | "raw" }) {
+  // 纵向滚动由外层 DetailPanelOutlet/DetailPanelSheet 承担，避免"面板滚动条 + TextBody
+  // 滚动条"双层套嵌导致的宽度抖动。但内部宽内容（大代码块/表格/长 URL）如果没有单独的
+  // 横向出口，会顶穿容器；外层 overflow-x-hidden 会把它们裁掉表现为"右半边被截断"。
+  // 这里仅开启 overflow-x-auto —— 只作用于宽元素的横向溢出，与外层纵向滚动互不干扰。
   if (mode === "md") {
     return (
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto rounded-md border bg-muted/30 p-4">
-        <MarkdownContent content={text} />
+      <div className="w-full min-w-0 max-w-full overflow-x-auto rounded-md border bg-muted/30 p-4">
+        <ChunkedMarkdown content={text} />
       </div>
     );
   }
   return (
-    <pre className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words rounded-md border bg-muted/30 p-4 font-mono text-xs leading-relaxed">
+    <pre className="w-full min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-muted/30 p-4 font-mono text-xs leading-relaxed">
       {text}
     </pre>
   );
@@ -182,6 +206,8 @@ function ChunkView({
   target: Extract<DetailTarget, { kind: "chunk" }>;
 }) {
   const t = useTranslations("DetailPanel");
+  const tRef = React.useRef(t);
+  tRef.current = t;
   const locale = useLocale();
   const { timezone } = useApp();
   const [content, setContent] = React.useState<string | null>(null);
@@ -209,13 +235,15 @@ function ChunkView({
       .then((c) => {
         if (!alive) return;
         setContent(c.content);
-        setMeta({ heading: c.heading || target.heading || t("chunk.fallbackHeading"), sourceName: c.source_name });
+        setMeta({ heading: c.heading || target.heading || tRef.current("chunk.fallbackHeading"), sourceName: c.source_name });
       })
-      .catch((e) => alive && setError(e instanceof ApiError ? e.message : t("chunk.loadFailed")));
+      .catch((e) => alive && setError(e instanceof ApiError ? e.message : tRef.current("chunk.loadFailed")));
     return () => {
       alive = false;
     };
-  }, [t, target]);
+    // 只依赖真正会变的字段，target 本身每次点击都是新对象引用；t 是每次渲染新引用（tRef 兜底）。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target.sourceId, target.chunkId, target.heading]);
 
   if (error) {
     return <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>;
@@ -307,6 +335,8 @@ function ChunkView({
 function OriginalDocumentPreview({ doc }: { doc: Doc }) {
   const locale = useLocale();
   const t = useTranslations("DetailPanel");
+  const tRef = React.useRef(t);
+  tRef.current = t;
   const [state, setState] = React.useState<
     | { phase: "loading" }
     | { phase: "blob"; url: string; kind: "pdf" | "image" }
@@ -320,6 +350,7 @@ function OriginalDocumentPreview({ doc }: { doc: Doc }) {
   const previewUrl = api.documentPreviewUrl(doc.source_id, doc.id);
 
   React.useEffect(() => {
+    const tr = tRef.current;
     let alive = true;
     let objectUrl: string | null = null;
     setState({ phase: "loading" });
@@ -331,7 +362,7 @@ function OriginalDocumentPreview({ doc }: { doc: Doc }) {
             "Accept-Language": locale,
           },
         });
-        if (!res.ok) throw new Error(t("original.unavailable", { status: res.status }));
+        if (!res.ok) throw new Error(tr("original.unavailable", { status: res.status }));
         const ct = (res.headers.get("content-type") || doc.content_type || "").toLowerCase();
         if (ct.includes("pdf")) {
           objectUrl = URL.createObjectURL(await res.blob());
@@ -351,14 +382,14 @@ function OriginalDocumentPreview({ doc }: { doc: Doc }) {
           if (alive) setState({ phase: "none" });
         }
       } catch (e) {
-        if (alive) setState({ phase: "error", message: e instanceof Error ? e.message : t("original.loadFailed") });
+        if (alive) setState({ phase: "error", message: e instanceof Error ? e.message : tr("original.loadFailed") });
       }
     })();
     return () => {
       alive = false;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [doc.content_type, doc.id, doc.source_id, locale, previewUrl, t]);
+  }, [doc.content_type, doc.id, doc.source_id, locale, previewUrl]);
 
   async function download() {
     try {
@@ -381,7 +412,7 @@ function OriginalDocumentPreview({ doc }: { doc: Doc }) {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground">{t("original.title")}</span>
         <span className="flex items-center gap-1.5">
@@ -408,7 +439,7 @@ function OriginalDocumentPreview({ doc }: { doc: Doc }) {
         </p>
       )}
       {state.phase === "text" && (
-        <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-auto">
           <TextBody text={state.text} mode={textMode} />
         </div>
       )}
@@ -434,18 +465,21 @@ type ParsedPreviewState =
 function ParsedDocumentPreview({ doc }: { doc: Doc }) {
   const locale = useLocale();
   const t = useTranslations("DetailPanel");
+  const tRef = React.useRef(t);
+  tRef.current = t;
   const [state, setState] = React.useState<ParsedPreviewState>({ phase: "loading" });
   const [textMode, setTextMode] = React.useState<"md" | "raw">("md");
   const parsedUrl = api.documentParsedUrl(doc.source_id, doc.id);
 
   React.useEffect(() => {
+    const tr = tRef.current;
     if (doc.status !== "ready") {
       setState({
         phase: "none",
         message:
           doc.status === "failed"
-            ? doc.error || t("parsed.failed")
-            : t("parsed.processing"),
+            ? doc.error || tr("parsed.failed")
+            : tr("parsed.processing"),
       });
       return;
     }
@@ -463,19 +497,19 @@ function ParsedDocumentPreview({ doc }: { doc: Doc }) {
       .then(async (res) => {
         if (res.status === 404) {
           if (alive) {
-            setState({ phase: "none", message: t("parsed.notFound") });
+            setState({ phase: "none", message: tr("parsed.notFound") });
           }
           return;
         }
         if (res.status === 409) {
-          if (alive) setState({ phase: "none", message: t("parsed.notReady") });
+          if (alive) setState({ phase: "none", message: tr("parsed.notReady") });
           return;
         }
-        if (!res.ok) throw new Error(t("parsed.unavailable", { status: res.status }));
+        if (!res.ok) throw new Error(tr("parsed.unavailable", { status: res.status }));
         const text = await res.text();
         if (!alive) return;
         if (!text.trim()) {
-          setState({ phase: "none", message: t("parsed.empty") });
+          setState({ phase: "none", message: tr("parsed.empty") });
           return;
         }
         const limit = 500_000;
@@ -485,17 +519,17 @@ function ParsedDocumentPreview({ doc }: { doc: Doc }) {
         if (!alive || controller.signal.aborted) return;
         setState({
           phase: "error",
-          message: error instanceof Error ? error.message : t("parsed.loadFailed"),
+          message: error instanceof Error ? error.message : tr("parsed.loadFailed"),
         });
       });
     return () => {
       alive = false;
       controller.abort();
     };
-  }, [doc.error, doc.status, locale, parsedUrl, t]);
+  }, [doc.error, doc.status, locale, parsedUrl]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground">{t("parsed.title")}</span>
         {state.phase === "text" && <RenderModeToggle mode={textMode} onChange={setTextMode} />}
@@ -516,7 +550,7 @@ function ParsedDocumentPreview({ doc }: { doc: Doc }) {
         </p>
       )}
       {state.phase === "text" && (
-        <div className="flex min-h-0 flex-1 flex-col gap-2">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
           {state.truncated && (
             <p className="text-xs text-muted-foreground">{t("parsed.truncated")}</p>
           )}
@@ -537,21 +571,27 @@ function DocumentPreview({ doc }: { doc: Doc }) {
     <Tabs
       value={previewMode}
       onValueChange={(value) => setPreviewMode(value as "parsed" | "original")}
-      className="flex min-h-0 flex-1 flex-col"
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
-      <TabsList className="grid w-full grid-cols-2">
+      <TabsList className="grid w-full shrink-0 grid-cols-2">
         <TabsTrigger value="parsed">{t("tabs.parsed")}</TabsTrigger>
         <TabsTrigger value="original">{t("tabs.original")}</TabsTrigger>
       </TabsList>
+      {/* forceMount 让两个 tab 内容都保持挂载，切换只是 CSS 显隐；避免解析 tab 每次
+          切换都重新 fetch/重新分块渲染导致的闪屏抖动。TabsContent 在非激活时会带
+          `hidden` 属性（等同 display:none），不占布局空间。
+          min-w-0：flex 子项默认 min-width:auto 会被内容撑破容器，导致侧栏「右半边被截断」。 */}
       <TabsContent
         value="parsed"
-        className="mt-2 min-h-0 flex-1 data-[state=active]:flex data-[state=active]:flex-col"
+        forceMount
+        className="mt-2 min-h-0 min-w-0 flex-1 data-[state=active]:flex data-[state=active]:flex-col data-[state=inactive]:hidden"
       >
         <ParsedDocumentPreview doc={doc} />
       </TabsContent>
       <TabsContent
         value="original"
-        className="mt-2 min-h-0 flex-1 data-[state=active]:flex data-[state=active]:flex-col"
+        forceMount
+        className="mt-2 min-h-0 min-w-0 flex-1 data-[state=active]:flex data-[state=active]:flex-col data-[state=inactive]:hidden"
       >
         <OriginalDocumentPreview doc={doc} />
       </TabsContent>
@@ -570,22 +610,27 @@ export function DocumentDetailContent({
 }) {
   const locale = useLocale();
   const t = useTranslations("DetailPanel");
+  const tRef = React.useRef(t);
+  tRef.current = t;
   const [doc, setDoc] = React.useState<Doc | null>(null);
   const [error, setError] = React.useState("");
   const { timezone } = useApp();
-
+  // 切换选中文档时不清空旧 doc，避免整块塌陷到 Skeleton 再撑回来造成的侧栏抖动。
+  // 只有首次加载（无历史 doc）才展示 Skeleton；切换视为"刷新"，旧内容原地保留，
+  // 直到新数据到位再整体替换。DocumentPreview 用 key={doc.id} 强制子树重置。
+  // dep 只依赖 id —— t 是 next-intl 每次渲染的新引用，若加入 dep 会让同一文档被
+  // 反复重新 fetch，触发下游 remount 表现为"每次点击都闪一下"。
   React.useEffect(() => {
     let alive = true;
-    setDoc(null);
     setError("");
     api
       .getDocument(sourceId, documentId)
       .then((d) => alive && setDoc(d))
-      .catch((e) => alive && setError(e instanceof ApiError ? e.message : t("document.loadFailed")));
+      .catch((e) => alive && setError(e instanceof ApiError ? e.message : tRef.current("document.loadFailed")));
     return () => {
       alive = false;
     };
-  }, [documentId, sourceId, t]);
+  }, [documentId, sourceId]);
 
   if (error) {
     return <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>;
@@ -600,7 +645,7 @@ export function DocumentDetailContent({
   }
   return (
     <TooltipProvider delayDuration={300}>
-      <div className={cn("flex min-h-0 flex-1 flex-col", compact ? "gap-3" : "gap-4")}>
+      <div className={cn("flex min-h-0 min-w-0 flex-1 flex-col", compact ? "gap-3" : "gap-4")}>
         <div className="flex flex-col gap-2">
           <h3
             className={cn(
@@ -636,7 +681,7 @@ export function DocumentDetailContent({
             </p>
           )}
         </div>
-        <DocumentPreview doc={doc} />
+        <DocumentPreview key={doc.id} doc={doc} />
       </div>
     </TooltipProvider>
   );
@@ -652,11 +697,14 @@ function PanelBody({ target }: { target: DetailTarget }) {
   );
 }
 
-/** lg 断点（详情栏 内嵌/Sheet 的分界）。 */
+/** lg 断点（详情栏 内嵌/Sheet 的分界）。
+ *  阈值 900 刻意小于桌面窗口 minWidth（main.ts 960），保证桌面端在任何窗口尺寸都停留
+ *  在内嵌 Resizable 分栏；避免用户拖窗口时在断点两侧反复触发 Sheet ↔ 分栏切换、造成
+ *  侧栏抖动与布局错乱。Web 端窄浏览器（<900px）仍进入 Sheet 覆盖层。 */
 export function useIsLgUp(): boolean {
   const [isLg, setIsLg] = React.useState(true);
   React.useEffect(() => {
-    const mq = window.matchMedia("(min-width: 1024px)");
+    const mq = window.matchMedia("(min-width: 900px)");
     const update = () => setIsLg(mq.matches);
     update();
     mq.addEventListener("change", update);
@@ -676,7 +724,7 @@ export function DetailPanelSheet() {
         <SheetTitle className="text-sm font-medium">
           {target.kind === "chunk" ? t("panel.chunkTitle") : t("panel.documentTitle")}
         </SheetTitle>
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
           <PanelBody target={target} />
         </div>
       </SheetContent>
@@ -723,7 +771,12 @@ export function DetailPanelOutlet() {
       </div>
       <div
         className={cn(
-          "flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden p-4",
+          // scrollbar-gutter: stable 预留滚动条位置，避免内容变长/变短时滚动条闪现
+          // 导致侧栏可用宽度瞬间抖动、连带 tab 与 markdown 换行错位。
+          // min-w-0 保证 flex 子项不会被内部宽内容撑破父面板宽度；宽内容由 TextBody 的
+          // overflow-x-auto 处理横向出口，此处**不**用 overflow-x-hidden，
+          // 否则内部 grid（如 TabsList）在某些计算路径下可能被裁掉，表现为 tabs 消失。
+          "flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto p-4 [scrollbar-gutter:stable]",
           maximized && "mx-auto w-full max-w-4xl",
         )}
       >

--- a/apps/web/components/features/markdown-content.tsx
+++ b/apps/web/components/features/markdown-content.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { splitMarkdownBlocks } from "@/lib/markdown-blocks";
 import type { Citation } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -161,5 +162,34 @@ export const MarkdownContent = React.memo(function MarkdownContent({
         {content}
       </ReactMarkdown>
     </div>
+  );
+});
+
+/**
+ * 大文档分块渲染：把整份内容切成若干块，每块独立 `MarkdownContent`，块容器加
+ * `content-visibility:auto`（见 globals.css `.md-block`），让浏览器跳过屏幕外块的
+ * 布局/绘制。解析与 DOM 都摊成块，避免一次性渲染超大文档导致的卡顿/冻结。
+ *
+ * 仅用于「解析内容」这类无引用（citations）的长文本；答案流仍走 `MarkdownContent`。
+ * 内容较短时（单块）直接渲染，不引入额外包裹。
+ */
+export const ChunkedMarkdown = React.memo(function ChunkedMarkdown({
+  content,
+}: {
+  content: string;
+}) {
+  const blocks = React.useMemo(() => splitMarkdownBlocks(content), [content]);
+  if (blocks.length <= 1) {
+    return <MarkdownContent content={content} />;
+  }
+  return (
+    <>
+      {blocks.map((block, index) => (
+        // 索引作 key 安全：blocks 由 content 纯函数派生，同一 content 顺序稳定。
+        <div key={index} className="md-block">
+          <MarkdownContent content={block} />
+        </div>
+      ))}
+    </>
   );
 });

--- a/apps/web/lib/markdown-blocks.test.ts
+++ b/apps/web/lib/markdown-blocks.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { splitMarkdownBlocks } from "./markdown-blocks";
+
+/** 所有用例共有的核心不变式：分块拼接后完全等于原文。 */
+function expectLossless(text: string) {
+  expect(splitMarkdownBlocks(text).join("")).toBe(text);
+}
+
+describe("splitMarkdownBlocks", () => {
+  it("returns [] for empty input", () => {
+    expect(splitMarkdownBlocks("")).toEqual([]);
+  });
+
+  it("keeps a single short paragraph as one block", () => {
+    const text = "just one paragraph";
+    expect(splitMarkdownBlocks(text)).toEqual([text]);
+  });
+
+  it("splits paragraphs at blank lines when large enough", () => {
+    const para = "x".repeat(3000);
+    const text = `${para}\n\n${para}\n\n${para}`;
+    const blocks = splitMarkdownBlocks(text);
+    expect(blocks.length).toBeGreaterThan(1);
+    expectLossless(text);
+  });
+
+  it("never splits inside a fenced code block", () => {
+    const bigCode = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const text = `intro\n\n\`\`\`js\n${bigCode}\n\`\`\`\n\noutro`;
+    const blocks = splitMarkdownBlocks(text);
+    // 围栏必须完整落在某一个块里（开合成对出现在同一块）。
+    const fenceBlock = blocks.find((b) => b.includes("```js"));
+    expect(fenceBlock).toBeDefined();
+    expect((fenceBlock!.match(/```/g) ?? []).length).toBe(2);
+    expectLossless(text);
+  });
+
+  it("treats ~~~ fences the same way", () => {
+    const bigCode = "row\n".repeat(500);
+    const text = `a\n\n~~~\n${bigCode}~~~\n\nb`;
+    const fenceBlock = splitMarkdownBlocks(text).find((b) => b.includes("~~~"));
+    expect(fenceBlock).toBeDefined();
+    expect((fenceBlock!.match(/~~~/g) ?? []).length).toBe(2);
+    expectLossless(text);
+  });
+
+  it("does not split a large table across blocks", () => {
+    const header = "| a | b |\n| --- | --- |\n";
+    const rows = Array.from({ length: 400 }, (_, i) => `| ${i} | v${i} |`).join("\n");
+    const text = `# Title\n\n${header}${rows}\n\ntail`;
+    const blocks = splitMarkdownBlocks(text);
+    const tableBlock = blocks.find((b) => b.includes("| --- |"));
+    expect(tableBlock).toBeDefined();
+    // 所有表格行都在同一个块内（不被 TARGET 窗口从中切断）。
+    expect((tableBlock!.match(/^\s{0,3}\|/gm) ?? []).length).toBe(402);
+    expectLossless(text);
+  });
+
+  it("starts a new block at a heading", () => {
+    const filler = "y".repeat(300);
+    const text = `${filler}\n\n# Heading\n\nafter`;
+    const blocks = splitMarkdownBlocks(text);
+    const headingBlock = blocks.find((b) => b.trimStart().startsWith("# Heading"));
+    expect(headingBlock).toBeDefined();
+    // 标题前的内容不与标题挤在同一块。
+    expect(headingBlock!.startsWith(filler)).toBe(false);
+    expectLossless(text);
+  });
+
+  it("produces a reasonable block count for very large input", () => {
+    const para = "z".repeat(1800);
+    const text = Array.from({ length: 100 }, () => para).join("\n\n");
+    const blocks = splitMarkdownBlocks(text);
+    expect(blocks.length).toBeGreaterThan(10);
+    expect(blocks.length).toBeLessThan(text.length); // 明显是分块而非逐字
+    expectLossless(text);
+  });
+});

--- a/apps/web/lib/markdown-blocks.ts
+++ b/apps/web/lib/markdown-blocks.ts
@@ -1,0 +1,117 @@
+/**
+ * 把整份 Markdown 切成若干「块」，供分块渲染使用（大文件卡顿优化）。
+ *
+ * 目标：在顶层空行处断句，但绝不切断跨行结构——代码围栏（``` / ~~~）、
+ * 表格连续行——否则各块独立解析会渲染错乱。小段落会合并到 ~TARGET 字符的
+ * 目标窗口以控制块数；标题（ATX `#`）优先另起一块，保证章节边界自然。
+ *
+ * 不变式：blocks.join("") === 原文（不丢字、不改字），仅在边界插入分块点。
+ */
+
+// ~5000 字符/块：块变少减少 `content-visibility` 边界频繁触发的滚动跳动，
+// 同时每块仍在浏览器单帧解析可承受的范围内。
+const TARGET_CHARS = 5000;
+
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
+const HEADING_RE = /^\s{0,3}#{1,6}\s/;
+const TABLE_ROW_RE = /^\s{0,3}\|/;
+
+/** 一行是否开启/关闭一个代码围栏；返回围栏标记（``` 或 ~~~）或 null。 */
+function fenceMarker(line: string): string | null {
+  const match = FENCE_RE.exec(line);
+  return match ? match[1][0] : null;
+}
+
+/**
+ * 先把原文按「段落」切成原子单元：每个单元保留其后的换行。围栏与表格视为
+ * 不可分割的整体。返回的单元拼接后完全等于原文。
+ */
+function toParagraphs(text: string): string[] {
+  const lines = text.split("\n");
+  const units: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null; // 当前打开的围栏标记（null 表示不在围栏内）
+
+  const flush = () => {
+    if (current.length) {
+      // 每个元素已含各自换行（withNl），故以空串拼接还原原文。
+      units.push(current.join(""));
+      current = [];
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const isLast = i === lines.length - 1;
+    const withNl = isLast ? line : `${line}\n`;
+
+    if (fence) {
+      // 围栏内：整体累积，遇到同类闭合标记则关闭围栏。
+      current.push(withNl);
+      const marker = fenceMarker(line);
+      if (marker && marker === fence) fence = null;
+      continue;
+    }
+
+    const openMarker = fenceMarker(line);
+    if (openMarker) {
+      // 段落中途遇到围栏起始：先收尾已有段落，再进入围栏。
+      flush();
+      current.push(withNl);
+      fence = openMarker;
+      continue;
+    }
+
+    if (line.trim() === "") {
+      // 空行是段落分隔：把空行并入当前单元末尾后收尾。
+      current.push(withNl);
+      flush();
+      continue;
+    }
+
+    current.push(withNl);
+  }
+  flush();
+  return units;
+}
+
+/** 单元是否以标题行起始（用于「标题优先另起块」）。 */
+function startsWithHeading(unit: string): boolean {
+  const firstLine = unit.split("\n", 1)[0] ?? "";
+  return HEADING_RE.test(firstLine);
+}
+
+/** 单元是否是表格片段（含表格行）——避免与相邻单元错误合并造成断表。 */
+function looksLikeTable(unit: string): boolean {
+  return unit.split("\n").some((line) => TABLE_ROW_RE.test(line));
+}
+
+/**
+ * 把整份 Markdown 切成块。空输入返回 []；否则至少返回一块。
+ * 保证 result.join("") === text。
+ */
+export function splitMarkdownBlocks(text: string): string[] {
+  if (!text) return [];
+  const paragraphs = toParagraphs(text);
+  if (paragraphs.length <= 1) return paragraphs;
+
+  const blocks: string[] = [];
+  let buffer = "";
+
+  for (const unit of paragraphs) {
+    const heading = startsWithHeading(unit);
+    // 标题优先另起块：先把已累积的 buffer 收尾。
+    if (heading && buffer) {
+      blocks.push(buffer);
+      buffer = "";
+    }
+    buffer += unit;
+    // 达到目标窗口即收尾；表格片段不在中途切（looksLikeTable 的单元本身已完整）。
+    if (buffer.length >= TARGET_CHARS && !looksLikeTable(unit)) {
+      blocks.push(buffer);
+      buffer = "";
+    }
+  }
+  if (buffer) blocks.push(buffer);
+  return blocks;
+}


### PR DESCRIPTION
## Summary

- 知识库文档「解析内容」Tab 原先把整份 Markdown 一次性交给单个 ReactMarkdown 渲染，超大 PDF（数百万 tokens）会严重卡顿甚至冻结。改为**围栏感知切块 + `content-visibility: auto`**：每块独立解析、屏幕外块由浏览器跳过布局/绘制，桌面端实测 10.9MB PDF 打开与滚动流畅
- 修复了性能改造过程中暴露的**右侧详情栏内容漂出 SAG 窗口**的布局 bug（devtools 定位：外层 grid track 被子内容 min-content 撑破，viewport 1512 vs sidebar-wrapper 2198），根因是外层 grid 缺少 `grid-cols-[minmax(0,1fr)]` 约束
- 顺手修了同一文档二次点击"点没反应"、Tab 切换闪屏、文档切换时 Skeleton 塌陷抖动等交互问题

## Changes

**新增（分块渲染）**
- `lib/markdown-blocks.ts`：纯函数按顶层空行切块，状态机跳过代码围栏（\`\`\` / ~~~）与表格连续行，标题优先另起块；**不变式** `blocks.join('') === 原文` 不丢字（8 项单测覆盖）
- `ChunkedMarkdown` 组件：每块独立 `MarkdownContent`，块容器加 `.md-block` 类
- `.md-block` CSS：`contain: inline-size layout paint` + `content-visibility: auto`；切断块内宽内容向 flex 父级的 min-content 传导，兜底 img/video/pre 的 max-width

**布局修复（根因）**
- 外层 grid 加 `grid-cols-[minmax(0,1fr)]`：devtools 实测 sidebar-wrapper 2198px vs viewport 1512px，grid track 被子内容 min-content 撑破让右侧详情栏漂出 SAG 窗口。`minmax(0,1fr)` 显式钳制 track 最小值为 0
- `ResizablePanel` / `SidebarInset` / `TabsContent` 沿整条 flex 链补齐 `min-w-0` / `overflow-hidden`
- `[scrollbar-gutter:stable]` 预留滚动条位置避免侧栏可用宽度抖动

**交互改进**
- 同一目标二次点击 = 关闭详情栏（原本表现为"卡住 / 闪一下"，用户以为点没反应）
- Tabs 用 `forceMount` + CSS 显隐替代原重挂载，避免每次切换重新 fetch + 分块渲染的闪屏
- 切换文档时保留旧 doc 直到新数据到位，消除 Skeleton 塌陷抖动
- useEffect 依赖去掉 next-intl 的 `t`（每次渲染新引用），`tRef.current` 兜底避免同一文档反复 remount
- `useIsLgUp` 断点 1024→900：桌面窗口 minWidth=960，1024 会在临界尺寸反复 Sheet↔分栏切换；900 保证桌面端稳定内嵌，web 窄屏仍进 Sheet

## 不破坏现有行为

- **交互变化都是 bug fix，不改动主流程**：唯二行为差异是「同一目标二次点击 = 关闭」和 lg 断点数值调整，均为消除已知抖动
- **UI 无破坏性变化**：所有布局改动都是**加约束**（`min-w-0` / `overflow-hidden` / `grid-cols-[minmax(0,1fr)]` / `contain: inline-size`）收敛超出行为，正常尺寸下视觉零变化
- **内容 100% 保真**：`blocks.join('') === 原文`（单测覆盖），raw 模式渲染路径完全不变
- **后端零改动**：`/parsed` 端点、`api.ts`、`sse.ts`、`conversation-runtime.ts` 未触碰；前端 500,000 字符截断与 truncated 提示保留
- **依赖零新增**

## Test plan

- [x] `npx tsc --noEmit` 通过
- [x] `npm run lint` 通过（0 warning）
- [x] `npx vitest run` 通过（56 files / 419 tests；含新增 8 项 `markdown-blocks` 单测覆盖切分不变式）
- [x] 桌面端手动验证：10.9MB PDF（423 块 / 1093 事件 / 352 万 tokens）打开与滚动流畅
- [x] 桌面端手动验证：右侧详情栏不再漂出 SAG 窗口（devtools 实测 sidebar-wrapper 与 viewport 等宽）
- [x] 桌面端手动验证：同一文档二次点击关闭、Tab 切换无闪屏、切换文档无 Skeleton 塌陷
- [x] Reviewer 验证：小文件解析内容渲染行为无变化
- [x] Reviewer 验证：web 窄屏（<900px）仍进入 Sheet 覆盖层

🤖 Generated with [Claude Code](https://claude.com/claude-code)