### PR TITLE
feat(messages): persist assistant failure/cancel bubbles with structured status/error

### DIFF
--- a/apps/api/sag_api/core/db.py
+++ b/apps/api/sag_api/core/db.py
@@ -70,6 +70,8 @@ _COLUMN_UPGRADES: dict[str, dict[str, str]] = {
         "attachments_json": "JSON",
         "steps_json": "JSON",
         "prompt_preview": "TEXT NOT NULL DEFAULT ''",
+        "status": "VARCHAR(16) NOT NULL DEFAULT 'ok'",
+        "error_json": "JSON",
     },
     "universe_dirty_sources": {"revision": "INTEGER NOT NULL DEFAULT 1"},
 }

--- a/apps/api/sag_api/db/models/agent.py
+++ b/apps/api/sag_api/db/models/agent.py
@@ -5,7 +5,7 @@ from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column
 
 from sag_api.db.base import Base, IDMixin, TimestampMixin
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 
 
 class Agent(IDMixin, TimestampMixin, Base):
@@ -58,3 +58,18 @@ class Message(IDMixin, TimestampMixin, Base):
     # excludes tool results and the generated answer so historical playback
     # can audit the same role-separated input that was shown live.
     prompt_preview: Mapped[str] = mapped_column(Text, default="")
+    # 助手回复的终态；对话历史需要保留失败/取消气泡才能与实时会话一致。
+    # values_callable 强制以枚举 value（小写 ok/failed/cancelled）而不是 name（大写）存储，
+    # 与 server_default 保持一致，避免 SAEnum 在读回时按名字查表报 LookupError。
+    status: Mapped[MessageStatus] = mapped_column(
+        SAEnum(
+            MessageStatus,
+            native_enum=False,
+            length=16,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        default=MessageStatus.OK,
+        server_default=MessageStatus.OK.value,
+    )
+    # 失败/取消时的错误结构 {code, message, retryable, details}；成功时为 None。
+    error: Mapped[dict | None] = mapped_column("error_json", JSON, default=None, nullable=True)

--- a/apps/api/sag_api/enums.py
+++ b/apps/api/sag_api/enums.py
@@ -69,6 +69,12 @@ class MessageRole(StrEnum):
     SYSTEM = "system"
 
 
+class MessageStatus(StrEnum):
+    OK = "ok"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
 class BindingTargetType(StrEnum):
     SOURCE = "source"
     MCP_SERVER = "mcp_server"  # Phase C：挂载 MCP server 作为工具来源

--- a/apps/api/sag_api/schemas/agent.py
+++ b/apps/api/sag_api/schemas/agent.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 
 
 class AgentCreate(BaseModel):
@@ -78,6 +78,10 @@ class MessageOut(BaseModel):
     attachments: list[dict[str, Any]] = Field(default_factory=list)
     steps: list[dict[str, Any]] = Field(default_factory=list)
     prompt_preview: str = ""
+    # 助手气泡的终态：ok / failed / cancelled。用户消息始终 ok。
+    status: MessageStatus = MessageStatus.OK
+    # 失败/取消时的结构化错误 {code, message, retryable, details}；ok 时为 None。
+    error: dict[str, Any] | None = None
     created_at: datetime
 
 

--- a/apps/api/sag_api/services/agent_domain.py
+++ b/apps/api/sag_api/services/agent_domain.py
@@ -20,7 +20,7 @@ from sag_api.core.config import settings
 from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ConflictError, NotFoundError, ValidationError
 from sag_api.db.models import Agent, AgentBinding, Message, Source, Thread
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 from sag_api.generation import build_agent_messages, build_prompt_preview
 from sag_api.generation.prompt import estimate_tokens
 from sag_api.services.source_service import search_source_candidates
@@ -563,7 +563,12 @@ async def persist_answer(
     citations: list[dict],
     steps: list[dict] | None = None,
     prompt_preview: str = "",
+    *,
+    status: MessageStatus = MessageStatus.OK,
+    error: dict | None = None,
 ) -> str:
+    """写入一条 assistant 消息。失败/取消时 answer 传部分已生成文本（可为 ""），
+    并附带结构化 error {code, message, retryable, details}。"""
     async with session_factory() as session:
         message = Message(
             thread_id=thread_id,
@@ -572,6 +577,8 @@ async def persist_answer(
             citations=citations,
             steps=steps or [],
             prompt_preview=prompt_preview,
+            status=status,
+            error=error,
         )
         session.add(message)
         await session.commit()

--- a/apps/api/sag_api/services/agent_service.py
+++ b/apps/api/sag_api/services/agent_service.py
@@ -27,6 +27,7 @@ from sag_agent import (
 from sag_agent import (
     ToolResult as RuntimeToolResult,
 )
+from sag_api.enums import MessageStatus
 from sag_api.generation import LLMClient, build_prompt_preview
 from sag_api.sag import EngineManager, SourceGraphInfo
 from sag_api.services.agent_domain import (
@@ -530,6 +531,7 @@ async def generate_stream(
     external_reference_urls: set[str] = set()
     trace: list[dict] = []
     tool_inputs: dict[str, dict[str, Any]] = {}
+    partial_answer: list[str] = []  # 失败/取消时保留已流出的正文
     handle = None
     terminal = False
 
@@ -706,6 +708,13 @@ async def generate_stream(
                         }
                     )
                 elif (
+                    event.type == EventType.MESSAGE_DELTA
+                    and payload.get("role") == "assistant"
+                ):
+                    delta = payload.get("delta")
+                    if isinstance(delta, str):
+                        partial_answer.append(delta)
+                elif (
                     event.type == EventType.MESSAGE_COMPLETED and payload.get("message", {}).get("role") == "assistant"
                 ):
                     duration = int(payload.get("duration_ms") or 0)
@@ -754,6 +763,36 @@ async def generate_stream(
                     }
                     terminal = True
                 elif event.type in (EventType.RUN_FAILED, EventType.RUN_CANCELLED):
+                    # 失败/取消也写入 assistant 消息，保留会话错误历史（含已流出的 partial answer）。
+                    partial_text = "".join(partial_answer)
+                    canonical_answer, internal_citations = _finalize_answer_citations(
+                        partial_text,
+                        citations,
+                    )
+                    error_payload = payload.get("error") if isinstance(payload, Mapping) else None
+                    status = (
+                        MessageStatus.CANCELLED
+                        if event.type == EventType.RUN_CANCELLED
+                        else MessageStatus.FAILED
+                    )
+                    message_id = None
+                    if thread_id is not None:
+                        message_id = await persist_answer(
+                            session_factory,
+                            thread_id,
+                            canonical_answer,
+                            internal_citations,
+                            steps=trace,
+                            prompt_preview=frozen_prompt_preview,
+                            status=status,
+                            error=dict(error_payload) if isinstance(error_payload, Mapping) else None,
+                        )
+                    output_payload = {
+                        **payload,
+                        "message_id": message_id,
+                        "partial_output": canonical_answer,
+                        "prompt_preview": frozen_prompt_preview,
+                    }
                     terminal = True
 
                 yield _stream_event(event, payload=output_payload)

--- a/apps/api/tests/test_ask_stream.py
+++ b/apps/api/tests/test_ask_stream.py
@@ -270,9 +270,24 @@ async def test_ask_stream_agentic_events_and_trace():
             assert "details" in tool_step
 
 
+class PartialThenFailLLM(AgenticLLM):
+    """流出几个 token 后再抛错 → 用于验证 partial answer 是否随失败气泡入库。"""
+
+    async def stream_turn(self, request, cancellation):
+        del request
+        cancellation.raise_if_cancelled()
+        yield ModelChunk(text_delta="部分")
+        yield ModelChunk(text_delta="回答")
+        raise UpstreamError("read timed out")
+        yield  # pragma: no cover
+
+
 @pytest.mark.asyncio
 async def test_ask_stream_provider_failure_has_terminal_error():
-    """Provider failures remain explicit instead of silently changing protocols."""
+    """Provider failure → assistant bubble persisted with status=failed & structured error.
+
+    此前空 assistant 会导致刷新丢失错误提示；改为持久化后前端能稳定回放失败气泡。
+    """
     from sag_api.main import app
 
     transport = httpx.ASGITransport(app=app)
@@ -288,10 +303,114 @@ async def test_ask_stream_provider_failure_has_terminal_error():
             body = ask.text
             assert "event: run.failed" in body
             assert "event: run.completed" not in body
+            # RUN_FAILED payload 中带 message_id，前端可对应替换本地临时气泡 id。
+            assert '"message_id":' in body
             msgs = (
                 await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
             ).json()["items"]
-            assert not any(m["role"] == "assistant" for m in msgs)
+            asst = [m for m in msgs if m["role"] == "assistant"]
+            assert len(asst) == 1
+            failed = asst[0]
+            assert failed["status"] == "failed"
+            assert failed["error"]
+            assert isinstance(failed["error"].get("message"), str)
+            # 无 token 流出 → 正文为空，前端展示纯错误说明。
+            assert failed["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_ask_stream_partial_answer_preserved_on_failure():
+    """Partial output before failure 应写入 failed 气泡的 content 中，保留可读上下文。"""
+    from sag_api.main import app
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        app.state.llm = PartialThenFailLLM()
+        async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=60) as c:
+            H, a, th = await _setup(c)
+            ask = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "分段失败"},
+            )
+            assert "event: run.failed" in ask.text
+            msgs = (
+                await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
+            ).json()["items"]
+            asst = [m for m in msgs if m["role"] == "assistant"][-1]
+            assert asst["status"] == "failed"
+            assert asst["content"] == "部分回答"
+            assert asst["error"] and asst["error"].get("code")
+
+
+@pytest.mark.asyncio
+async def test_ask_stream_failure_then_success_preserves_history_order():
+    """
+    复现 bug 的历史回放路径：连续两次 QA（首次失败、二次成功），
+    /messages 应按时间顺序返回：user₁, assistant(failed), user₂, assistant(ok)。
+    前端 mergeHistory 依赖这个稳定顺序来避免失败气泡被挤到最底部。
+    """
+    from sag_api.main import app
+
+    class OneShotBroken:
+        """第一次调用抛错，之后正常回答。"""
+
+        def __init__(self):
+            self.calls = 0
+
+        @property
+        def configured(self):
+            return True
+
+        async def stream_turn(self, request, cancellation):
+            del request
+            self.calls += 1
+            if self.calls == 1:
+                raise UpstreamError("read timed out")
+                yield  # pragma: no cover
+            cancellation.raise_if_cancelled()
+            for token in ["恢", "复"]:
+                yield ModelChunk(text_delta=token)
+            yield ModelChunk(finish_reason="stop")
+
+        async def complete(self, messages):
+            del messages
+            return ""
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        app.state.llm = OneShotBroken()
+        async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=60) as c:
+            H, a, th = await _setup(c)
+            first = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "第一个问题"},
+            )
+            assert "event: run.failed" in first.text
+            second = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "第二个问题"},
+            )
+            assert "event: run.completed" in second.text
+
+            msgs = (
+                await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
+            ).json()["items"]
+            # 关键点：两次问答都持久化 → 后续刷新能稳定回放（首次失败气泡不会消失）。
+            assert len(msgs) == 4
+            users = [m for m in msgs if m["role"] == "user"]
+            assistants = [m for m in msgs if m["role"] == "assistant"]
+            assert {m["content"] for m in users} == {"第一个问题", "第二个问题"}
+            assert len(assistants) == 2
+            statuses = sorted(m["status"] for m in assistants)
+            assert statuses == ["failed", "ok"]
+            ok_msg = next(m for m in assistants if m["status"] == "ok")
+            failed_msg = next(m for m in assistants if m["status"] == "failed")
+            assert ok_msg["content"] == "恢复"
+            assert failed_msg["content"] == ""
+            assert failed_msg["error"] and failed_msg["error"].get("message")
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_message_status_enum.py
+++ b/apps/api/tests/test_message_status_enum.py
@@ -1,0 +1,123 @@
+"""Regression: Message.status must roundtrip by enum *value* (lowercase).
+
+Prior bug: SAEnum(MessageStatus, native_enum=False) 默认按 enum **name** 存（OK/FAILED/CANCELLED），
+但 _ensure_columns 里的 ALTER TABLE 使用 server_default='ok'，两条写路径落库大小写不同。
+存量库里凡存在 server_default 回填出的小写行，SAEnum 读回时按 name 查表就会 LookupError，
+直接把 /messages 接口打成 500 → 前端整个 QA 主流程返回 "Failed to fetch"。
+
+Fixture 里每次都是全新的 tempdir SQLite，无存量行，所以这个分歧不会自然出现；
+下面的用例显式模拟"有一行是 server_default 路径写入的（小写）"这个存量场景。
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select, text
+
+from sag_api.core.db import SessionLocal, init_db
+from sag_api.db.models import Agent, Message, Thread
+from sag_api.enums import MessageRole, MessageStatus
+
+
+async def _make_thread(session) -> str:
+    agent = Agent(name="enum-fixture")
+    session.add(agent)
+    await session.flush()
+    thread = Thread(agent_id=agent.id)
+    session.add(thread)
+    await session.flush()
+    return thread.id
+
+
+@pytest.mark.asyncio
+async def test_status_column_stores_enum_value_not_name():
+    """ORM 写入的行落库应为小写 value（ok/failed/cancelled），与 server_default 一致。"""
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        for status in (MessageStatus.OK, MessageStatus.FAILED, MessageStatus.CANCELLED):
+            session.add(
+                Message(thread_id=thread_id, role=MessageRole.ASSISTANT, status=status)
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        # 绕过 ORM 直接看物理值，避免枚举适配器掩盖大小写分歧。
+        rows = (await session.execute(text("SELECT status FROM messages"))).all()
+    stored = {row[0] for row in rows}
+    assert stored == {"ok", "failed", "cancelled"}, stored
+
+
+@pytest.mark.asyncio
+async def test_orm_reads_row_with_lowercase_status_value():
+    """存量行的 status 若来自 server_default（小写），ORM 读回不应 LookupError。
+
+    _ensure_columns 在既有表上 ALTER TABLE ADD COLUMN status ... DEFAULT 'ok'，
+    该分支只在生产升级路径出现；下面先用 ORM 建一行合法记录，再 raw UPDATE 把 status
+    强行写成小写 value，隔离出 status 列自身的 name/value 分歧行为。
+    """
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        session.add(
+            Message(
+                id="seed-lowercase",
+                thread_id=thread_id,
+                role=MessageRole.ASSISTANT,
+                status=MessageStatus.OK,
+            )
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        # 显式覆盖成小写 value，模拟 server_default 回填 / raw SQL 迁移路径。
+        await session.execute(
+            text("UPDATE messages SET status='ok' WHERE id='seed-lowercase'")
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        row = (
+            await session.execute(select(Message).where(Message.id == "seed-lowercase"))
+        ).scalar_one()
+
+    assert row.status is MessageStatus.OK
+    assert row.status.value == "ok"
+
+
+@pytest.mark.asyncio
+async def test_orm_roundtrips_all_statuses_via_new_session():
+    """完整来回：ORM 写 → commit → 新 session ORM 读，三个终态都不炸。"""
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        for suffix, status in [
+            ("ok", MessageStatus.OK),
+            ("failed", MessageStatus.FAILED),
+            ("cancelled", MessageStatus.CANCELLED),
+        ]:
+            session.add(
+                Message(
+                    id=f"roundtrip-{suffix}",
+                    thread_id=thread_id,
+                    role=MessageRole.ASSISTANT,
+                    status=status,
+                )
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        loaded = (
+            (
+                await session.execute(
+                    select(Message).where(Message.id.like("roundtrip-%")).order_by(Message.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {m.id: m.status for m in loaded} == {
+        "roundtrip-cancelled": MessageStatus.CANCELLED,
+        "roundtrip-failed": MessageStatus.FAILED,
+        "roundtrip-ok": MessageStatus.OK,
+    }

--- a/apps/web/components/features/chat/conversation-transcript.tsx
+++ b/apps/web/components/features/chat/conversation-transcript.tsx
@@ -18,6 +18,8 @@ export interface ConversationTranscriptMessage {
   content: string;
   citations?: Citation[];
   steps?: AgentActivityStep[];
+  /** 失败/取消气泡的错误说明；有值时以警示样式显示在正文下方。 */
+  errorMessage?: string;
 }
 
 export interface ConversationLiveActivity {
@@ -116,7 +118,8 @@ export const ConversationMessageItem = React.memo(function ConversationMessageIt
 
   const steps = activity?.steps ?? message.steps ?? [];
   const waiting = streaming && !message.content;
-  const footer = !streaming && message.content
+  const showFooter = !streaming && (message.content || message.errorMessage);
+  const footer = showFooter
     ? renderAssistantFooter?.({ message, index, previousUser })
     : null;
 
@@ -145,6 +148,18 @@ export const ConversationMessageItem = React.memo(function ConversationMessageIt
             onCitationClick={handleCitationClick}
             streaming={streaming}
           />
+        ) : null}
+
+        {!streaming && message.errorMessage ? (
+          <div
+            role="alert"
+            className={cn(
+              "mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive",
+              message.content ? "" : "mt-0",
+            )}
+          >
+            {message.errorMessage}
+          </div>
         ) : null}
 
         {footer}

--- a/apps/web/lib/conversation-runtime.test.ts
+++ b/apps/web/lib/conversation-runtime.test.ts
@@ -38,6 +38,28 @@ function message(id: string, content: string, promptPreview?: string): Message {
   };
 }
 
+function persistedMessage(overrides: {
+  id: string;
+  role: Message["role"];
+  content: string;
+  created_at: string;
+  status?: Message["status"];
+  error?: Message["error"];
+}): Message {
+  return {
+    id: overrides.id,
+    thread_id: "thread-1",
+    role: overrides.role,
+    content: overrides.content,
+    citations: [],
+    attachments: [],
+    steps: [],
+    status: overrides.status,
+    error: overrides.error,
+    created_at: overrides.created_at,
+  };
+}
+
 function messageRange(from: number, to: number): Message[] {
   return Array.from({ length: to - from + 1 }, (_, index) => {
     const value = from + index;
@@ -146,6 +168,32 @@ class FakeTransport implements ConversationTransport {
   emit(value: AgentEvent): void {
     if (!this.onEvent) throw new Error("stream has not started");
     this.onEvent(value);
+  }
+}
+
+/**
+ * FakeTransport 只能处理单次 stream。这里扩展一个允许排队多轮 stream 的版本,
+ * 保留 FakeTransport 的其它行为(历史分页、审批、取消、删除)。
+ */
+class SequentialTransport extends FakeTransport {
+  readonly streamQueue: Array<Deferred<AgentRunOutcome>> = [];
+
+  enqueueStream(): Deferred<AgentRunOutcome> {
+    const next = deferred<AgentRunOutcome>();
+    this.streamQueue.push(next);
+    return next;
+  }
+
+  stream(input: Parameters<ConversationTransport["stream"]>[0]): Promise<AgentRunOutcome> {
+    this.streamCalls.push({
+      webEnabled: input.webEnabled,
+      knowledgeOnly: input.knowledgeOnly,
+    });
+    this.onEvent = input.onEvent;
+    this.streamSignal = input.signal;
+    const pending = this.streamQueue.shift();
+    if (!pending) throw new Error("stream called without enqueued outcome");
+    return pending.promise;
   }
 }
 
@@ -576,7 +624,8 @@ describe("conversation runtime", () => {
     transport.streamResult.resolve({ status: "cancelled", runId: "run-1" });
     await running;
     expect(conversations.getSessionSnapshot(sessionId).messages.at(-1)).toMatchObject({
-      content: "已停止",
+      content: "",
+      errorMessage: "已停止",
       delivery: "cancelled",
     });
     expect(conversations.getSessionSnapshot(sessionId).messages.at(-1)?.steps.at(-1)).toMatchObject({
@@ -650,6 +699,187 @@ describe("conversation runtime", () => {
 
     transport.streamResult.resolve({ status: "completed", runId: "run-1" });
     await running;
+  });
+
+  it("keeps a failed bubble in history order after a subsequent successful reply", async () => {
+    const transport = new SequentialTransport();
+    const conversations = runtime(transport);
+    const sessionId = conversations.forThread("thread-1", { activate: true });
+
+    // 第一轮 QA 失败:服务端已把失败气泡持久化,并回带 message_id。
+    // finishOperation 会调 ensureHistory({force:true}),这一页应带回 (user, failed-assistant)。
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "server-user-1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "server-failed-1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+      ]),
+    );
+    const round1 = transport.enqueueStream();
+    const running1 = conversations.send(sessionId, { query: "问题一" });
+    transport.emit(event("run.started", 0, { user_message_id: "server-user-1" }, 1, "run-1"));
+    transport.emit(event("message.delta", 1, { role: "assistant", delta: "半句" }, 1, "run-1"));
+    transport.emit(
+      event(
+        "run.failed",
+        2,
+        {
+          error: { code: "llm_timeout", message: "读超时", retryable: true },
+          message_id: "server-failed-1",
+        },
+        1,
+        "run-1",
+      ),
+    );
+    round1.resolve({
+      status: "failed",
+      runId: "run-1",
+      messageId: "server-failed-1",
+      error: { code: "llm_timeout", message: "读超时", retryable: true },
+    });
+    await running1.catch(() => {});
+
+    const after1 = conversations.getSessionSnapshot(sessionId);
+    expect(after1.messages.map((message) => message.id)).toEqual([
+      "server-user-1",
+      "server-failed-1",
+    ]);
+    expect(after1.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      content: "半句",
+      errorMessage: "读超时",
+    });
+
+    // 第二轮 QA 成功。ensureHistory 会带回全量 [u1, failed-a1, u2, ok-a2],
+    // mergeHistory 必须让失败气泡留在 u1 之后、u2 之前(bug 表现是失败气泡被顶到最底部)。
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "server-user-1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "server-failed-1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+        persistedMessage({
+          id: "server-user-2",
+          role: "user",
+          content: "问题二",
+          created_at: "2026-07-12T00:00:02Z",
+        }),
+        persistedMessage({
+          id: "server-ok-2",
+          role: "assistant",
+          content: "完整答案",
+          created_at: "2026-07-12T00:00:03Z",
+        }),
+      ]),
+    );
+    const round2 = transport.enqueueStream();
+    const running2 = conversations.send(sessionId, { query: "问题二" });
+    transport.emit(event("run.started", 0, { user_message_id: "server-user-2" }, 1, "run-2"));
+    transport.emit(event("message.delta", 1, { role: "assistant", delta: "完整答案" }, 1, "run-2"));
+    transport.emit(
+      event(
+        "run.completed",
+        2,
+        { output: "完整答案", citations: [], message_id: "server-ok-2" },
+        1,
+        "run-2",
+      ),
+    );
+    round2.resolve({ status: "completed", runId: "run-2", messageId: "server-ok-2" });
+    await running2;
+
+    const after2 = conversations.getSessionSnapshot(sessionId);
+    expect(after2.messages.map((message) => message.id)).toEqual([
+      "server-user-1",
+      "server-failed-1",
+      "server-user-2",
+      "server-ok-2",
+    ]);
+    expect(after2.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      errorMessage: "读超时",
+    });
+    expect(after2.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      delivery: "persisted",
+      content: "完整答案",
+    });
+    // 关键回归断言:失败气泡没有被追加到最底部。
+    expect(after2.messages.at(-1)?.id).not.toBe("server-failed-1");
+  });
+
+  it("restores persisted failed bubbles on a fresh runtime (page refresh)", async () => {
+    const transport = new FakeTransport();
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "u1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "a1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+        persistedMessage({
+          id: "u2",
+          role: "user",
+          content: "问题二",
+          created_at: "2026-07-12T00:00:02Z",
+        }),
+        persistedMessage({
+          id: "a2",
+          role: "assistant",
+          content: "完整答案",
+          created_at: "2026-07-12T00:00:03Z",
+        }),
+      ]),
+    );
+    const conversations = runtime(transport);
+    const sessionId = conversations.forThread("thread-1", { activate: true });
+    await conversations.ensureHistory(sessionId);
+
+    const snapshot = conversations.getSessionSnapshot(sessionId);
+    expect(snapshot.messages.map((message) => message.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(snapshot.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      content: "半句",
+      errorMessage: "读超时",
+    });
+    expect(snapshot.messages[3]).toMatchObject({
+      role: "assistant",
+      delivery: "persisted",
+      content: "完整答案",
+    });
   });
 
   it("aborts owned work only when the runtime is disposed", () => {

--- a/apps/web/lib/conversation-runtime.ts
+++ b/apps/web/lib/conversation-runtime.ts
@@ -84,6 +84,8 @@ export interface ConversationMessage {
   delivery: ConversationDelivery;
   promptPreview?: string;
   universeActivation?: UniverseActivation;
+  /** 失败/取消时的可读错误文本。UI 用它在气泡内展示错误说明。 */
+  errorMessage?: string;
 }
 
 export type ConversationHistoryStatus = "idle" | "loading" | "ready" | "error";
@@ -218,6 +220,13 @@ function isAbortError(reason: unknown): boolean {
 }
 
 function normalizeMessage(message: Message): ConversationMessage {
+  const status = message.status ?? "ok";
+  const delivery: ConversationDelivery =
+    status === "failed" ? "failed" : status === "cancelled" ? "cancelled" : "persisted";
+  const errorMessage =
+    status !== "ok" && message.error && typeof message.error.message === "string"
+      ? message.error.message
+      : undefined;
   return {
     id: message.id,
     threadId: message.thread_id,
@@ -231,7 +240,8 @@ function normalizeMessage(message: Message): ConversationMessage {
         ? message.prompt_preview
         : undefined,
     createdAt: message.created_at,
-    delivery: "persisted",
+    delivery,
+    errorMessage,
   };
 }
 
@@ -281,11 +291,11 @@ function mergeHistory(
   });
   const local = current.filter(
     (message) =>
-      (message.delivery === "pending" ||
-        message.delivery === "streaming" ||
-        message.delivery === "complete" ||
-        message.delivery === "failed" ||
-        message.delivery === "cancelled") &&
+      // 只有真正“进行中”的本地气泡才保留：complete/failed/cancelled 一旦被后端确认落库
+      // （outcome.messageId 存在），会经 finishOperation 改写 id 后走 uniquePersisted 分支合并；
+      // 未落库的终态气泡由 finishOperation 直接跳过 ensureHistory({force:true}) 兜底，
+      // 因此这里不需要留在 local。
+      (message.delivery === "pending" || message.delivery === "streaming") &&
       !ids.has(message.id),
   );
   return [...uniquePersisted, ...local];
@@ -1029,6 +1039,12 @@ export class ConversationRuntime {
           ? "cancelled"
           : "failed";
     const assistantMessageId = outcome.messageId || operation.assistantMessageId;
+    const errorText =
+      outcome.status === "cancelled"
+        ? clientErrorMessage("stopped")
+        : outcome.status === "failed"
+          ? failure
+          : undefined;
     this.activeOperation = null;
     this.updateSession(
       operation.sessionId,
@@ -1040,14 +1056,11 @@ export class ConversationRuntime {
           updateMessage(current.messages, operation.assistantMessageId, (message) => ({
             ...message,
             id: assistantMessageId,
-            content:
-              message.content ||
-              (outcome.status === "cancelled"
-                ? clientErrorMessage("stopped")
-                : outcome.status === "failed"
-                  ? `⚠︎ ${failure}`
-                  : ""),
+            // 失败/取消时保留已流出的 partial content;为空时也不再塞错误文本，
+            // 错误说明改由 errorMessage 承载,与后端持久化的 (content, error) 分离一致。
+            content: message.content,
             delivery,
+            errorMessage: errorText,
             steps: persistentSteps(steps),
           })).map((message) =>
             message.delivery === "pending"
@@ -1062,7 +1075,11 @@ export class ConversationRuntime {
     this.notifyActivity();
 
     const threadId = this.getSessionSnapshot(operation.sessionId).threadId;
-    if (outcome.status === "completed" && threadId) {
+    // 只有服务端确认落库（拿到 outcome.messageId）时才重拉历史，避免把仅存在于前端的
+    // 终态气泡（例如网络中断、老版本服务端）在 mergeHistory 中被过滤掉。
+    // 修复目标：失败气泡持久化后重跑 mergeHistory，把 (user, failed-assistant) 顺序稳住，
+    // 避免第二次成功回答落回底部时把失败气泡顶到最下。
+    if (threadId && outcome.messageId) {
       await this.ensureHistory(operation.sessionId, { force: true });
     }
   }

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -295,6 +295,14 @@ export interface MessageAttachment {
   media_type?: string;
 }
 
+export type MessageStatus = "ok" | "failed" | "cancelled";
+
+export interface MessageError {
+  message?: string;
+  code?: string;
+  [key: string]: unknown;
+}
+
 export interface Message {
   id: string;
   thread_id: string;
@@ -304,6 +312,8 @@ export interface Message {
   attachments?: MessageAttachment[];
   steps?: MessageStep[];
   prompt_preview?: string;
+  status?: MessageStatus;
+  error?: MessageError | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## 一句话总结
为助手消息新增 `status` / `error` 两列，把「失败 / 取消」时已生成的 partial answer 与结构化错误一起落库；前端据此渲染独立的失败气泡并支持刷新恢复。

## 变更内容
**Backend**
- `enums.MessageStatus`：新增 `StrEnum`（`ok`/`failed`/`cancelled`）
- `models.Message`：新增 `status`/`error` 列；`SAEnum` 使用 `values_callable`，让物理存储与 `server_default='ok'` 一致按 value（小写）落库
- `core.db._ensure_columns`：为存量库幂等补齐 `status` / `error_json` 列
- `schemas.MessageOut`：透出 `status` / `error`
- `services.agent_domain.persist_answer`：接收 `status` / `error` 参数
- `services.agent_service`：在 `MESSAGE_DELTA` 阶段累积 `partial_answer`；`RUN_FAILED` / `RUN_CANCELLED` 阶段把 partial + status + error 一并落库，payload 携带 `message_id`

**Frontend**
- `conversation-runtime.finishOperation`：`content` 只放 partial，错误单独进 `errorMessage`；`ensureHistory({force:true})` 依赖 `outcome.messageId`
- `conversation-runtime.normalizeMessage`：从持久化的 `message.error.message` 反解非 ok 状态的 `errorMessage`
- `conversation-transcript`：把 `errorMessage` 渲染为 `role=alert` 的独立 destructive 样式块
- `types.Message`：补 `status` / `error` 可选字段与 `MessageStatus` 类型别名

## 影响范围
- Backend：仅 `messages` 持久化路径。成功路径无变化；失败 / 取消现在会写入一条 assistant 消息（`status != ok`，含 `error` JSON）
- Frontend：仅失败气泡的渲染与恢复行为变化，成功流不受影响
- DB 迁移：`_ensure_columns` 幂等补列，无破坏性

## 测试
- 新增 `apps/api/tests/test_message_status_enum.py`（3 个用例：物理小写落库、混合大小写行 ORM 读回、三态往返 —— 去掉 `values_callable` 后 2 个会失败，锁定按 value 存储的契约）
- `apps/api/tests/test_ask_stream.py` 增加「失败-带-partial」「失败后成功历史顺序保持」两例
- `apps/web/lib/conversation-runtime.test.ts` 增加「失败-后-成功历史顺序」与「页面刷新持久化失败气泡回放」两例
- 本地全套：backend `uv run pytest apps/api` 221 passed / 1 skipped；frontend `pnpm --filter web test` 56 files / 423 passed