### PR TITLE
fix(ci): install verified fnpack 1.2.3 and unbreak native probe tests on bash 5

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -29,6 +29,19 @@ jobs:
         with: { node-version: 22, cache: npm, cache-dependency-path: apps/web/package-lock.json }
       - uses: astral-sh/setup-uv@v5
         with: { version: "0.6.14", enable-cache: true }
+      - name: Install verified fnpack 1.2.3
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d "$RUNNER_TEMP/fnpack-bin"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            https://static2.fnnas.com/fnpack/fnpack-1.2.3-linux-amd64 \
+            --output "$RUNNER_TEMP/fnpack-bin/fnpack"
+          echo '54b97fa7b70968c4d05c79840f5daeff508957d0bb2062fdb0376d00d9615c93  fnpack' \
+            | (cd "$RUNNER_TEMP/fnpack-bin" && sha256sum --check --strict -)
+          chmod 0755 "$RUNNER_TEMP/fnpack-bin/fnpack"
+          echo "$RUNNER_TEMP/fnpack-bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/fnpack-bin/fnpack" --help
       - name: Validate publish request
         shell: bash
         run: |
@@ -39,6 +52,10 @@ jobs:
           test -s docs/fnos/evidence/native-p0-x86.json
       - name: Test Native implementation
         shell: bash
+        env:
+          # fnpack was installed and checksum-verified above, so structural
+          # tests that shell out to the real binary may run on this runner.
+          SAG_FNPACK_TESTS: "1"
         run: |
           set -euo pipefail
           cd apps/api && uv run --extra dev ruff check sag_api sag_agent tests && uv run --extra dev pytest -q

--- a/scripts/tests/fnos-native-package.test.mjs
+++ b/scripts/tests/fnos-native-package.test.mjs
@@ -76,7 +76,7 @@ if [[ "$1" == "export" ]]; then
   done
   : > "$output"
 elif [[ "$1" == "pip" ]]; then
-  [[ " $* " == *" --python-platform aarch64-unknown-linux-gnu "* ]]
+  [[ " $* " == *" --python-platform aarch64-unknown-linux-gnu "* || " $* " == *" --python-platform x86_64-unknown-linux-gnu "* ]] || { echo 'pip must target a supported linux triple' >&2; exit 21; }
   [[ " $* " == *" --python-version 3.12 "* ]]
   [[ " $* " == *" --only-binary :all: "* ]] || { echo 'pip must install binary wheels only' >&2; exit 20; }
   if [[ -n "\${FAKE_NATIVE_VENDOR_PAYLOAD:-}" ]]; then
@@ -304,7 +304,9 @@ test("probe builder validates the rendered package after fnpack builds it", asyn
   await assert.rejects(access(rendered), { code: "ENOENT" });
 });
 
-test("probe builder copies the FPK emitted by real fnpack from the rendered package", async (t) => {
+test("probe builder copies the FPK emitted by real fnpack from the rendered package", {
+  skip: process.env.SAG_FNPACK_TESTS !== "1",
+}, async (t) => {
   const fixture = await fakeProbeBuild(t, { useRealFnpack: true });
   const result = buildProbe(["--platform", "x86", "--output", fixture.output], fixture.env);
 
@@ -317,7 +319,9 @@ test("probe builder copies the FPK emitted by real fnpack from the rendered pack
     assert.match(listed.stdout, new RegExp(`cmd/${callback}`));
 });
 
-test("probe builder embeds the probe and vendor payload inside app.tgz", async (t) => {
+test("probe builder embeds the probe and vendor payload inside app.tgz", {
+  skip: process.env.SAG_FNPACK_TESTS !== "1",
+}, async (t) => {
   const fixture = await fakeProbeBuild(t, { useRealFnpack: true, vendorPayload: "fixture-native.so" });
   const result = buildProbe(["--platform", "x86", "--output", fixture.output], fixture.env);
 

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -20,6 +20,14 @@ test("fnOS delivery is a single manual publish flow guarded by explicit confirma
   assert.match(workflow, /inputs\.publish_confirmation.*PUBLISH/);
   // The build environment must disable window scaling for fnOS.
   assert.match(workflow, /NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0/);
+  // fnpack is pinned to the official 1.2.3 binary and verified before use.
+  assert.match(workflow, /https:\/\/static2\.fnnas\.com\/fnpack\/fnpack-1\.2\.3-linux-amd64/);
+  assert.match(workflow, /curl --fail --location --proto '=https' --tlsv1\.2/);
+  assert.match(workflow, /54b97fa7b70968c4d05c79840f5daeff508957d0bb2062fdb0376d00d9615c93 {2}fnpack/);
+  assert.match(workflow, /sha256sum --check --strict/);
+  assert.match(workflow, /\$GITHUB_PATH/);
+  // Structural tests may shell out to the verified fnpack binary.
+  assert.match(workflow, /SAG_FNPACK_TESTS: "1"/);
   // Tests and packaging still run.
   assert.match(workflow, /uv run --extra dev pytest -q/);
   assert.match(workflow, /node scripts\/build-fnos-native-package\.mjs/);


### PR DESCRIPTION
## 背景

合并 #63 后首次触发 fnOS Delivery（run [31109657255](https://github.com/Zleap-AI/SAG/actions/runs/31109657255)）在 **Test Native implementation** 步失败，3 例全部来自 `scripts/tests/fnos-native-package.test.mjs`，发布步未执行、未产生任何 tag/release。

## 根因（两个）

1. **fake uv shim 硬编码 aarch64 三元组**：x86 用例（#109/#113/#114）触发 `uv pip install --python-platform x86_64-unknown-linux-gnu`，shim 的 `[[ ]]` 断言失败。Ubuntu bash 5 在 `set -eu` 下对裸 `[[ ]]` 失败直接退出且 stderr 为空 → `uv failed: `。**macOS bash 3.2 不退出**，所以本地与 PR CI 全绿、只有 delivery workflow 的 glob 跑到这个文件才暴露（PR CI 的 release-safety 用的是显式文件清单，不含该文件）。
2. **delivery workflow 从未安装 fnpack**：`build-fnos-native-package.mjs` 直接 `spawnSync("fnpack", ["build"])`，而 `ubuntu-24.04` runner 不自带 fnpack。即使测试修好，Build 步也会 ENOENT。两个 `useRealFnpack: true` 的 probe 测试同样依赖 PATH 上的 fnpack。

## 修复

- **`.github/workflows/fnos-release.yml`**：新增 `Install verified fnpack 1.2.3` 步（按 handoff 文档 P0-2：固定 URL + 完整 SHA-256 + `sha256sum --check --strict` + `curl --fail`，不用 `curl | sh`）；Test 步标记 `SAG_FNPACK_TESTS=1`（该 runner 现在是"已校验 fnpack"环境，结构性测试跑真二进制）。
- **`scripts/tests/fnos-native-package.test.mjs`**：uv shim 接受 `aarch64`/`x86_64` 两种三元组，失败时报清晰错误；两个 real-fnpack probe 测试改为 `SAG_FNPACK_TESTS=1` 门控（与 `fnos-package.test.mjs` 既有模式一致），无 fnpack 的环境 skip 而不是 ENOENT。
- **`scripts/tests/fnos-release-workflow.test.mjs`**：快照断言钉住 fnpack URL、版本、完整 checksum、`--strict` 校验、`SAG_FNPACK_TESTS` 标记。

## 验证

| 环境 | 命令 | 结果 |
|---|---|---|
| macOS（fnpack+docker） | `SAG_FNPACK_TESTS=1 node --test scripts/tests/fnos-*.test.mjs` | **220 pass / 0 fail / 1 skip**（221 全量，与 delivery 同一 glob） |
| bash 5.2 容器（无 fnpack） | `node --test scripts/tests/fnos-native-package.test.mjs` | 21 pass / **0 fail** / 2 skip（修复前 2 fail） |
| bash 5.2 容器（真实 fnpack 1.2.3 + =1） | 同上 + `fnos-package.test.mjs` | 仅 2 例 docker-dependent 失败（容器内无 docker；GitHub runner 预装 docker，run 31109657255 中同类测试已通过） |

合并后重跑 fnOS Delivery 即可发布 `fnos-v1.5.0-fnos.15`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)