### PR TITLE
fix(web): 「清除日志」按钮真正清空诊断缓冲

### DIFF
--- a/apps/web/components/features/app-shell.tsx
+++ b/apps/web/components/features/app-shell.tsx
@@ -237,6 +237,7 @@ interface AppCtx {
   diagnostics: {
     entries: DiagEntry[];
     record: (type: DiagEntry["type"], data?: Record<string, unknown>) => void;
+    clear: () => void;
     exportLogs: () => DiagExport;
     downloadLogs: () => Promise<void>;
   };
@@ -270,6 +271,7 @@ const AppContext = React.createContext<AppCtx>({
   diagnostics: {
     entries: [],
     record: () => {},
+    clear: () => {},
     exportLogs: () => ({ version: 1 as const, exported_at: "", environment: { app: "web" as const, user_agent: "", language: "", timezone: "" }, model_config: null, capabilities: null, entries: [] }),
     downloadLogs: async () => {},
   },
@@ -805,6 +807,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         diagnostics: {
           entries: diag.entries,
           record: diag.record,
+          clear: diag.clear,
           exportLogs: diagnosticsExportLogs,
           downloadLogs: diagnosticsDownloadLogs,
         },

--- a/apps/web/components/features/diagnostics-settings.tsx
+++ b/apps/web/components/features/diagnostics-settings.tsx
@@ -38,7 +38,7 @@ export function DiagnosticsSettings() {
   };
 
   const handleClear = () => {
-    // Entries are managed by the global store; clearing is a future enhancement
+    diagnostics.clear();
     setClearOpen(false);
     toast.success(t("clearSuccess"));
   };

--- a/apps/web/hooks/use-diagnostics.ts
+++ b/apps/web/hooks/use-diagnostics.ts
@@ -41,6 +41,10 @@ export function useDiagnostics() {
     [store],
   );
 
+  const clear = React.useCallback(() => {
+    store.clear();
+  }, [store]);
+
   const exportLogs = React.useCallback(
     (
       environment: DiagEnvironment,
@@ -71,9 +75,10 @@ export function useDiagnostics() {
       entries,
       count: entries.length,
       record,
+      clear,
       exportLogs,
       downloadLogs,
     }),
-    [entries, record, exportLogs, downloadLogs],
+    [entries, record, clear, exportLogs, downloadLogs],
   );
 }

--- a/apps/web/lib/diagnostics.test.ts
+++ b/apps/web/lib/diagnostics.test.ts
@@ -244,4 +244,38 @@ describe("DiagnosticsStore", () => {
     store.record("model.load");
     expect(count).toBe(1);
   });
+
+  it("clear() empties the buffer, resets seq, and notifies subscribers", () => {
+    const store = new DiagnosticsStore();
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount += 1;
+    });
+    store.record("app.init");
+    store.record("model.load");
+    expect(store.count).toBe(2);
+    expect(notifyCount).toBe(2);
+
+    store.clear();
+
+    expect(store.count).toBe(0);
+    expect(store.snapshot()).toEqual([]);
+    expect(notifyCount).toBe(3);
+
+    store.record("qa.ask");
+    const snapshot = store.snapshot();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].seq).toBe(1);
+  });
+
+  it("clear() is a no-op on an empty store (no notify)", () => {
+    const store = new DiagnosticsStore();
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount += 1;
+    });
+    store.clear();
+    expect(notifyCount).toBe(0);
+    expect(store.count).toBe(0);
+  });
 });

--- a/apps/web/lib/diagnostics.ts
+++ b/apps/web/lib/diagnostics.ts
@@ -158,6 +158,14 @@ export class DiagnosticsStore {
     return this.cachedSnapshot;
   }
 
+  clear(): void {
+    if (this.buffer.length === 0 && this.seq === 0) return;
+    this.buffer = [];
+    this.seq = 0;
+    this.cachedSnapshot = null;
+    this.notify();
+  }
+
   get count(): number {
     return this.buffer.length;
   }


### PR DESCRIPTION
## 背景

设置 → 诊断中的「清除日志」按钮点了以后弹 toast 说"清除成功"，
但诊断缓冲区里的条目一条没少 —— `handleClear` 只做 `setClearOpen(false) + toast.success`，
没触碰 `DiagnosticsStore`。原代码里还留着注释 `// clearing is a future enhancement`
标记这是占位。

## 改动

补齐从 store 到 UI 的清空链路，5 个文件、+52 −2 行、纯功能补丁：

- `lib/diagnostics.ts` — 新增 `DiagnosticsStore.clear()`：重置 `buffer`、`seq=0`、
  失效 snapshot 缓存、通知订阅者；空 store 时短路不通知
- `hooks/use-diagnostics.ts` — 暴露 `clear` 回调
- `components/features/app-shell.tsx` — `AppContext.diagnostics` 类型 / default noop /
  provider value 各加一行 `clear`
- `components/features/diagnostics-settings.tsx` — `handleClear` 真调 `diagnostics.clear()`，
  删除 "future enhancement" 占位注释
- `lib/diagnostics.test.ts` — 补 2 个 vitest 用例：
  1. `clear()` 清空 buffer + 重置 seq + 通知订阅者 + 之后 record 从 seq=1 重来
  2. 空 store 上调 `clear()` 是 no-op，不触发通知

## 侵入性

零业务改动：
- UI（按钮、弹窗、toast 文案）完全不变，用户操作路径不变
- 不动 electron-log 的 `main.log`（`desktop_log_files` 导出照旧），
  按钮只清前端环形缓冲；崩溃/更新等底层日志证据保留
- 类型、默认 context、provider 三处的默认值都是 noop，SSR / 未挂载场景零副作用

## 验证

- `cd apps/web && npm run test:unit` — **56 files / 421 tests pass**（含新增 2 个）
- `cd apps/web && npm run typecheck` — 无错误
- 未跑手测；改动没触碰 UI 元素，行为路径未变

## 相关

- 「清除日志」按钮出自 PR #61（诊断日志导出能力），当时明确标注为 future enhancement 占位；本 PR 收尾