### PR TITLE
fix(ci): bump workflow uv 0.6.14 → 0.10.8 to resolve greenlet wheels

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: npm, cache-dependency-path: apps/web/package-lock.json }
       - uses: astral-sh/setup-uv@v5
-        with: { version: "0.6.14", enable-cache: true }
+        # uv must be recent enough to resolve current PyPI wheel metadata;
+        # 0.6.14 rejects greenlet 3.5.3 manylinux wheels as "no usable wheels".
+        with: { version: "0.10.8", enable-cache: true }
       - name: Install verified fnpack 1.2.3
         shell: bash
         run: |

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -28,6 +28,10 @@ test("fnOS delivery is a single manual publish flow guarded by explicit confirma
   assert.match(workflow, /\$GITHUB_PATH/);
   // Structural tests may shell out to the verified fnpack binary.
   assert.match(workflow, /SAG_FNPACK_TESTS: "1"/);
+  // uv is pinned to a release that resolves current PyPI wheel metadata
+  // (0.6.14 rejected greenlet 3.5.3 manylinux wheels).
+  assert.match(workflow, /setup-uv@v5/);
+  assert.match(workflow, /version: "0\.10\.8"/);
   // Tests and packaging still run.
   assert.match(workflow, /uv run --extra dev pytest -q/);
   assert.match(workflow, /node scripts\/build-fnos-native-package\.mjs/);


### PR DESCRIPTION
## 背景

#66 合并后重跑 fnOS Delivery（run [31113421103](https://github.com/Zleap-AI/SAG/actions/runs/31113421103)）：fnpack 安装 ✅、测试 ✅，进入 **Build offline Native inputs** 后 `build-fnos-native-vendor.mjs` 失败：

```
× No solution found when resolving dependencies:
  ╰─▶ Because greenlet==3.5.3 has no usable wheels and you require
      greenlet==3.5.3, we can conclude that your requirements are unsatisfiable.
```

## 根因

workflow 用 `astral-sh/setup-uv@v5` 钉的是 **uv 0.6.14**（2025 年初）。greenlet 3.5.3 发布于 2026-06-26，PyPI 上有 `cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl`，但 0.6.x resolver 无法正确处理其 wheel 元数据，误判 "no usable wheels"。本地打 FPK 从没踩到是因为本机 uv 是 0.10.8。

## 复现（python:3.12-slim 干净容器，同 workflow 命令）

| uv 版本 | `uv pip install --python-platform x86_64-unknown-linux-gnu --only-binary :all:` |
|---|---|
| 0.6.14 | ❌ 与 runner 完全一致的 "no usable wheels" |
| 0.10.8 | ✅ 全部装好，greenlet 在位 |

## 修复

- `fnos-release.yml`：uv 钉 `0.6.14` → `0.10.8`，注释说明原因。
- `fnos-release-workflow.test.mjs`：快照断言钉住 `setup-uv@v5` + `version: "0.10.8"`，防止未来降级静默回归。

合并后再重跑 fnOS Delivery（version `1.5.0-fnos.15`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)