### PR TITLE
fix(fnos): Docker→Native 覆盖安装自愈 + 启动错误诊断 + main 分支 bugfix 同步

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -4,9 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: FPK version, e.g. 1.5.0-fnos.15. Determines the artifact filename and the release tag (fnos-v<version>).
-        required: true
+        description: >
+          FPK version, e.g. 1.5.3-fnos.1.
+          Leave empty to auto-derive from the latest main release tag + next fnOS build number.
+        required: false
         type: string
+        default: ""
       publish_confirmation:
         description: Type PUBLISH exactly to confirm a real Release will be created.
         required: true
@@ -16,21 +19,95 @@ permissions:
   contents: read
 
 jobs:
-  native-x86:
-    name: Build & publish Native x86 FPK
+  resolve-version:
+    name: Resolve version
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      base_version: ${{ steps.resolve.outputs.base_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Resolve base version from git tags
+        id: find-base
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The latest semver tag on the repo (excluding fnOS tags) is the
+          # base version.  Tags must match v<major>.<minor>.<patch>.
+          base="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+            | grep -Ev -- '-fnos\.' \
+            | head -1 \
+            | sed 's/^v//')"
+          test -n "$base" || { echo "No base version tag found"; exit 1; }
+          echo "Base version: $base"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve fpNOS version
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.find-base.outputs.base }}"
+          MANUAL="${{ inputs.version }}"
+
+          if [ -n "$MANUAL" ]; then
+            VERSION="$MANUAL"
+            echo "Using manual version: $VERSION"
+          else
+            # Find the highest existing fnOS build number for this base.
+            N=1
+            existing="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
+            if [ -n "$existing" ]; then
+              highest="$(echo "$existing" | grep -E "^fnos-v${BASE//./\\.}-fnos\\.[0-9]+\$" \
+                | sed 's/^fnos-v.*-fnos\.//' \
+                | sort -n \
+                | tail -1 || true)"
+              if [ -n "$highest" ] && [ "$highest" -ge 1 ] 2>/dev/null; then
+                N=$((highest + 1))
+              fi
+            fi
+            VERSION="${BASE}-fnos.${N}"
+            echo "Auto-derived version: $VERSION (highest existing fnos build for $BASE: ${highest:-none})"
+          fi
+
+          # Validate format: <semver>-fnos.<positive int>
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-fnos\.[1-9][0-9]*$'; then
+            echo "VERSION '$VERSION' does not match <major>.<minor>.<patch>-fnos.<N>"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "base_version=$BASE" >> "$GITHUB_OUTPUT"
+
+  native-x86:
+    name: Build & publish Native x86 FPK
+    runs-on: ubuntu-24.04
+    needs: resolve-version
+    permissions:
+      contents: write
+    env:
+      SAG_VERSION: ${{ needs.resolve-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: npm, cache-dependency-path: apps/web/package-lock.json }
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
       - uses: astral-sh/setup-uv@v5
-        # uv must be recent enough to resolve current PyPI wheel metadata;
-        # 0.6.14 rejects greenlet 3.5.3 manylinux wheels as "no usable wheels".
-        with: { version: "0.10.8", enable-cache: true }
+        with:
+          version: "0.10.8"
+          enable-cache: true
+
       - name: Install verified fnpack 1.2.3
         shell: bash
         run: |
@@ -44,41 +121,67 @@ jobs:
           chmod 0755 "$RUNNER_TEMP/fnpack-bin/fnpack"
           echo "$RUNNER_TEMP/fnpack-bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/fnpack-bin/fnpack" --help
+
       - name: Validate publish request
         shell: bash
         run: |
           set -euo pipefail
-          test "${{ github.ref }}" = "refs/heads/fnos/develop"
-          test "${{ inputs.publish_confirmation }}" = "PUBLISH"
-          test -n "${{ inputs.version }}"
-          test -s docs/fnos/evidence/native-p0-x86.json
+          test "${{ github.ref }}" = "refs/heads/fnos/develop" \
+            || { echo "Publish must be triggered from fnos/develop"; exit 1; }
+          test "${{ inputs.publish_confirmation }}" = "PUBLISH" \
+            || { echo "Confirmation must be exactly PUBLISH"; exit 1; }
+          test -n "$SAG_VERSION"
+          test -s docs/fnos/evidence/native-p0-x86.json \
+            || { echo "Missing native-p0-x86.json evidence"; exit 1; }
+
       - name: Test Native implementation
         shell: bash
         env:
-          # fnpack was installed and checksum-verified above, so structural
-          # tests that shell out to the real binary may run on this runner.
           SAG_FNPACK_TESTS: "1"
         run: |
           set -euo pipefail
-          cd apps/api && uv run --extra dev ruff check sag_api sag_agent tests && uv run --extra dev pytest -q
-          cd ../web && npm ci && npm run typecheck && npm run test:unit
-          cd ../.. && node --test scripts/tests/fnos-*.test.mjs
+          cd apps/api
+          uv run --extra dev ruff check sag_api sag_agent tests
+          uv run --extra dev pytest -q
+          cd ../web
+          npm ci
+          npm run typecheck
+          npm run test:unit
+          cd ../..
+          node --test scripts/tests/fnos-*.test.mjs
+
       - name: Build offline Native inputs
         shell: bash
-        env:
-          SAG_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          cd apps/web && NEXT_PUBLIC_APP_BASE_PATH=/app/sag NEXT_PUBLIC_API_BASE=/app/sag NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0 npm run build
-          cd ../.. && node scripts/build-fnos-native-vendor.mjs --platform linux/amd64 --output "$RUNNER_TEMP/vendor"
-          node scripts/build-fnos-native-package.mjs --platform x86 --vendor "$RUNNER_TEMP/vendor" --web apps/web/.next/standalone --version "$SAG_VERSION" --output "sag-$SAG_VERSION-x86.fpk"
+          cd apps/web
+          NEXT_PUBLIC_APP_BASE_PATH=/app/sag \
+            NEXT_PUBLIC_API_BASE=/app/sag \
+            NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0 \
+            npm run build
+          cd ../..
+          node scripts/build-fnos-native-vendor.mjs \
+            --platform linux/amd64 \
+            --output "$RUNNER_TEMP/vendor"
+          node scripts/build-fnos-native-package.mjs \
+            --platform x86 \
+            --vendor "$RUNNER_TEMP/vendor" \
+            --web apps/web/.next/standalone \
+            --version "$SAG_VERSION" \
+            --output "sag-$SAG_VERSION-x86.fpk"
           sha256sum "sag-$SAG_VERSION-x86.fpk" > "sag-$SAG_VERSION-x86.fpk.sha256"
+
       - name: Publish Native x86 release
         env:
           GH_TOKEN: ${{ github.token }}
-          SAG_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          gh release create "fnos-v$SAG_VERSION" "sag-$SAG_VERSION-x86.fpk" "sag-$SAG_VERSION-x86.fpk.sha256" \
+          gh release create "fnos-v$SAG_VERSION" \
+            "sag-$SAG_VERSION-x86.fpk" \
+            "sag-$SAG_VERSION-x86.fpk.sha256" \
             --title "SAG fnOS Native x86 $SAG_VERSION" \
-            --notes "Auto-published from fnos/develop @ ${GITHUB_SHA}"
+            --notes "Published from fnos/develop @ ${GITHUB_SHA}
+
+          - **Base version**: ${{ needs.resolve-version.outputs.base_version }}
+          - **FPK**: sag-$SAG_VERSION-x86.fpk
+          - **SHA256**: $(cat sag-$SAG_VERSION-x86.fpk.sha256 | awk '{print $1}')"

--- a/apps/api/sag_api/core/db.py
+++ b/apps/api/sag_api/core/db.py
@@ -75,6 +75,8 @@ _COLUMN_UPGRADES: dict[str, dict[str, str]] = {
         "attachments_json": "JSON",
         "steps_json": "JSON",
         "prompt_preview": "TEXT NOT NULL DEFAULT ''",
+        "status": "VARCHAR(16) NOT NULL DEFAULT 'ok'",
+        "error_json": "JSON",
     },
     "universe_dirty_sources": {"revision": "INTEGER NOT NULL DEFAULT 1"},
 }

--- a/apps/api/sag_api/core/litellm_policy.py
+++ b/apps/api/sag_api/core/litellm_policy.py
@@ -72,7 +72,7 @@ def apply_litellm_completion_policy(
         normalized["extra_body"] = dict(settings.llm_extra_body)
 
     model = str(normalized.get("model") or settings.routed_llm_model)
-    if normalized.get("tools") and _is_deepseek_v4(model):
+    if _is_deepseek_v4(model):
         extra_body = dict(normalized.get("extra_body") or {})
         extra_body["thinking"] = {"type": "disabled"}
         normalized["extra_body"] = extra_body

--- a/apps/api/sag_api/db/models/agent.py
+++ b/apps/api/sag_api/db/models/agent.py
@@ -5,7 +5,7 @@ from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column
 
 from sag_api.db.base import Base, IDMixin, TimestampMixin
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 
 
 class Agent(IDMixin, TimestampMixin, Base):
@@ -58,3 +58,18 @@ class Message(IDMixin, TimestampMixin, Base):
     # excludes tool results and the generated answer so historical playback
     # can audit the same role-separated input that was shown live.
     prompt_preview: Mapped[str] = mapped_column(Text, default="")
+    # 助手回复的终态；对话历史需要保留失败/取消气泡才能与实时会话一致。
+    # values_callable 强制以枚举 value（小写 ok/failed/cancelled）而不是 name（大写）存储，
+    # 与 server_default 保持一致，避免 SAEnum 在读回时按名字查表报 LookupError。
+    status: Mapped[MessageStatus] = mapped_column(
+        SAEnum(
+            MessageStatus,
+            native_enum=False,
+            length=16,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        default=MessageStatus.OK,
+        server_default=MessageStatus.OK.value,
+    )
+    # 失败/取消时的错误结构 {code, message, retryable, details}；成功时为 None。
+    error: Mapped[dict | None] = mapped_column("error_json", JSON, default=None, nullable=True)

--- a/apps/api/sag_api/enums.py
+++ b/apps/api/sag_api/enums.py
@@ -69,6 +69,12 @@ class MessageRole(StrEnum):
     SYSTEM = "system"
 
 
+class MessageStatus(StrEnum):
+    OK = "ok"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
 class BindingTargetType(StrEnum):
     SOURCE = "source"
     MCP_SERVER = "mcp_server"  # Phase C：挂载 MCP server 作为工具来源

--- a/apps/api/sag_api/schemas/agent.py
+++ b/apps/api/sag_api/schemas/agent.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 
 
 class AgentCreate(BaseModel):
@@ -78,6 +78,10 @@ class MessageOut(BaseModel):
     attachments: list[dict[str, Any]] = Field(default_factory=list)
     steps: list[dict[str, Any]] = Field(default_factory=list)
     prompt_preview: str = ""
+    # 助手气泡的终态：ok / failed / cancelled。用户消息始终 ok。
+    status: MessageStatus = MessageStatus.OK
+    # 失败/取消时的结构化错误 {code, message, retryable, details}；ok 时为 None。
+    error: dict[str, Any] | None = None
     created_at: datetime
 
 

--- a/apps/api/sag_api/services/agent_domain.py
+++ b/apps/api/sag_api/services/agent_domain.py
@@ -20,7 +20,7 @@ from sag_api.core.config import settings
 from sag_api.core.error_taxonomy import ErrorCode
 from sag_api.core.errors import ConflictError, NotFoundError, ValidationError
 from sag_api.db.models import Agent, AgentBinding, Message, Source, Thread
-from sag_api.enums import BindingTargetType, MessageRole
+from sag_api.enums import BindingTargetType, MessageRole, MessageStatus
 from sag_api.generation import build_agent_messages, build_prompt_preview
 from sag_api.generation.prompt import estimate_tokens
 from sag_api.services.source_service import search_source_candidates
@@ -563,7 +563,12 @@ async def persist_answer(
     citations: list[dict],
     steps: list[dict] | None = None,
     prompt_preview: str = "",
+    *,
+    status: MessageStatus = MessageStatus.OK,
+    error: dict | None = None,
 ) -> str:
+    """写入一条 assistant 消息。失败/取消时 answer 传部分已生成文本（可为 ""），
+    并附带结构化 error {code, message, retryable, details}。"""
     async with session_factory() as session:
         message = Message(
             thread_id=thread_id,
@@ -572,6 +577,8 @@ async def persist_answer(
             citations=citations,
             steps=steps or [],
             prompt_preview=prompt_preview,
+            status=status,
+            error=error,
         )
         session.add(message)
         await session.commit()

--- a/apps/api/sag_api/services/agent_service.py
+++ b/apps/api/sag_api/services/agent_service.py
@@ -27,6 +27,7 @@ from sag_agent import (
 from sag_agent import (
     ToolResult as RuntimeToolResult,
 )
+from sag_api.enums import MessageStatus
 from sag_api.generation import LLMClient, build_prompt_preview
 from sag_api.sag import EngineManager, SourceGraphInfo
 from sag_api.services.agent_domain import (
@@ -530,6 +531,7 @@ async def generate_stream(
     external_reference_urls: set[str] = set()
     trace: list[dict] = []
     tool_inputs: dict[str, dict[str, Any]] = {}
+    partial_answer: list[str] = []  # 失败/取消时保留已流出的正文
     handle = None
     terminal = False
 
@@ -706,6 +708,13 @@ async def generate_stream(
                         }
                     )
                 elif (
+                    event.type == EventType.MESSAGE_DELTA
+                    and payload.get("role") == "assistant"
+                ):
+                    delta = payload.get("delta")
+                    if isinstance(delta, str):
+                        partial_answer.append(delta)
+                elif (
                     event.type == EventType.MESSAGE_COMPLETED and payload.get("message", {}).get("role") == "assistant"
                 ):
                     duration = int(payload.get("duration_ms") or 0)
@@ -754,6 +763,36 @@ async def generate_stream(
                     }
                     terminal = True
                 elif event.type in (EventType.RUN_FAILED, EventType.RUN_CANCELLED):
+                    # 失败/取消也写入 assistant 消息，保留会话错误历史（含已流出的 partial answer）。
+                    partial_text = "".join(partial_answer)
+                    canonical_answer, internal_citations = _finalize_answer_citations(
+                        partial_text,
+                        citations,
+                    )
+                    error_payload = payload.get("error") if isinstance(payload, Mapping) else None
+                    status = (
+                        MessageStatus.CANCELLED
+                        if event.type == EventType.RUN_CANCELLED
+                        else MessageStatus.FAILED
+                    )
+                    message_id = None
+                    if thread_id is not None:
+                        message_id = await persist_answer(
+                            session_factory,
+                            thread_id,
+                            canonical_answer,
+                            internal_citations,
+                            steps=trace,
+                            prompt_preview=frozen_prompt_preview,
+                            status=status,
+                            error=dict(error_payload) if isinstance(error_payload, Mapping) else None,
+                        )
+                    output_payload = {
+                        **payload,
+                        "message_id": message_id,
+                        "partial_output": canonical_answer,
+                        "prompt_preview": frozen_prompt_preview,
+                    }
                     terminal = True
 
                 yield _stream_event(event, payload=output_payload)

--- a/apps/api/tests/test_ask_stream.py
+++ b/apps/api/tests/test_ask_stream.py
@@ -287,9 +287,24 @@ async def test_ask_stream_agentic_events_and_trace():
             assert "details" in tool_step
 
 
+class PartialThenFailLLM(AgenticLLM):
+    """流出几个 token 后再抛错 → 用于验证 partial answer 是否随失败气泡入库。"""
+
+    async def stream_turn(self, request, cancellation):
+        del request
+        cancellation.raise_if_cancelled()
+        yield ModelChunk(text_delta="部分")
+        yield ModelChunk(text_delta="回答")
+        raise UpstreamError("read timed out")
+        yield  # pragma: no cover
+
+
 @pytest.mark.asyncio
 async def test_ask_stream_provider_failure_has_terminal_error():
-    """Provider failures remain explicit instead of silently changing protocols."""
+    """Provider failure → assistant bubble persisted with status=failed & structured error.
+
+    此前空 assistant 会导致刷新丢失错误提示；改为持久化后前端能稳定回放失败气泡。
+    """
     from sag_api.main import app
 
     transport = httpx.ASGITransport(app=app)
@@ -305,10 +320,114 @@ async def test_ask_stream_provider_failure_has_terminal_error():
             body = ask.text
             assert "event: run.failed" in body
             assert "event: run.completed" not in body
+            # RUN_FAILED payload 中带 message_id，前端可对应替换本地临时气泡 id。
+            assert '"message_id":' in body
             msgs = (
                 await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
             ).json()["items"]
-            assert not any(m["role"] == "assistant" for m in msgs)
+            asst = [m for m in msgs if m["role"] == "assistant"]
+            assert len(asst) == 1
+            failed = asst[0]
+            assert failed["status"] == "failed"
+            assert failed["error"]
+            assert isinstance(failed["error"].get("message"), str)
+            # 无 token 流出 → 正文为空，前端展示纯错误说明。
+            assert failed["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_ask_stream_partial_answer_preserved_on_failure():
+    """Partial output before failure 应写入 failed 气泡的 content 中，保留可读上下文。"""
+    from sag_api.main import app
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        app.state.llm = PartialThenFailLLM()
+        async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=60) as c:
+            H, a, th = await _setup(c)
+            ask = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "分段失败"},
+            )
+            assert "event: run.failed" in ask.text
+            msgs = (
+                await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
+            ).json()["items"]
+            asst = [m for m in msgs if m["role"] == "assistant"][-1]
+            assert asst["status"] == "failed"
+            assert asst["content"] == "部分回答"
+            assert asst["error"] and asst["error"].get("code")
+
+
+@pytest.mark.asyncio
+async def test_ask_stream_failure_then_success_preserves_history_order():
+    """
+    复现 bug 的历史回放路径：连续两次 QA（首次失败、二次成功），
+    /messages 应按时间顺序返回：user₁, assistant(failed), user₂, assistant(ok)。
+    前端 mergeHistory 依赖这个稳定顺序来避免失败气泡被挤到最底部。
+    """
+    from sag_api.main import app
+
+    class OneShotBroken:
+        """第一次调用抛错，之后正常回答。"""
+
+        def __init__(self):
+            self.calls = 0
+
+        @property
+        def configured(self):
+            return True
+
+        async def stream_turn(self, request, cancellation):
+            del request
+            self.calls += 1
+            if self.calls == 1:
+                raise UpstreamError("read timed out")
+                yield  # pragma: no cover
+            cancellation.raise_if_cancelled()
+            for token in ["恢", "复"]:
+                yield ModelChunk(text_delta=token)
+            yield ModelChunk(finish_reason="stop")
+
+        async def complete(self, messages):
+            del messages
+            return ""
+
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        app.state.llm = OneShotBroken()
+        async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=60) as c:
+            H, a, th = await _setup(c)
+            first = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "第一个问题"},
+            )
+            assert "event: run.failed" in first.text
+            second = await c.post(
+                f"/api/v1/agents/{a['id']}/threads/{th['id']}/ask",
+                headers=H,
+                json={"query": "第二个问题"},
+            )
+            assert "event: run.completed" in second.text
+
+            msgs = (
+                await c.get(f"/api/v1/agents/{a['id']}/threads/{th['id']}/messages", headers=H)
+            ).json()["items"]
+            # 关键点：两次问答都持久化 → 后续刷新能稳定回放（首次失败气泡不会消失）。
+            assert len(msgs) == 4
+            users = [m for m in msgs if m["role"] == "user"]
+            assistants = [m for m in msgs if m["role"] == "assistant"]
+            assert {m["content"] for m in users} == {"第一个问题", "第二个问题"}
+            assert len(assistants) == 2
+            statuses = sorted(m["status"] for m in assistants)
+            assert statuses == ["failed", "ok"]
+            ok_msg = next(m for m in assistants if m["status"] == "ok")
+            failed_msg = next(m for m in assistants if m["status"] == "failed")
+            assert ok_msg["content"] == "恢复"
+            assert failed_msg["content"] == ""
+            assert failed_msg["error"] and failed_msg["error"].get("message")
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_message_status_enum.py
+++ b/apps/api/tests/test_message_status_enum.py
@@ -1,0 +1,123 @@
+"""Regression: Message.status must roundtrip by enum *value* (lowercase).
+
+Prior bug: SAEnum(MessageStatus, native_enum=False) 默认按 enum **name** 存（OK/FAILED/CANCELLED），
+但 _ensure_columns 里的 ALTER TABLE 使用 server_default='ok'，两条写路径落库大小写不同。
+存量库里凡存在 server_default 回填出的小写行，SAEnum 读回时按 name 查表就会 LookupError，
+直接把 /messages 接口打成 500 → 前端整个 QA 主流程返回 "Failed to fetch"。
+
+Fixture 里每次都是全新的 tempdir SQLite，无存量行，所以这个分歧不会自然出现；
+下面的用例显式模拟"有一行是 server_default 路径写入的（小写）"这个存量场景。
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select, text
+
+from sag_api.core.db import SessionLocal, init_db
+from sag_api.db.models import Agent, Message, Thread
+from sag_api.enums import MessageRole, MessageStatus
+
+
+async def _make_thread(session) -> str:
+    agent = Agent(name="enum-fixture")
+    session.add(agent)
+    await session.flush()
+    thread = Thread(agent_id=agent.id)
+    session.add(thread)
+    await session.flush()
+    return thread.id
+
+
+@pytest.mark.asyncio
+async def test_status_column_stores_enum_value_not_name():
+    """ORM 写入的行落库应为小写 value（ok/failed/cancelled），与 server_default 一致。"""
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        for status in (MessageStatus.OK, MessageStatus.FAILED, MessageStatus.CANCELLED):
+            session.add(
+                Message(thread_id=thread_id, role=MessageRole.ASSISTANT, status=status)
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        # 绕过 ORM 直接看物理值，避免枚举适配器掩盖大小写分歧。
+        rows = (await session.execute(text("SELECT status FROM messages"))).all()
+    stored = {row[0] for row in rows}
+    assert stored == {"ok", "failed", "cancelled"}, stored
+
+
+@pytest.mark.asyncio
+async def test_orm_reads_row_with_lowercase_status_value():
+    """存量行的 status 若来自 server_default（小写），ORM 读回不应 LookupError。
+
+    _ensure_columns 在既有表上 ALTER TABLE ADD COLUMN status ... DEFAULT 'ok'，
+    该分支只在生产升级路径出现；下面先用 ORM 建一行合法记录，再 raw UPDATE 把 status
+    强行写成小写 value，隔离出 status 列自身的 name/value 分歧行为。
+    """
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        session.add(
+            Message(
+                id="seed-lowercase",
+                thread_id=thread_id,
+                role=MessageRole.ASSISTANT,
+                status=MessageStatus.OK,
+            )
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        # 显式覆盖成小写 value，模拟 server_default 回填 / raw SQL 迁移路径。
+        await session.execute(
+            text("UPDATE messages SET status='ok' WHERE id='seed-lowercase'")
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        row = (
+            await session.execute(select(Message).where(Message.id == "seed-lowercase"))
+        ).scalar_one()
+
+    assert row.status is MessageStatus.OK
+    assert row.status.value == "ok"
+
+
+@pytest.mark.asyncio
+async def test_orm_roundtrips_all_statuses_via_new_session():
+    """完整来回：ORM 写 → commit → 新 session ORM 读，三个终态都不炸。"""
+    await init_db()
+    async with SessionLocal() as session:
+        thread_id = await _make_thread(session)
+        for suffix, status in [
+            ("ok", MessageStatus.OK),
+            ("failed", MessageStatus.FAILED),
+            ("cancelled", MessageStatus.CANCELLED),
+        ]:
+            session.add(
+                Message(
+                    id=f"roundtrip-{suffix}",
+                    thread_id=thread_id,
+                    role=MessageRole.ASSISTANT,
+                    status=status,
+                )
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        loaded = (
+            (
+                await session.execute(
+                    select(Message).where(Message.id.like("roundtrip-%")).order_by(Message.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {m.id: m.status for m in loaded} == {
+        "roundtrip-cancelled": MessageStatus.CANCELLED,
+        "roundtrip-failed": MessageStatus.FAILED,
+        "roundtrip-ok": MessageStatus.OK,
+    }

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -7,6 +7,7 @@ import pytest
 
 from sag_api.connectors import registry
 from sag_api.core import security
+from sag_api.core.security import hash_password, verify_password
 from sag_api.core.config import Settings, settings
 from sag_api.core.litellm_policy import (
     apply_litellm_completion_policy,
@@ -158,20 +159,65 @@ def test_litellm_policy_preserves_explicit_reasoning_and_allowed_params():
     assert request["allowed_openai_params"] == ["seed", "reasoning_effort"]
 
 
+@pytest.mark.parametrize("tool_choice", ["none", "required", None])
 @pytest.mark.parametrize(
     ("base_url", "model"),
     [
         ("https://api.deepseek.com", "deepseek-v4-flash"),
-        ("https://openai-compatible.example.com/v1", "deepseek/deepseek-v4-pro"),
+        ("https://api.deepseek.com", "deepseek-v4-pro"),
+        ("https://openai-compatible.example.com/v1", "deepseek/deepseek-v4-flash"),
     ],
 )
-def test_deepseek_v4_tool_request_disables_thinking(base_url, model):
+def test_deepseek_v4_disables_thinking_for_every_agent_tool_turn(tool_choice, base_url, model):
     configured = Settings(
         _env_file=None,
         llm_provider="openai",
         llm_base_url=base_url,
         llm_api_key="provider-key",
         llm_model=model,
+    )
+    raw = {
+        "model": configured.routed_llm_model,
+        "messages": [],
+        "tools": [{"type": "function", "function": {"name": "search_context"}}],
+    }
+    if tool_choice is not None:
+        raw["tool_choice"] = tool_choice
+
+    request = apply_litellm_completion_policy(configured, raw)
+
+    assert request["extra_body"]["thinking"] == {"type": "disabled"}
+    if tool_choice is None:
+        assert "tool_choice" not in request
+    else:
+        assert request["tool_choice"] == tool_choice
+
+
+def test_deepseek_v4_plain_completion_disables_thinking():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://api.deepseek.com",
+        llm_api_key="provider-key",
+        llm_model="deepseek-v4-pro",
+    )
+
+    request = apply_litellm_completion_policy(
+        configured,
+        {"model": configured.routed_llm_model, "messages": []},
+    )
+
+    assert request["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_deepseek_v4_tool_policy_preserves_other_extra_body_fields():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://api.deepseek.com",
+        llm_api_key="provider-key",
+        llm_model="deepseek-v4-flash",
+        llm_extra_body={"user_id": "sag-local"},
     )
 
     request = apply_litellm_completion_policy(
@@ -180,10 +226,34 @@ def test_deepseek_v4_tool_request_disables_thinking(base_url, model):
             "model": configured.routed_llm_model,
             "messages": [],
             "tools": [{"type": "function", "function": {"name": "search_context"}}],
+            "tool_choice": "required",
         },
     )
 
-    assert request["extra_body"]["thinking"] == {"type": "disabled"}
+    assert request["extra_body"] == {
+        "user_id": "sag-local",
+        "thinking": {"type": "disabled"},
+    }
+
+
+def test_non_deepseek_openai_compatible_tool_request_is_unchanged():
+    configured = Settings(
+        _env_file=None,
+        llm_provider="openai",
+        llm_base_url="https://openai-compatible.example.com/v1",
+        llm_api_key="provider-key",
+        llm_model="custom-model",
+    )
+    raw = {
+        "model": configured.routed_llm_model,
+        "messages": [],
+        "tools": [{"type": "function", "function": {"name": "search_context"}}],
+        "tool_choice": "required",
+    }
+
+    request = apply_litellm_completion_policy(configured, raw)
+
+    assert request == raw
 
 
 @pytest.mark.asyncio
@@ -266,6 +336,61 @@ async def test_llm_timeout_and_retries_reach_unified_client(monkeypatch):
     assert engine.llm.model == "openai/qwen3.6-flash"
     assert engine.llm.timeout == 45
     assert engine.llm.max_retries == 3
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_agent_turn_sends_non_thinking_tool_request(monkeypatch):
+    from sag_agent import AgentMessage, CancellationToken, ModelRequest
+    from sag_api.generation import llm as generation_llm
+
+    class EmptyStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            return None
+
+    seen: dict = {}
+
+    async def fake_completion(**kwargs):
+        seen.update(kwargs)
+        return EmptyStream()
+
+    monkeypatch.setattr(generation_llm, "_litellm_completion", fake_completion)
+    client = generation_llm.LLMClient(
+        Settings(
+            _env_file=None,
+            llm_provider="openai",
+            llm_base_url="https://api.deepseek.com",
+            llm_api_key="provider-key",
+            llm_model="deepseek-v4-flash",
+        )
+    )
+    request = ModelRequest(
+        messages=(AgentMessage(role="user", content="你好"),),
+        tools=(
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_context",
+                    "description": "search",
+                    "parameters": {"type": "object"},
+                },
+            },
+        ),
+        tool_choice="none",
+        turn=1,
+    )
+
+    chunks = [chunk async for chunk in client.stream_turn(request, CancellationToken())]
+
+    assert chunks == []
+    assert seen["model"] == "openai/deepseek-v4-flash"
+    assert seen["tool_choice"] == "none"
+    assert seen["extra_body"]["thinking"] == {"type": "disabled"}
 
 
 @pytest.mark.asyncio
@@ -765,23 +890,9 @@ async def test_zleap_sag_extract_compat_falls_back_to_json_object_when_json_sche
     assert [item["type"] for item in client.response_formats] == ["json_schema", "json_object"]
 
 
-def test_agent_name_is_injected_into_prompt():
-    messages = build_agent_messages(
-        "小跃",
-        {"system_prompt": "保持严谨。"},
-        "你叫什么？",
-        language="zh",
-    )
-    system = messages[0]["content"]
-    assert "你的名字是「小跃」" in system
-    assert "保持严谨。" in system
-    assert "sag" not in system.lower()
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model", ["openai/deepseek-v4-flash", "openai/deepseek-v3"])
 async def test_zleap_sag_extract_compat_uses_json_object_directly_for_deepseek(model):
-    """DeepSeek rejects the zleap-sag json_schema response-format contract."""
     from zleap.sag.modules.extract.processor import EventProcessor
 
     from sag_api.sag.compat import install_zleap_sag_extract_compat
@@ -803,3 +914,16 @@ async def test_zleap_sag_extract_compat_uses_json_object_directly_for_deepseek(m
 
     assert result["data"]["meta"]["reason"] == "ok"
     assert client.calls == [(None, {"type": "json_object"})]
+
+
+def test_agent_name_is_injected_into_prompt():
+    messages = build_agent_messages(
+        "小跃",
+        {"system_prompt": "保持严谨。"},
+        "你叫什么？",
+        language="zh",
+    )
+    system = messages[0]["content"]
+    assert "你的名字是「小跃」" in system
+    assert "保持严谨。" in system
+    assert "sag" not in system.lower()

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -7,7 +7,6 @@ import pytest
 
 from sag_api.connectors import registry
 from sag_api.core import security
-from sag_api.core.security import hash_password, verify_password
 from sag_api.core.config import Settings, settings
 from sag_api.core.litellm_policy import (
     apply_litellm_completion_policy,

--- a/apps/web/components/features/app-shell.tsx
+++ b/apps/web/components/features/app-shell.tsx
@@ -236,6 +236,7 @@ interface AppCtx {
   diagnostics: {
     entries: DiagEntry[];
     record: (type: DiagEntry["type"], data?: Record<string, unknown>) => void;
+    clear: () => void;
     exportLogs: () => DiagExport;
     downloadLogs: () => Promise<void>;
   };
@@ -269,6 +270,7 @@ const AppContext = React.createContext<AppCtx>({
   diagnostics: {
     entries: [],
     record: () => {},
+    clear: () => {},
     exportLogs: () => ({ version: 1 as const, exported_at: "", environment: { app: "web" as const, user_agent: "", language: "", timezone: "" }, model_config: null, capabilities: null, entries: [] }),
     downloadLogs: async () => {},
   },
@@ -803,6 +805,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         diagnostics: {
           entries: diag.entries,
           record: diag.record,
+          clear: diag.clear,
           exportLogs: diagnosticsExportLogs,
           downloadLogs: diagnosticsDownloadLogs,
         },

--- a/apps/web/components/features/chat/conversation-transcript.tsx
+++ b/apps/web/components/features/chat/conversation-transcript.tsx
@@ -18,6 +18,8 @@ export interface ConversationTranscriptMessage {
   content: string;
   citations?: Citation[];
   steps?: AgentActivityStep[];
+  /** 失败/取消气泡的错误说明；有值时以警示样式显示在正文下方。 */
+  errorMessage?: string;
 }
 
 export interface ConversationLiveActivity {
@@ -116,7 +118,8 @@ export const ConversationMessageItem = React.memo(function ConversationMessageIt
 
   const steps = activity?.steps ?? message.steps ?? [];
   const waiting = streaming && !message.content;
-  const footer = !streaming && message.content
+  const showFooter = !streaming && (message.content || message.errorMessage);
+  const footer = showFooter
     ? renderAssistantFooter?.({ message, index, previousUser })
     : null;
 
@@ -145,6 +148,18 @@ export const ConversationMessageItem = React.memo(function ConversationMessageIt
             onCitationClick={handleCitationClick}
             streaming={streaming}
           />
+        ) : null}
+
+        {!streaming && message.errorMessage ? (
+          <div
+            role="alert"
+            className={cn(
+              "mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive",
+              message.content ? "" : "mt-0",
+            )}
+          >
+            {message.errorMessage}
+          </div>
         ) : null}
 
         {footer}

--- a/apps/web/components/features/diagnostics-settings.tsx
+++ b/apps/web/components/features/diagnostics-settings.tsx
@@ -38,7 +38,7 @@ export function DiagnosticsSettings() {
   };
 
   const handleClear = () => {
-    // Entries are managed by the global store; clearing is a future enhancement
+    diagnostics.clear();
     setClearOpen(false);
     toast.success(t("clearSuccess"));
   };

--- a/apps/web/hooks/use-diagnostics.ts
+++ b/apps/web/hooks/use-diagnostics.ts
@@ -41,6 +41,10 @@ export function useDiagnostics() {
     [store],
   );
 
+  const clear = React.useCallback(() => {
+    store.clear();
+  }, [store]);
+
   const exportLogs = React.useCallback(
     (
       environment: DiagEnvironment,
@@ -71,9 +75,10 @@ export function useDiagnostics() {
       entries,
       count: entries.length,
       record,
+      clear,
       exportLogs,
       downloadLogs,
     }),
-    [entries, record, exportLogs, downloadLogs],
+    [entries, record, clear, exportLogs, downloadLogs],
   );
 }

--- a/apps/web/lib/conversation-runtime.test.ts
+++ b/apps/web/lib/conversation-runtime.test.ts
@@ -38,6 +38,28 @@ function message(id: string, content: string, promptPreview?: string): Message {
   };
 }
 
+function persistedMessage(overrides: {
+  id: string;
+  role: Message["role"];
+  content: string;
+  created_at: string;
+  status?: Message["status"];
+  error?: Message["error"];
+}): Message {
+  return {
+    id: overrides.id,
+    thread_id: "thread-1",
+    role: overrides.role,
+    content: overrides.content,
+    citations: [],
+    attachments: [],
+    steps: [],
+    status: overrides.status,
+    error: overrides.error,
+    created_at: overrides.created_at,
+  };
+}
+
 function messageRange(from: number, to: number): Message[] {
   return Array.from({ length: to - from + 1 }, (_, index) => {
     const value = from + index;
@@ -146,6 +168,32 @@ class FakeTransport implements ConversationTransport {
   emit(value: AgentEvent): void {
     if (!this.onEvent) throw new Error("stream has not started");
     this.onEvent(value);
+  }
+}
+
+/**
+ * FakeTransport 只能处理单次 stream。这里扩展一个允许排队多轮 stream 的版本,
+ * 保留 FakeTransport 的其它行为(历史分页、审批、取消、删除)。
+ */
+class SequentialTransport extends FakeTransport {
+  readonly streamQueue: Array<Deferred<AgentRunOutcome>> = [];
+
+  enqueueStream(): Deferred<AgentRunOutcome> {
+    const next = deferred<AgentRunOutcome>();
+    this.streamQueue.push(next);
+    return next;
+  }
+
+  stream(input: Parameters<ConversationTransport["stream"]>[0]): Promise<AgentRunOutcome> {
+    this.streamCalls.push({
+      webEnabled: input.webEnabled,
+      knowledgeOnly: input.knowledgeOnly,
+    });
+    this.onEvent = input.onEvent;
+    this.streamSignal = input.signal;
+    const pending = this.streamQueue.shift();
+    if (!pending) throw new Error("stream called without enqueued outcome");
+    return pending.promise;
   }
 }
 
@@ -576,7 +624,8 @@ describe("conversation runtime", () => {
     transport.streamResult.resolve({ status: "cancelled", runId: "run-1" });
     await running;
     expect(conversations.getSessionSnapshot(sessionId).messages.at(-1)).toMatchObject({
-      content: "已停止",
+      content: "",
+      errorMessage: "已停止",
       delivery: "cancelled",
     });
     expect(conversations.getSessionSnapshot(sessionId).messages.at(-1)?.steps.at(-1)).toMatchObject({
@@ -650,6 +699,187 @@ describe("conversation runtime", () => {
 
     transport.streamResult.resolve({ status: "completed", runId: "run-1" });
     await running;
+  });
+
+  it("keeps a failed bubble in history order after a subsequent successful reply", async () => {
+    const transport = new SequentialTransport();
+    const conversations = runtime(transport);
+    const sessionId = conversations.forThread("thread-1", { activate: true });
+
+    // 第一轮 QA 失败:服务端已把失败气泡持久化,并回带 message_id。
+    // finishOperation 会调 ensureHistory({force:true}),这一页应带回 (user, failed-assistant)。
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "server-user-1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "server-failed-1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+      ]),
+    );
+    const round1 = transport.enqueueStream();
+    const running1 = conversations.send(sessionId, { query: "问题一" });
+    transport.emit(event("run.started", 0, { user_message_id: "server-user-1" }, 1, "run-1"));
+    transport.emit(event("message.delta", 1, { role: "assistant", delta: "半句" }, 1, "run-1"));
+    transport.emit(
+      event(
+        "run.failed",
+        2,
+        {
+          error: { code: "llm_timeout", message: "读超时", retryable: true },
+          message_id: "server-failed-1",
+        },
+        1,
+        "run-1",
+      ),
+    );
+    round1.resolve({
+      status: "failed",
+      runId: "run-1",
+      messageId: "server-failed-1",
+      error: { code: "llm_timeout", message: "读超时", retryable: true },
+    });
+    await running1.catch(() => {});
+
+    const after1 = conversations.getSessionSnapshot(sessionId);
+    expect(after1.messages.map((message) => message.id)).toEqual([
+      "server-user-1",
+      "server-failed-1",
+    ]);
+    expect(after1.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      content: "半句",
+      errorMessage: "读超时",
+    });
+
+    // 第二轮 QA 成功。ensureHistory 会带回全量 [u1, failed-a1, u2, ok-a2],
+    // mergeHistory 必须让失败气泡留在 u1 之后、u2 之前(bug 表现是失败气泡被顶到最底部)。
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "server-user-1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "server-failed-1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+        persistedMessage({
+          id: "server-user-2",
+          role: "user",
+          content: "问题二",
+          created_at: "2026-07-12T00:00:02Z",
+        }),
+        persistedMessage({
+          id: "server-ok-2",
+          role: "assistant",
+          content: "完整答案",
+          created_at: "2026-07-12T00:00:03Z",
+        }),
+      ]),
+    );
+    const round2 = transport.enqueueStream();
+    const running2 = conversations.send(sessionId, { query: "问题二" });
+    transport.emit(event("run.started", 0, { user_message_id: "server-user-2" }, 1, "run-2"));
+    transport.emit(event("message.delta", 1, { role: "assistant", delta: "完整答案" }, 1, "run-2"));
+    transport.emit(
+      event(
+        "run.completed",
+        2,
+        { output: "完整答案", citations: [], message_id: "server-ok-2" },
+        1,
+        "run-2",
+      ),
+    );
+    round2.resolve({ status: "completed", runId: "run-2", messageId: "server-ok-2" });
+    await running2;
+
+    const after2 = conversations.getSessionSnapshot(sessionId);
+    expect(after2.messages.map((message) => message.id)).toEqual([
+      "server-user-1",
+      "server-failed-1",
+      "server-user-2",
+      "server-ok-2",
+    ]);
+    expect(after2.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      errorMessage: "读超时",
+    });
+    expect(after2.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      delivery: "persisted",
+      content: "完整答案",
+    });
+    // 关键回归断言:失败气泡没有被追加到最底部。
+    expect(after2.messages.at(-1)?.id).not.toBe("server-failed-1");
+  });
+
+  it("restores persisted failed bubbles on a fresh runtime (page refresh)", async () => {
+    const transport = new FakeTransport();
+    transport.historyPages.push(
+      page([
+        persistedMessage({
+          id: "u1",
+          role: "user",
+          content: "问题一",
+          created_at: "2026-07-12T00:00:00Z",
+        }),
+        persistedMessage({
+          id: "a1",
+          role: "assistant",
+          content: "半句",
+          created_at: "2026-07-12T00:00:01Z",
+          status: "failed",
+          error: { code: "llm_timeout", message: "读超时" },
+        }),
+        persistedMessage({
+          id: "u2",
+          role: "user",
+          content: "问题二",
+          created_at: "2026-07-12T00:00:02Z",
+        }),
+        persistedMessage({
+          id: "a2",
+          role: "assistant",
+          content: "完整答案",
+          created_at: "2026-07-12T00:00:03Z",
+        }),
+      ]),
+    );
+    const conversations = runtime(transport);
+    const sessionId = conversations.forThread("thread-1", { activate: true });
+    await conversations.ensureHistory(sessionId);
+
+    const snapshot = conversations.getSessionSnapshot(sessionId);
+    expect(snapshot.messages.map((message) => message.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(snapshot.messages[1]).toMatchObject({
+      role: "assistant",
+      delivery: "failed",
+      content: "半句",
+      errorMessage: "读超时",
+    });
+    expect(snapshot.messages[3]).toMatchObject({
+      role: "assistant",
+      delivery: "persisted",
+      content: "完整答案",
+    });
   });
 
   it("aborts owned work only when the runtime is disposed", () => {

--- a/apps/web/lib/conversation-runtime.ts
+++ b/apps/web/lib/conversation-runtime.ts
@@ -84,6 +84,8 @@ export interface ConversationMessage {
   delivery: ConversationDelivery;
   promptPreview?: string;
   universeActivation?: UniverseActivation;
+  /** 失败/取消时的可读错误文本。UI 用它在气泡内展示错误说明。 */
+  errorMessage?: string;
 }
 
 export type ConversationHistoryStatus = "idle" | "loading" | "ready" | "error";
@@ -218,6 +220,13 @@ function isAbortError(reason: unknown): boolean {
 }
 
 function normalizeMessage(message: Message): ConversationMessage {
+  const status = message.status ?? "ok";
+  const delivery: ConversationDelivery =
+    status === "failed" ? "failed" : status === "cancelled" ? "cancelled" : "persisted";
+  const errorMessage =
+    status !== "ok" && message.error && typeof message.error.message === "string"
+      ? message.error.message
+      : undefined;
   return {
     id: message.id,
     threadId: message.thread_id,
@@ -231,7 +240,8 @@ function normalizeMessage(message: Message): ConversationMessage {
         ? message.prompt_preview
         : undefined,
     createdAt: message.created_at,
-    delivery: "persisted",
+    delivery,
+    errorMessage,
   };
 }
 
@@ -281,11 +291,11 @@ function mergeHistory(
   });
   const local = current.filter(
     (message) =>
-      (message.delivery === "pending" ||
-        message.delivery === "streaming" ||
-        message.delivery === "complete" ||
-        message.delivery === "failed" ||
-        message.delivery === "cancelled") &&
+      // 只有真正“进行中”的本地气泡才保留：complete/failed/cancelled 一旦被后端确认落库
+      // （outcome.messageId 存在），会经 finishOperation 改写 id 后走 uniquePersisted 分支合并；
+      // 未落库的终态气泡由 finishOperation 直接跳过 ensureHistory({force:true}) 兜底，
+      // 因此这里不需要留在 local。
+      (message.delivery === "pending" || message.delivery === "streaming") &&
       !ids.has(message.id),
   );
   return [...uniquePersisted, ...local];
@@ -1029,6 +1039,12 @@ export class ConversationRuntime {
           ? "cancelled"
           : "failed";
     const assistantMessageId = outcome.messageId || operation.assistantMessageId;
+    const errorText =
+      outcome.status === "cancelled"
+        ? clientErrorMessage("stopped")
+        : outcome.status === "failed"
+          ? failure
+          : undefined;
     this.activeOperation = null;
     this.updateSession(
       operation.sessionId,
@@ -1040,14 +1056,11 @@ export class ConversationRuntime {
           updateMessage(current.messages, operation.assistantMessageId, (message) => ({
             ...message,
             id: assistantMessageId,
-            content:
-              message.content ||
-              (outcome.status === "cancelled"
-                ? clientErrorMessage("stopped")
-                : outcome.status === "failed"
-                  ? `⚠︎ ${failure}`
-                  : ""),
+            // 失败/取消时保留已流出的 partial content;为空时也不再塞错误文本，
+            // 错误说明改由 errorMessage 承载,与后端持久化的 (content, error) 分离一致。
+            content: message.content,
             delivery,
+            errorMessage: errorText,
             steps: persistentSteps(steps),
           })).map((message) =>
             message.delivery === "pending"
@@ -1062,7 +1075,11 @@ export class ConversationRuntime {
     this.notifyActivity();
 
     const threadId = this.getSessionSnapshot(operation.sessionId).threadId;
-    if (outcome.status === "completed" && threadId) {
+    // 只有服务端确认落库（拿到 outcome.messageId）时才重拉历史，避免把仅存在于前端的
+    // 终态气泡（例如网络中断、老版本服务端）在 mergeHistory 中被过滤掉。
+    // 修复目标：失败气泡持久化后重跑 mergeHistory，把 (user, failed-assistant) 顺序稳住，
+    // 避免第二次成功回答落回底部时把失败气泡顶到最下。
+    if (threadId && outcome.messageId) {
       await this.ensureHistory(operation.sessionId, { force: true });
     }
   }

--- a/apps/web/lib/diagnostics.test.ts
+++ b/apps/web/lib/diagnostics.test.ts
@@ -244,4 +244,38 @@ describe("DiagnosticsStore", () => {
     store.record("model.load");
     expect(count).toBe(1);
   });
+
+  it("clear() empties the buffer, resets seq, and notifies subscribers", () => {
+    const store = new DiagnosticsStore();
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount += 1;
+    });
+    store.record("app.init");
+    store.record("model.load");
+    expect(store.count).toBe(2);
+    expect(notifyCount).toBe(2);
+
+    store.clear();
+
+    expect(store.count).toBe(0);
+    expect(store.snapshot()).toEqual([]);
+    expect(notifyCount).toBe(3);
+
+    store.record("qa.ask");
+    const snapshot = store.snapshot();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].seq).toBe(1);
+  });
+
+  it("clear() is a no-op on an empty store (no notify)", () => {
+    const store = new DiagnosticsStore();
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount += 1;
+    });
+    store.clear();
+    expect(notifyCount).toBe(0);
+    expect(store.count).toBe(0);
+  });
 });

--- a/apps/web/lib/diagnostics.ts
+++ b/apps/web/lib/diagnostics.ts
@@ -158,6 +158,14 @@ export class DiagnosticsStore {
     return this.cachedSnapshot;
   }
 
+  clear(): void {
+    if (this.buffer.length === 0 && this.seq === 0) return;
+    this.buffer = [];
+    this.seq = 0;
+    this.cachedSnapshot = null;
+    this.notify();
+  }
+
   get count(): number {
     return this.buffer.length;
   }

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -298,6 +298,14 @@ export interface MessageAttachment {
   media_type?: string;
 }
 
+export type MessageStatus = "ok" | "failed" | "cancelled";
+
+export interface MessageError {
+  message?: string;
+  code?: string;
+  [key: string]: unknown;
+}
+
 export interface Message {
   id: string;
   thread_id: string;
@@ -307,6 +315,8 @@ export interface Message {
   attachments?: MessageAttachment[];
   steps?: MessageStep[];
   prompt_preview?: string;
+  status?: MessageStatus;
+  error?: MessageError | null;
   created_at: string;
 }
 

--- a/packages/fnos/native/sag/cmd/install_init
+++ b/packages/fnos/native/sag/cmd/install_init
@@ -1,17 +1,220 @@
 #!/bin/sh
-set -eu
-secret="${TRIM_PKGETC}/internal-secret"
-mkdir -p "${TRIM_PKGETC}"
+# install_init — provision the fnOS internal identity secret and scrub
+# residues from prior installs.
+#
+# The secret lives under TRIM_PKGVAR (== /vol1/@appdata/<pkg>), NOT
+# TRIM_PKGETC (== /vol1/@appconf/<pkg>). fnpack treats @appconf as a
+# shared config volume whose perms it manages itself and does not
+# re-normalize on overwrite install — a prior release that wrote
+# @appconf/sag/internal-secret at 0700 root:root left the secret
+# unreadable to the sag package user forever, and cmd/main (running as
+# sag) had no way to chmod it back. @appdata/sag is package-owned by
+# fnpack, so both install_init (root) and main (sag) can always write
+# the file with correct perms.
+#
+# This callback is safe to no-op: cmd/main also self-heals the secret
+# on every start. install_init just avoids the very first start having
+# to detour through the fallback path.
+#
+# Every fatal exit writes context to TRIM_TEMP_LOGFILE so the fnOS app
+# centre surfaces a real cause instead of "执行脚本出错且原因未知".
+
+set -u
+
+log_file="${TRIM_TEMP_LOGFILE:-}"
+log() {
+  if [ -n "$log_file" ]; then
+    printf 'install_init: %s\n' "$*" >>"$log_file" 2>/dev/null && return 0
+  fi
+  printf 'install_init: %s\n' "$*" >&2
+}
+die() { log "$*"; exit 1; }
+
+on_exit() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    log "aborting with status $status (last step: ${LAST_STEP:-<startup>}); TRIM_PKGVAR=${TRIM_PKGVAR:-<unset>} TRIM_PKGETC=${TRIM_PKGETC:-<unset>}"
+  fi
+}
+LAST_STEP="startup"
+trap on_exit EXIT
+
+hex_ok() {
+  case "$1" in
+    "") return 1 ;;
+    *[!0-9a-f]*) return 1 ;;
+    ????????????????????????????????????????????????????????????????) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+generate_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    material="$(openssl rand -hex 32 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  if command -v xxd >/dev/null 2>&1; then
+    material="$(head -c 32 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  if command -v od >/dev/null 2>&1; then
+    material="$(head -c 32 /dev/urandom 2>/dev/null | od -An -v -tx1 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  return 1
+}
+
+secret_ok() {
+  test -f "$1" || return 1
+  bytes="$(wc -c <"$1" 2>/dev/null | tr -d ' \n\t')"
+  test "$bytes" = 64 || return 1
+  content="$(cat "$1" 2>/dev/null)" || return 1
+  hex_ok "$content"
+}
+
+# ---- 1. Environment sanity ------------------------------------------------
+LAST_STEP="env-sanity"
+: "${TRIM_PKGVAR:=}"
+test -n "$TRIM_PKGVAR" || die "TRIM_PKGVAR is empty; fnpack did not inject a package var directory"
+case "$TRIM_PKGVAR" in
+  /*) ;;
+  *) die "TRIM_PKGVAR ($TRIM_PKGVAR) is not an absolute path" ;;
+esac
+
+# ---- 2. Ensure the var directory exists and is writable -------------------
+LAST_STEP="mkdir-pkgvar"
+if ! mkdir -p "$TRIM_PKGVAR" 2>/dev/null; then
+  die "cannot create $TRIM_PKGVAR (permission denied or read-only filesystem?)"
+fi
+test -d "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not a directory"
+test -w "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not writable by the installer"
+
+# ---- 3. Force TRIM_PKGVAR to a mode the sag package user can traverse ----
+# fnpack chowns @appdata/<pkg> to the package user, but on some upgrade
+# paths (or when a prior version misconfigured privilege) the dir may
+# still be root:root. Set both mode and owner defensively.
+LAST_STEP="pkgvar-perms"
+chmod 0755 "$TRIM_PKGVAR" 2>/dev/null || log "chmod 0755 $TRIM_PKGVAR failed (non-fatal)"
+
+# Resolve the package user now so Section 3b can use it. The full ownership
+# section below re-uses the same variable to chown the secret itself.
+package_user="${SAG_INSTALL_PACKAGE_USER:-sag}"
+
+# ---- 3b. Normalize ownership of the whole var tree ------------------------
+# Docker-era SAG wrote /vol1/@appdata/sag as root inside a container. On
+# Docker→Native overwrite install, sag (uid 984) then cannot read those
+# files, so the gateway crashes on the first sqlite open and status
+# reports "gateway process is not running" with no other clue. User has
+# explicitly authorised discarding old install data; the gentler variant
+# is to just remap ownership — data stays in place but becomes accessible.
+# Best-effort: on nested bind-mounts / EROFS / xattr edge cases the
+# recursive chown may partially fail; main will still refuse to open any
+# stragglers with a specific errno, and the operator log tells the story.
+LAST_STEP="normalize-pkgvar-ownership"
+if id "$package_user" >/dev/null 2>&1; then
+  chown -R "$package_user" "$TRIM_PKGVAR" 2>/dev/null || \
+    log "recursive chown of $TRIM_PKGVAR to $package_user failed (non-fatal; probable Docker-era residue — main will surface any unreadable files at start with a specific errno)"
+  if command -v getent >/dev/null 2>&1 && getent group "$package_user" >/dev/null 2>&1; then
+    chgrp -R "$package_user" "$TRIM_PKGVAR" 2>/dev/null || :
+  fi
+fi
+
+secret="$TRIM_PKGVAR/internal-secret"
+
+# ---- 4. Scrub residues from prior installs --------------------------------
+# The user explicitly authorised discarding old-install data on overwrite.
+# The concrete residue that broke start on real hardware was a root-owned
+# secret at @appconf/sag/internal-secret (permissions the sag user could
+# not fix). Remove it so it can't shadow the new @appdata/sag location.
+LAST_STEP="scrub-appconf-residue"
+if [ -n "${TRIM_PKGETC:-}" ] && [ -e "$TRIM_PKGETC/internal-secret" ]; then
+  rm -f "$TRIM_PKGETC/internal-secret" 2>/dev/null || log "could not remove legacy $TRIM_PKGETC/internal-secret (non-fatal; main no longer reads it)"
+fi
+
+# ---- 5. Reject a symlinked secret path ------------------------------------
+LAST_STEP="reject-symlink"
 if [ -L "$secret" ]; then
-  echo "refusing symlinked fnOS internal secret" >&2
-  exit 1
+  # A symlink under our own data dir is almost certainly stale; delete it.
+  rm -f "$secret" 2>/dev/null || die "refusing symlinked $secret and cannot remove it"
 fi
-if [ ! -e "$secret" ]; then
+
+# ---- 6. Reuse a healthy secret; regenerate an unhealthy one ---------------
+LAST_STEP="secret-provisioning"
+if ! secret_ok "$secret"; then
+  if [ -e "$secret" ]; then
+    log "existing internal-secret is not a 64-hex blob; regenerating"
+    rm -f "$secret" || die "cannot remove stale $secret"
+  fi
   umask 077
-  od -An -N32 -tx1 /dev/urandom | tr -d ' \n' > "$secret"
+  material="$(generate_secret)" || die "no working RNG (need openssl, xxd, or od + /dev/urandom)"
+  hex_ok "$material" || die "generated secret material failed hex validation"
+  printf '%s' "$material" >"$secret" || die "cannot write $secret (disk full or read-only?)"
 fi
-if id sag >/dev/null 2>&1; then
-  chown sag:sag "$secret"
+
+# ---- 7. Ownership -------------------------------------------------------
+# Even though @appdata/sag is package-owned, be defensive: explicitly
+# chown the secret and its containing dir to the sag package user.
+# SAG_INSTALL_PACKAGE_USER lets the test harness pin the current shell
+# user; production always resolves to "sag".
+LAST_STEP="ownership"
+if id "$package_user" >/dev/null 2>&1; then
+  chown "$package_user" "$secret" 2>/dev/null || log "chown $package_user $secret failed (non-fatal; main will self-heal at start)"
+  chown "$package_user" "$TRIM_PKGVAR" 2>/dev/null || log "chown $package_user $TRIM_PKGVAR failed (non-fatal)"
+  if command -v getent >/dev/null 2>&1; then
+    if getent group "$package_user" >/dev/null 2>&1; then
+      chgrp "$package_user" "$secret" 2>/dev/null || :
+      chgrp "$package_user" "$TRIM_PKGVAR" 2>/dev/null || :
+    else
+      log "group $package_user missing; keeping user's primary group on $secret"
+    fi
+  else
+    chgrp "$package_user" "$secret" 2>/dev/null || :
+    chgrp "$package_user" "$TRIM_PKGVAR" 2>/dev/null || :
+  fi
+elif [ -n "${SAG_INSTALL_ALLOW_MISSING_USER:-}" ]; then
+  log "package user $package_user missing but SAG_INSTALL_ALLOW_MISSING_USER set; leaving ownership unchanged"
+else
+  # main's self-heal will still cover this at first start (it runs as the
+  # package user and rewrites the secret under its own uid), so demote to
+  # a warning rather than aborting install.
+  log "package user $package_user does not exist; leaving secret ownership unchanged (main will self-heal at start)"
 fi
-chmod 600 "$secret"
-test "$(wc -c < "$secret" | tr -d ' ')" = 64
+
+# ---- 8. Mode 0600 --------------------------------------------------------
+LAST_STEP="chmod"
+chmod 600 "$secret" || die "cannot chmod 600 $secret"
+
+# ---- 9. Post-condition ---------------------------------------------------
+LAST_STEP="post-condition"
+size="$(wc -c <"$secret" 2>/dev/null | tr -d ' \n\t')"
+case "$size" in
+  64) ;;
+  *) die "post-condition failed: internal-secret is $size bytes (want 64)" ;;
+esac
+
+# ---- 10. Cross-user self-check ------------------------------------------
+# Since main.prepare_secret now self-heals, an EACCES here is no longer
+# fatal — we just log and move on so install itself succeeds.
+LAST_STEP="cross-user-selfcheck"
+if [ "$package_user" != "$(id -un)" ] && id "$package_user" >/dev/null 2>&1; then
+  drop=""
+  if command -v runuser >/dev/null 2>&1; then
+    drop="runuser -u $package_user --"
+  elif command -v su >/dev/null 2>&1; then
+    drop="su -s /bin/sh $package_user -c"
+  fi
+  if [ -n "$drop" ]; then
+    if [ "$drop" = "su -s /bin/sh $package_user -c" ]; then
+      probe_out="$(su -s /bin/sh "$package_user" -c "cat '$secret' >/dev/null 2>&1 && wc -c <'$secret'" 2>&1)"
+      probe_status=$?
+    else
+      probe_out="$($drop sh -c "cat '$secret' >/dev/null 2>&1 && wc -c <'$secret'" 2>&1)"
+      probe_status=$?
+    fi
+    if [ "$probe_status" -ne 0 ]; then
+      log "package user $package_user cannot read $secret at install time (exit $probe_status). Dir: $(ls -ld "$TRIM_PKGVAR" 2>&1). File: $(ls -l "$secret" 2>&1). Probe: $probe_out. main.start will self-heal."
+    fi
+  fi
+fi
+
+exit 0

--- a/packages/fnos/native/sag/cmd/main
+++ b/packages/fnos/native/sag/cmd/main
@@ -13,12 +13,97 @@ web_entry="${TRIM_APPDEST}/web/server.js"
 web_root="${TRIM_APPDEST}/web"
 gateway_log="${log_dir}/gateway.log"
 web_log="${log_dir}/web.log"
-secret="${TRIM_PKGETC}/internal-secret"
+secret="${TRIM_PKGVAR}/internal-secret"
 
 log_error() { printf '%s\n' "$1" >> "${TRIM_TEMP_LOGFILE:-/dev/null}"; }
 
+# The internal secret lives in TRIM_PKGVAR (== /vol1/@appdata/<pkg> on
+# fnOS), NOT in TRIM_PKGETC (== /vol1/@appconf/<pkg>). fnpack treats
+# @appconf as a shared config volume whose perms it manages itself and
+# does not re-normalize on upgrade — a prior install that left the
+# secret 0700 root:root at @appconf/sag/internal-secret would then be
+# unreadable to the sag package user forever, with no way for main to
+# fix it (main runs as sag; only root can chmod a root-owned file).
+# @appdata/sag is package-owned, so main can always self-heal.
+#
+# hex_ok / generate_secret / secret_ok are duplicated with install_init
+# on purpose: main must be able to bootstrap a working secret without
+# assuming install_init succeeded (fnpack does not re-run install_init
+# on overwrite install, and the file may pre-date this build).
+hex_ok() {
+  case "$1" in
+    "") return 1 ;;
+    *[!0-9a-f]*) return 1 ;;
+    ????????????????????????????????????????????????????????????????) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+generate_secret_material() {
+  if command -v openssl >/dev/null 2>&1; then
+    material="$(openssl rand -hex 32 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  if command -v xxd >/dev/null 2>&1; then
+    material="$(head -c 32 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  if command -v od >/dev/null 2>&1; then
+    material="$(head -c 32 /dev/urandom 2>/dev/null | od -An -v -tx1 2>/dev/null | tr -d '\n\r\t ')"
+    if hex_ok "$material"; then printf '%s' "$material"; return 0; fi
+  fi
+  return 1
+}
+
+secret_content_ok() {
+  test -f "$1" || return 1
+  bytes="$(wc -c <"$1" 2>/dev/null | tr -d ' \n\t')"
+  test "$bytes" = 64 || return 1
+  content="$(cat "$1" 2>/dev/null)" || return 1
+  hex_ok "$content"
+}
+
+# prepare_secret returns 0 iff main can safely hand the secret to the
+# gateway. Unlike the .19 version this SELF-HEALS: if the file is
+# missing, unreadable-because-wrong-owner, malformed, or truncated,
+# rewrite it. This is safe on this package — the secret is a per-install
+# token, only referenced by processes we spawn, and losing it just
+# forces one re-login on the local UDS. It also makes overwrite-install
+# residues (root-owned file left by a prior version whose install_init
+# ran under a different umask) recover automatically.
 prepare_secret() {
-  test ! -L "$secret" && test -f "$secret" && chmod 600 "$secret"
+  # Refuse a symlink outright — we won't chase it into someone else's dir.
+  if [ -L "$secret" ]; then
+    log_error "SAG Native internal secret at $secret is a symlink; refusing. Delete it manually and restart."
+    return 1
+  fi
+  # Fast path: the common case is a healthy, package-owned file.
+  if secret_content_ok "$secret" && [ -r "$secret" ]; then
+    chmod 600 "$secret" 2>/dev/null || :
+    return 0
+  fi
+  # Slow / recovery path — regenerate.
+  umask 077
+  # Try to remove the residue first. If we can't unlink (e.g. dir is
+  # writable by us but the file is +i or on a read-only mount), fall
+  # through to the write, which will produce the specific errno.
+  if [ -e "$secret" ]; then
+    rm -f "$secret" 2>/dev/null || :
+  fi
+  if [ ! -w "$(dirname "$secret")" ]; then
+    log_error "SAG Native cannot rewrite internal secret: $(dirname "$secret") is not writable by uid=$(id -u 2>/dev/null || echo ?). $(ls -ld "$(dirname "$secret")" 2>&1)."
+    return 1
+  fi
+  material="$(generate_secret_material)" || {
+    log_error "SAG Native cannot regenerate internal secret: no working RNG (need openssl, xxd, or od + /dev/urandom)."
+    return 1
+  }
+  if ! printf '%s' "$material" >"$secret" 2>/dev/null; then
+    log_error "SAG Native cannot write internal secret at $secret. $(ls -ld "$(dirname "$secret")" 2>&1)."
+    return 1
+  fi
+  chmod 600 "$secret" 2>/dev/null || :
+  return 0
 }
 
 write_pid() {
@@ -91,9 +176,17 @@ wait_for_gateway_socket() {
   local waited=0
   while test "$waited" -lt 15; do
     if test -S "$gateway_socket" && valid_pid "$gateway_pid" "sag_api.fnos.cli" && gateway_healthy; then return 0; fi
+    # If the process died during the wait loop, don't waste 14 more
+    # seconds polling a corpse — surface the log tail and bail.
+    if test "$waited" -ge 2 && ! valid_pid "$gateway_pid" "sag_api.fnos.cli"; then
+      log_error "SAG Native gateway process died during startup (waited ${waited}s). Last 20 lines of gateway.log: $(tail -n 20 "$gateway_log" 2>/dev/null | tr '\n' ' ' | head -c 800). Socket: $(ls -l "$gateway_socket" 2>&1)."
+      return 1
+    fi
     sleep 1
     waited=$((waited + 1))
   done
+  # Timed out after 15s — the process may still be alive but not serving.
+  log_error "SAG Native gateway did not become ready within 15s. Socket exists: $(test -S "$gateway_socket" && echo yes || echo no). PID alive: $(valid_pid "$gateway_pid" "sag_api.fnos.cli" && echo yes || echo no). Last 20 lines of gateway.log: $(tail -n 20 "$gateway_log" 2>/dev/null | tr '\n' ' ' | head -c 800)."
   return 1
 }
 
@@ -118,16 +211,62 @@ web_healthy() {
   curl -fsS --max-time 8 "http://127.0.0.1:${web_port}/app/sag/chat" >/dev/null 2>> "$web_log"
 }
 
+# Only registered as the EXIT trap during "main start".  The trap makes
+# sure EVERY non-zero exit from the start path — even an unexpected one —
+# leaves at least a pid/dir/log-tail breadcrumb in TRIM_TEMP_LOGFILE so
+# fnpack never shows the generic "执行脚本出错且原因未知".
+_start_crash_trap() {
+  local s=$?
+  if [ "$s" -ne 0 ]; then
+    log_error "SAG Native start exited with code $s (last step: ${_START_STEP:-<startup>}). UID=$(id -u 2>/dev/null || echo ?) GID=$(id -g 2>/dev/null || echo ?). GW log: $(tail -n 20 "$gateway_log" 2>/dev/null | tr '\n' ' ' | head -c 800). Secret: $(ls -l "$secret" 2>&1). Socket dir: $(ls -ld "$(dirname "$gateway_socket")" 2>&1)."
+  fi
+}
+
 case "${1:-}" in
   start)
-    mkdir -p "$run_dir" "$log_dir"
+    trap _start_crash_trap EXIT
+
+    _START_STEP="mkdir"
+    mkdir -p "$run_dir" "$log_dir" || {
+      log_error "SAG Native cannot create run/log dirs under $TRIM_PKGVAR. UID=$(id -u 2>/dev/null || echo ?). Parent dir: $(ls -ld "$TRIM_PKGVAR" 2>&1)."
+      exit 1
+    }
+
+    # Verify the gateway log is writable BEFORE we launch anything that
+    # redirects into it. A silent redirect failure (read-only fs, wrong
+    # owner, missing parent dir) would otherwise swallow the real error
+    # and leave gateway.log empty — the operator would see nothing at all.
+    _START_STEP="touch-gateway-log"
+    if ! touch "$gateway_log" 2>/dev/null; then
+      log_error "SAG Native cannot write gateway log at $gateway_log. UID=$(id -u 2>/dev/null || echo ?). Dir: $(ls -ld "$log_dir" 2>&1)."
+      exit 1
+    fi
+
+    # Warm the operator if the socket dir is not writable by us so the
+    # eventual PermissionError in uvicorn is not a surprise.
+    _START_STEP="check-socket-dir"
+    if [ ! -w "$(dirname "$gateway_socket")" ]; then
+      log_error "SAG Native gateway socket directory $(dirname "$gateway_socket") is not writable by uid=$(id -u 2>/dev/null || echo ?). $(ls -ld "$(dirname "$gateway_socket")" 2>&1). uvicorn will be unable to bind the UDS."
+      # Don't exit — maybe an ACL grants write after all. The gateway
+      # launch will surface the real errno either way.
+    fi
+
     export PATH="/var/apps/python312/target/bin:/var/apps/nodejs_v22/target/bin:$PATH"
     export PYTHONPATH="${TRIM_APPDEST}/server/vendor:${TRIM_APPDEST}/server${PYTHONPATH:+:$PYTHONPATH}"
     export SAG_FNOS_DATA_ROOT="${TRIM_PKGVAR}"
     export SAG_FNOS_TEMP_ROOT="${TRIM_PKGTMP}"
     export SAG_FNOS_INTERNAL_SECRET_FILE="$secret"
-    test -x "$runtime" && test -x "$node_runtime" && test -f "$web_entry" && test -d "$web_root" || { log_error "SAG Native runtime payload is unavailable."; exit 1; }
-    prepare_secret || { log_error "SAG Native internal identity secret is unavailable or has unsafe permissions."; exit 1; }
+
+    _START_STEP="check-runtimes"
+    if ! test -x "$runtime"; then log_error "SAG Native runtime payload is unavailable: python3 missing at $runtime."; exit 1; fi
+    if ! test -x "$node_runtime"; then log_error "SAG Native runtime payload is unavailable: node missing at $node_runtime."; exit 1; fi
+    if ! test -f "$web_entry"; then log_error "SAG Native runtime payload is unavailable: web entry missing at $web_entry."; exit 1; fi
+    if ! test -d "$web_root"; then log_error "SAG Native runtime payload is unavailable: web root missing at $web_root."; exit 1; fi
+
+    _START_STEP="prepare-secret"
+    prepare_secret || exit 1
+
+    _START_STEP="start-web"
     if valid_pid "$web_pid" "$web_entry" "web" && test -f "$web_port_file"; then
       web_port="$(cat "$web_port_file")"
     else
@@ -137,16 +276,47 @@ case "${1:-}" in
       write_pid "$web_pid" "$!"
       write_pid "$web_port_file" "$web_port"
     fi
+
+    _START_STEP="wait-web"
     if ! wait_for_web; then
+      log_error "SAG Native web process did not become ready within 15s. Web log tail: $(tail -n 20 "$web_log" 2>/dev/null | tr '\n' ' ' | head -c 800)."
       stop_process "$web_pid" "$web_entry" "web"
       exit 1
     fi
+
+    _START_STEP="start-gateway"
     if ! valid_pid "$gateway_pid" "sag_api.fnos.cli"; then
       rm -f "$gateway_socket"
       "$runtime" -m sag_api.fnos.cli gateway --socket "$gateway_socket" --web-origin "http://127.0.0.1:${web_port}" >> "$gateway_log" 2>&1 &
-      write_pid "$gateway_pid" "$!"
+      gw_pid=$!
+      write_pid "$gateway_pid" "$gw_pid"
+      # Give Python ~1s to import + settle, then check it is still alive.
+      # A quick death (permission denied on sqlite, missing native dep,
+      # config parse error, secret mode != 0600, etc.) would otherwise be
+      # invisible until wait_for_gateway_socket times out 15s later with
+      # the useless "gateway process is not running" line. Surface a tail
+      # of the log so the operator can act on the real errno.
+      sleep 1
+      if ! kill -0 "$gw_pid" 2>/dev/null; then
+        gw_tail="$(tail -n 20 "$gateway_log" 2>/dev/null | tr '\n' ' ' | head -c 800)"
+        log_error "SAG Native gateway process exited immediately after launch (pid=$gw_pid). Last gateway.log: ${gw_tail:-<empty>}"
+        stop_process "$web_pid" "$web_entry" "web"
+        rm -f "$gateway_pid" "$gateway_socket"
+        exit 1
+      fi
     fi
-    wait_for_gateway_socket || { stop_process "$gateway_pid" "sag_api.fnos.cli"; stop_process "$web_pid" "$web_entry" "web"; exit 1; }
+
+    _START_STEP="wait-gateway"
+    wait_for_gateway_socket || {
+      # wait_for_gateway_socket already wrote its own log_error; this arm
+      # only cleans up so the next start is from a blank slate.
+      stop_process "$gateway_pid" "sag_api.fnos.cli"
+      stop_process "$web_pid" "$web_entry" "web"
+      exit 1
+    }
+
+    # Success — disarm the crash trap so stop/status are not affected.
+    trap - EXIT
     ;;
   stop)
     stop_process "$gateway_pid" "sag_api.fnos.cli"

--- a/packages/fnos/native/sag/cmd/upgrade_init
+++ b/packages/fnos/native/sag/cmd/upgrade_init
@@ -1,32 +1,196 @@
 #!/bin/sh
-set -eu
+# upgrade_init — pre-upgrade backup + install-side prep.
+#
+# fnpack invokes this callback for every upgrade path, including the
+# Docker→Native transition where fnpack treats the two as the same
+# appname and calls upgrade_init instead of install_init. Two things
+# went wrong in that path before:
+#
+#   1. "$main" status writes its failure text ("SAG Native gateway
+#      process is not running.") directly to TRIM_TEMP_LOGFILE via
+#      log_error, bypassing stderr, so `2>&1 >/dev/null` cannot mask
+#      it. fnpack then reads TRIM_TEMP_LOGFILE and surfaces that text
+#      as the upgrade error to the user. Redirect TRIM_TEMP_LOGFILE
+#      to /dev/null during the probe so a "not running" answer is
+#      just information, not a user-visible failure.
+#
+#   2. python3 "$lifecycle" size --root "$users" hard-fails when the
+#      users directory does not exist OR when lifecycle.py itself is
+#      not yet in TRIM_APPDEST (fnpack may execute upgrade_init
+#      *before* installing the new package files — TRIM_APPDEST at
+#      this point contains the OLD Docker-version files, which have
+#      no runtime/lifecycle.py). Guard both.
+#
+#   3. Any *unexpected* failure (missing python3, awk absent on a
+#      minimal image, tmpfs full, whatever) must NOT surface to the
+#      user as fnpack's generic "执行脚本出错且原因未知". We install
+#      an EXIT trap that always writes a diagnostic line to
+#      TRIM_TEMP_LOGFILE — the log is the only channel fnpack shows.
+#
+# Docker data at /vol1/@appdata/sag is intentionally left untouched.
+# We do not migrate it: the schema, embeddings layout, and secret
+# format differ. The user re-creates knowledge bases in the Native
+# install. The informational log makes this explicit.
+
+# NOTE: we deliberately do NOT `set -e`. Under strict -e in dash,
+# any subshell/pipe/df/awk hiccup can kill the script before the
+# log write runs, producing the generic fnpack error. Instead we
+# check exit status explicitly at the few real fail-fast points.
+set -u
+
 command_dir="$(dirname "$0")"
 main="$command_dir/main"
-lifecycle="${TRIM_APPDEST}/runtime/lifecycle.py"
-users="${TRIM_PKGVAR}/users"
-backup_dir="${TRIM_PKGVAR}/backup"
+lifecycle="${TRIM_APPDEST:-}/runtime/lifecycle.py"
+users="${TRIM_PKGVAR:-}/users"
+backup_dir="${TRIM_PKGVAR:-}/backup"
+log_file="${TRIM_TEMP_LOGFILE:-}"
 
-"$command_dir/install_init"
+log() {
+  if [ -n "$log_file" ]; then
+    printf 'upgrade_init: %s\n' "$*" >>"$log_file" 2>/dev/null && return 0
+  fi
+  printf 'upgrade_init: %s\n' "$*" >&2
+}
+
+die() { log "$*"; exit 1; }
+
+# Catch every non-zero exit — even ones from commands we didn't
+# guard — so fnpack always shows a concrete cause rather than
+# "执行脚本出错且原因未知".
+on_exit() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    log "aborting with status $status (last command: ${LAST_STEP:-<startup>}); TRIM_APPDEST=${TRIM_APPDEST:-<unset>} TRIM_PKGVAR=${TRIM_PKGVAR:-<unset>} TRIM_PKGETC=${TRIM_PKGETC:-<unset>}"
+  fi
+}
+trap on_exit EXIT
+
+# Every meaningful step updates LAST_STEP so the exit trap can name
+# the offender. Keep the labels short — they show up in the fnpack UI.
+LAST_STEP="startup"
+
+# ---- Environment sanity ---------------------------------------------------
+LAST_STEP="env-check"
+: "${TRIM_APPDEST:=}"
+: "${TRIM_PKGVAR:=}"
+[ -n "$TRIM_APPDEST" ] || die "TRIM_APPDEST is empty; fnpack did not inject the appdest directory"
+[ -n "$TRIM_PKGVAR" ]  || die "TRIM_PKGVAR is empty; fnpack did not inject the package var directory"
+
+# ---- Delegate identity-secret provisioning to install_init ---------------
+LAST_STEP="install_init"
+if ! "$command_dir/install_init"; then
+  die "install_init failed (see preceding install_init lines in this log)"
+fi
+
+# ---- Probe previous service state (silently) ------------------------------
+# main's log_error() appends to TRIM_TEMP_LOGFILE directly; redirecting
+# stderr does not mask it, so we point TRIM_TEMP_LOGFILE at /dev/null
+# for the duration of this probe. On Docker→Native transitions the
+# probe *should* return non-zero (no Native gateway); that is not an
+# error, just information for the restore-if-needed trap.
+LAST_STEP="probe-status"
 was_running=false
-if "$main" status >/dev/null 2>&1; then was_running=true; fi
-"$main" stop
+if TRIM_TEMP_LOGFILE=/dev/null "$main" status >/dev/null 2>&1; then
+  was_running=true
+fi
+
+# ---- Stop the previous instance if one is running ------------------------
+LAST_STEP="stop-previous"
+if [ "$was_running" = true ]; then
+  if ! "$main" stop; then
+    die "failed to stop the running Native instance before upgrade"
+  fi
+else
+  TRIM_TEMP_LOGFILE=/dev/null "$main" stop >/dev/null 2>&1 || :
+fi
 
 restore_if_needed() {
-  if [ "$was_running" = true ]; then "$main" start >/dev/null 2>&1 || true; fi
+  if [ "$was_running" = true ]; then
+    TRIM_TEMP_LOGFILE=/dev/null "$main" start >/dev/null 2>&1 || :
+  fi
 }
-trap restore_if_needed EXIT HUP INT TERM
+trap 'restore_if_needed; on_exit' EXIT HUP INT TERM
 
-used="$(python3 "$lifecycle" size --root "$users")"
-available="$(df -Pk "$TRIM_PKGVAR" | awk 'NR == 2 { print $4 }')"
+# ---- Decide whether there is anything to back up -------------------------
+# Skip the whole backup pipeline when any of these hold:
+#   - Native users directory does not exist yet
+#     (Docker→Native transition, or fresh first install)
+#   - Directory exists but is empty (fresh Native install)
+#   - lifecycle.py is not yet present in TRIM_APPDEST
+#     (fnpack ran upgrade_init before dropping new files, so the
+#     appdest still holds the OLD Docker payload)
+#   - python3 is not on PATH (edge case: minimal fnOS image)
+LAST_STEP="check-users-dir"
+if [ ! -d "$users" ]; then
+  log "no Native users directory yet — skipping pre-upgrade backup (first Native install or Docker→Native transition; Docker data at /vol1/@appdata/sag is preserved but not migrated; recreate knowledge bases in the Native app)"
+  trap - EXIT HUP INT TERM
+  exit 0
+fi
+
+LAST_STEP="check-users-empty"
+if [ -z "$(ls -A "$users" 2>/dev/null)" ]; then
+  log "Native users directory is empty — nothing to back up"
+  trap - EXIT HUP INT TERM
+  exit 0
+fi
+
+LAST_STEP="check-lifecycle-py"
+if [ ! -f "$lifecycle" ]; then
+  log "runtime/lifecycle.py not present in TRIM_APPDEST yet (fnpack has not swapped in the new package payload) — skipping pre-upgrade backup"
+  trap - EXIT HUP INT TERM
+  exit 0
+fi
+
+LAST_STEP="check-python3"
+if ! command -v python3 >/dev/null 2>&1; then
+  log "python3 not on PATH — skipping pre-upgrade backup (this is safe on a first Native install; the runtime is bundled and used by main, not by upgrade_init)"
+  trap - EXIT HUP INT TERM
+  exit 0
+fi
+
+# ---- Compute space budget ------------------------------------------------
+LAST_STEP="lifecycle-size"
+if ! used="$(python3 "$lifecycle" size --root "$users" 2>&1)"; then
+  die "lifecycle.py size failed: $used"
+fi
+case "$used" in
+  ''|*[!0-9]*) die "lifecycle.py size returned non-numeric output: $used" ;;
+esac
+
+LAST_STEP="df-available"
+if ! df_line="$(df -Pk "$TRIM_PKGVAR" 2>&1)"; then
+  die "df -Pk $TRIM_PKGVAR failed: $df_line"
+fi
+available="$(printf '%s\n' "$df_line" | awk 'NR == 2 { print $4 }')"
+case "$available" in
+  ''|*[!0-9]*) die "cannot parse available space from df output on $TRIM_PKGVAR (got: $df_line)" ;;
+esac
 required=$((used * 2 + 102400))
-case "$available" in ''|*[!0-9]*) exit 1 ;; esac
-[ "$available" -ge "$required" ] || exit 1
-mkdir -p "$backup_dir"
+if [ "$available" -lt "$required" ]; then
+  die "insufficient space in $TRIM_PKGVAR: need ${required}K, have ${available}K"
+fi
+
+# ---- Produce the backup archive ------------------------------------------
+LAST_STEP="mkdir-backup"
+if ! mkdir -p "$backup_dir"; then die "cannot create backup dir $backup_dir"; fi
+
+LAST_STEP="backup-archive"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 temporary="$backup_dir/sag-users-$timestamp.tar.gz.tmp"
 final="${temporary%.tmp}"
-python3 "$lifecycle" backup --root "$users" --output "$temporary"
-python3 "$lifecycle" validate --archive "$temporary"
-chmod 600 "$temporary"
-mv -f "$temporary" "$final"
+if ! backup_output="$(python3 "$lifecycle" backup --root "$users" --output "$temporary" 2>&1)"; then
+  die "lifecycle.py backup failed: $backup_output"
+fi
+
+LAST_STEP="validate-archive"
+if ! validate_output="$(python3 "$lifecycle" validate --archive "$temporary" 2>&1)"; then
+  die "lifecycle.py validate failed: $validate_output"
+fi
+
+LAST_STEP="finalize-archive"
+chmod 600 "$temporary" || die "cannot chmod 600 $temporary"
+mv -f "$temporary" "$final" || die "cannot rename $temporary to $final"
+
+log "pre-upgrade backup written to $final"
 trap - EXIT HUP INT TERM
+exit 0

--- a/scripts/tests/fnos-native-lifecycle.test.mjs
+++ b/scripts/tests/fnos-native-lifecycle.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -12,28 +12,56 @@ const cmd = path.join(root, "packages/fnos/native/sag/cmd");
 const chatPage = path.join(root, "apps/web/app/(app)/chat/[[...id]]/page.tsx");
 const appSidebar = path.join(root, "apps/web/components/features/app-sidebar.tsx");
 
+// install_init resolves the package user from SAG_INSTALL_PACKAGE_USER so
+// tests can run on hosts without a "sag" account. Production always uses
+// the default "sag" (fnpack creates it before install_init from
+// config/privilege).
+const currentUser = os.userInfo().username;
+function baseEnv(extra = {}) {
+  return { ...process.env, SAG_INSTALL_PACKAGE_USER: currentUser, ...extra };
+}
+
 function run(name, env, args = []) {
   return spawnSync("bash", [path.join(cmd, name), ...args], { encoding: "utf8", env });
+}
+function runSh(name, env, args = []) {
+  return spawnSync("/bin/sh", [path.join(cmd, name), ...args], { encoding: "utf8", env });
 }
 
 test("install_init creates one private, stable internal secret", async (t) => {
   const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
-  const etc = path.join(fixture, "etc");
-  await mkdir(etc);
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
   t.after(() => rm(fixture, { recursive: true, force: true }));
-  const env = { ...process.env, TRIM_PKGETC: etc };
+  const env = baseEnv({ TRIM_PKGVAR: pkgvar });
 
-  assert.equal(run("install_init", env).status, 0);
-  const first = await readFile(path.join(etc, "internal-secret"), "utf8");
-  assert.match(first, /^[0-9a-f]{64}$/);
-  assert.equal((await (await import("node:fs/promises")).stat(path.join(etc, "internal-secret"))).mode & 0o777, 0o600);
-  assert.equal(run("install_init", env).status, 0);
-  assert.equal(await readFile(path.join(etc, "internal-secret"), "utf8"), first);
+  const first = run("install_init", env);
+  assert.equal(first.status, 0, first.stderr);
+  const secretPath = path.join(pkgvar, "internal-secret");
+  const material = await readFile(secretPath, "utf8");
+  assert.match(material, /^[0-9a-f]{64}$/);
+  assert.equal((await stat(secretPath)).mode & 0o777, 0o600);
+  const second = run("install_init", env);
+  assert.equal(second.status, 0, second.stderr);
+  assert.equal(await readFile(secretPath, "utf8"), material);
 });
 
-test("install gives the package user access to the private gateway secret", async () => {
+test("install_init also runs under strict POSIX /bin/sh (dash on fnOS)", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const result = runSh("install_init", baseEnv({ TRIM_PKGVAR: pkgvar }));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
+});
+
+test("install_init grants ownership to the fnOS package user", async () => {
   const source = await readFile(path.join(cmd, "install_init"), "utf8");
-  assert.match(source, /chown sag:sag/);
+  // Production installs must chown to sag; hardcoded name outside test envs.
+  assert.match(source, /package_user="\$\{SAG_INSTALL_PACKAGE_USER:-sag\}"/);
+  assert.match(source, /chown "\$package_user"/);
 });
 
 test("native start repairs the package-owned secret to mode 0600", async () => {
@@ -49,13 +77,9 @@ test("native lifecycle verifies service identity from the complete process comma
 
 test("native lifecycle recognises Next after it rewrites its process title", async () => {
   const source = await readFile(path.join(cmd, "main"), "utf8");
-  // Next.js rewrites argv (and therefore /proc cmdline) to "next-server",
-  // so identity must fall back to the launch environment marker.
   assert.match(source, /SAG_NATIVE_SERVICE="web" HOSTNAME=127\.0\.0\.1/);
   assert.match(source, /\/proc\/\$pid\/environ/);
   assert.match(source, /SAG_NATIVE_SERVICE=\$service/);
-  // Every web identity check must pass the marker, or status/stop regress
-  // into "web process is not running" the moment Next boots.
   assert.doesNotMatch(source, /valid_pid "\$web_pid" "\$web_entry"(?! "web")/);
   assert.doesNotMatch(source, /stop_process "\$web_pid" "\$web_entry"(?! "web")/);
 });
@@ -106,16 +130,565 @@ test("Native sidebar icon uses the deployed application prefix", async () => {
   assert.match(source, /src=\{appPath\("\/sag-icon\.png"\)\}/);
 });
 
-test("install_init refuses a symlinked internal secret", async (t) => {
+test("install_init discards a symlinked residue instead of aborting", async (t) => {
+  // The user has authorised discarding old-install data on overwrite,
+  // and cmd/main self-heals in any case — install_init just removes
+  // the symlink so a valid file replaces it.
   const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
-  const etc = path.join(fixture, "etc");
+  const pkgvar = path.join(fixture, "pkgvar");
   const target = path.join(fixture, "target");
-  await mkdir(etc);
+  await mkdir(pkgvar);
   await writeFile(target, "0".repeat(64));
-  await symlink(target, path.join(etc, "internal-secret"));
+  await symlink(target, path.join(pkgvar, "internal-secret"));
   t.after(() => rm(fixture, { recursive: true, force: true }));
 
-  assert.notEqual(run("install_init", { ...process.env, TRIM_PKGETC: etc }).status, 0);
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar }));
+  assert.equal(result.status, 0, result.stderr);
+  const stats = await stat(path.join(pkgvar, "internal-secret"));
+  assert.equal(stats.mode & 0o777, 0o600);
+  assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
+});
+
+test("install_init regenerates a residue secret left by a prior Docker install", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  // Docker version of appname=sag may have written the file as an opaque
+  // base64 blob or a JSON envelope; both fail 64-hex validation.
+  await writeFile(path.join(pkgvar, "internal-secret"), '{"legacy":"docker","token":"AAAA"}');
+  await chmod(path.join(pkgvar, "internal-secret"), 0o644);
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar, TRIM_TEMP_LOGFILE: logFile }));
+  assert.equal(result.status, 0, result.stderr);
+  const material = await readFile(path.join(pkgvar, "internal-secret"), "utf8");
+  assert.match(material, /^[0-9a-f]{64}$/);
+  assert.equal((await stat(path.join(pkgvar, "internal-secret"))).mode & 0o777, 0o600);
+  const log = await readFile(logFile, "utf8");
+  assert.match(log, /regenerating/i);
+});
+
+test("install_init regenerates a truncated secret rather than dying at the length check", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  await writeFile(path.join(pkgvar, "internal-secret"), "abcdef"); // 6 bytes
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar }));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
+});
+
+test("install_init writes a human-readable cause to TRIM_TEMP_LOGFILE when it must abort", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+
+  const result = run("install_init", { ...process.env, TRIM_TEMP_LOGFILE: logFile, TRIM_PKGVAR: "" });
+  assert.notEqual(result.status, 0);
+  const log = await readFile(logFile, "utf8");
+  assert.match(log, /TRIM_PKGVAR/i);
+});
+
+test("install_init refuses a relative TRIM_PKGVAR instead of writing to /internal-secret", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: "relative/var" }));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /absolute path/i);
+});
+
+test("install_init warns but does not abort when the package user is missing", async (t) => {
+  // main.prepare_secret now self-heals under the process uid, so an
+  // absent package user (unusual — fnpack normally provisions it from
+  // config/privilege) is no longer fatal at install time.
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+  const result = run("install_init", {
+    ...process.env,
+    TRIM_PKGVAR: pkgvar,
+    TRIM_TEMP_LOGFILE: logFile,
+    SAG_INSTALL_PACKAGE_USER: "sag_missing_user_for_test_12345",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const log = await readFile(logFile, "utf8");
+  assert.match(log, /package user.*does not exist/i);
+  assert.match(log, /main will self-heal/i);
+});
+
+test("install_init tolerates a missing group for the package user", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  // Use the current user but claim a nonexistent group by setting the
+  // package user to a name whose primary group won't happen to match
+  // "sag_missing_group_...". We can't really force getent to lie without
+  // faking a chroot, but we can assert the script has no un-guarded
+  // "sag:sag" chown that would blow up under `set -e` on missing group.
+  const source = await readFile(path.join(cmd, "install_init"), "utf8");
+  assert.doesNotMatch(source, /chown[^\n]*"\$package_user":"\$package_user"/);
+  assert.doesNotMatch(source, /chown[^\n]*sag:sag/);
+  assert.match(source, /chgrp[^\n]*\|\| :/);
+});
+
+test("install_init scrubs a root-owned residue secret from the legacy @appconf path", async (t) => {
+  // The real-hardware failure on .19 was a root-owned secret at
+  // /vol1/@appconf/sag/internal-secret (TRIM_PKGETC) that fnpack did
+  // not re-normalize on overwrite install. .20 stops using @appconf
+  // entirely and best-effort removes the residue so it can't be
+  // mistaken for the current one by a downgrade-then-upgrade path.
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  const pkgetc = path.join(fixture, "pkgetc");
+  await mkdir(pkgvar);
+  await mkdir(pkgetc);
+  await writeFile(path.join(pkgetc, "internal-secret"), "legacy");
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar, TRIM_PKGETC: pkgetc }));
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(path.join(pkgetc, "internal-secret")), false, "legacy @appconf residue must be removed");
+  assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
+});
+
+test("install_init recursively normalizes TRIM_PKGVAR ownership to the package user", async (t) => {
+  // Docker-era SAG wrote /vol1/@appdata/sag as root inside a container.
+  // On Docker→Native overwrite install the sag package user (uid 984)
+  // cannot read those files; the gateway then crashes on the first
+  // sqlite open and status returns "gateway process is not running"
+  // with no other clue. install_init recursively chowns the tree to
+  // sag so start-up just works — the fix that unblocks Docker→Native
+  // covers without asking the user to uninstall first.
+  const source = await readFile(path.join(cmd, "install_init"), "utf8");
+  assert.match(source, /chown -R "\$package_user" "\$TRIM_PKGVAR"/);
+  // Must be best-effort — a partial failure logs and continues, so the
+  // rest of install_init (secret provisioning etc.) still runs.
+  assert.match(source, /recursive chown of \$TRIM_PKGVAR to \$package_user failed \(non-fatal/);
+  // And it must sit before secret provisioning so the secret write
+  // itself lands under sag's uid on a Docker-residue tree.
+  const chownIdx = source.indexOf('chown -R "$package_user" "$TRIM_PKGVAR"');
+  const provisionIdx = source.indexOf("secret-provisioning");
+  assert.ok(chownIdx > 0 && provisionIdx > 0 && chownIdx < provisionIdx,
+    "recursive chown must run before secret provisioning");
+});
+
+test("install_init actually chowns Docker-residue files it finds under TRIM_PKGVAR", async (t) => {
+  // Full round-trip: pre-seed a Docker-shape tree with a couple of
+  // stray files, run install_init as the current user (posing as the
+  // package user via SAG_INSTALL_PACKAGE_USER), and confirm the tree
+  // ends up owned by that user. We can't test the actual UID transition
+  // on macOS without sudo, so this asserts the code path fires without
+  // erroring rather than the OS-level uid delta.
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-chown-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  await mkdir(path.join(pkgvar, "users"));
+  await writeFile(path.join(pkgvar, "users", "docker-residue.db"), "sqlite-residue");
+  await mkdir(path.join(pkgvar, "logs"));
+  await writeFile(path.join(pkgvar, "logs", "app.log"), "old");
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar, TRIM_TEMP_LOGFILE: logFile }));
+  assert.equal(result.status, 0, `stderr=${result.stderr} log=${await readFile(logFile, "utf8")}`);
+  // Residue files must still exist (data preserved, only ownership normalized).
+  assert.equal(existsSync(path.join(pkgvar, "users", "docker-residue.db")), true);
+  assert.equal(existsSync(path.join(pkgvar, "logs", "app.log")), true);
+  // Secret provisioning still succeeded on top of the chowned tree.
+  assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
+});
+
+test("main.start reports gateway early-exit with a tail of gateway.log", async () => {
+  // Prior to .21 a gateway that died within the first second (permission
+  // denied on sqlite, native dep import error, config parse crash) was
+  // invisible until wait_for_gateway_socket timed out 15s later with the
+  // useless "gateway process is not running" line. .21 does a kill -0
+  // 1 second after launch and, if the process is gone, dumps the tail of
+  // gateway.log so the operator has a real errno to act on.
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  assert.match(source, /gw_pid=\$!/);
+  assert.match(source, /kill -0 "\$gw_pid"/);
+  assert.match(source, /tail -n 20 "\$gateway_log"/);
+  assert.match(source, /gateway process exited immediately after launch/);
+  assert.match(source, /rm -f "\$gateway_pid" "\$gateway_socket"/);
+  // .22 also arms a crash trap for the whole start path so exits from
+  // *any* step — not just the gateway launch — leave a breadcrumb.
+  assert.match(source, /_start_crash_trap/);
+  assert.match(source, /SAG Native start exited with code/);
+});
+
+test("main.start verifies the gateway log is writable before launching anything", async () => {
+  // A redirect failure on >> gateway.log would swallow uvicorn's stderr
+  // (the real PermissionError / ImportError) and leave the log empty —
+  // the operator would see "没有任何日志" even though the root cause was
+  // captured by the EXIT trap. Pre-touch guarantees the file exists and
+  // is writable before we depend on the redirect.
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  assert.match(source, /touch "\$gateway_log"/);
+  assert.match(source, /cannot write gateway log at/);
+});
+
+test("main.start warns when the gateway socket directory is not writable", async () => {
+  // uvicorn creates app.sock in TRIM_APPDEST. If sag can't write there,
+  // uvicorn dies with PermissionError. Surface a pre-launch warning so
+  // the operator knows what's coming even if the actual stderr is lost.
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  assert.match(source, /check-socket-dir/);
+  assert.match(source, /not writable by uid=/);
+});
+
+test("main.start fails early with a clear message when mkdir of run/log dirs fails", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  // mkdir -p must be checked, not fire-and-forget.
+  assert.match(source, /mkdir -p "\$run_dir" "\$log_dir"/);
+  assert.match(source, /cannot create run\/log dirs under/);
+});
+
+test("main.start wait_for_web failure writes a log_error with web log tail", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  // Prior to .22 wait_for_web failure just exit 1'd silently.
+  assert.match(source, /web process did not become ready within 15s/);
+  assert.match(source, /tail -n 20 "\$web_log"/);
+});
+
+test("wait_for_gateway_socket detects a dead gateway process early instead of looping 15 more seconds", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  // If the process died during the wait loop, don't waste 14 more
+  // seconds — capture the log and return immediately.
+  assert.match(source, /gateway process died during startup/);
+  assert.match(source, /valid_pid "\$gateway_pid" "sag_api\.fnos\.cli"/);
+  // The 15s timeout also writes a log_error now (was silent exit 1 before).
+  assert.match(source, /did not become ready within 15s/);
+});
+
+test("main.start EXIT trap captures pid / dir stats / gw log on any non-zero exit", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  // The trap fires on *any* unexpected non-zero exit, not just specific
+  // guarded points. It captures enough context to diagnose root-owned
+  // residues, missing env vars, permission failures, etc.
+  assert.match(source, /trap _start_crash_trap EXIT/);
+  assert.match(source, /UID=\$\(id -u/);
+  assert.match(source, /GW log:/);
+  assert.match(source, /Secret: \$\(ls -l "\$secret"/);
+  // The trap is disarmed on success so stop/status don't inherit it.
+  assert.match(source, /trap - EXIT/);
+});
+
+// -----------------------------------------------------------------
+// upgrade_init: Docker→Native transition tolerance
+// -----------------------------------------------------------------
+// The user-observed failure on real N150 hardware: with Docker sag
+// still installed, .16 aborted with "无法更新 SAG：SAG Native gateway
+// process is not running". Two root causes:
+//   (a) "$main" status writes via log_error → TRIM_TEMP_LOGFILE
+//       (bypasses stderr; 2>&1 cannot mask it). fnpack reads the
+//       log and displays that text as the upgrade error.
+//   (b) python3 lifecycle.py size --root "$users" hard-fails when
+//       the Native users directory does not exist yet (Docker→Native
+//       transition).
+async function stageUpgradeFixture(t) {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-upgrade-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const cmdDir = path.join(fixture, "cmd");
+  const appdest = path.join(fixture, "appdest");
+  const pkgvar = path.join(fixture, "pkgvar");
+  const pkgetc = path.join(fixture, "pkgetc");
+  await mkdir(cmdDir);
+  await mkdir(appdest);
+  await mkdir(pkgvar);
+  await mkdir(pkgetc);
+  await mkdir(path.join(appdest, "runtime"));
+  // Real upgrade_init copied into the scratch dir so its
+  // "$command_dir/main" and "$command_dir/install_init" resolve to
+  // our stubs, not the real binaries.
+  const upgradeSrc = await readFile(path.join(cmd, "upgrade_init"), "utf8");
+  await writeFile(path.join(cmdDir, "upgrade_init"), upgradeSrc);
+  await chmod(path.join(cmdDir, "upgrade_init"), 0o755);
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+  const env = {
+    ...process.env,
+    TRIM_APPDEST: appdest,
+    TRIM_PKGVAR: pkgvar,
+    TRIM_PKGETC: pkgetc,
+    TRIM_TEMP_LOGFILE: logFile,
+    SAG_INSTALL_PACKAGE_USER: currentUser,
+  };
+  return { fixture, cmdDir, appdest, pkgvar, pkgetc, logFile, env };
+}
+
+async function writeStubMain(cmdDir, { statusExit }) {
+  // The stub reproduces the real main's telltale behavior: when
+  // status returns non-zero, it appends the "gateway process is not
+  // running" message *to TRIM_TEMP_LOGFILE*, not to stderr. That is
+  // exactly the leak upgrade_init must guard against by redirecting
+  // TRIM_TEMP_LOGFILE for the duration of the status probe.
+  const body = `#!/bin/sh
+case "$1" in
+  status)
+    if [ ${statusExit} -ne 0 ]; then
+      printf '%s\\n' "SAG Native gateway process is not running." >> "\${TRIM_TEMP_LOGFILE:-/dev/null}"
+    fi
+    exit ${statusExit}
+    ;;
+  stop) exit 0 ;;
+  start) exit 0 ;;
+  *) exit 1 ;;
+esac
+`;
+  await writeFile(path.join(cmdDir, "main"), body);
+  await chmod(path.join(cmdDir, "main"), 0o755);
+}
+
+async function writeStubInstallInit(cmdDir) {
+  // install_init needs to succeed for upgrade_init to proceed past
+  // its first step. The real install_init handles secret provisioning
+  // but is validated separately; here we just no-op it.
+  await writeFile(path.join(cmdDir, "install_init"), "#!/bin/sh\nexit 0\n");
+  await chmod(path.join(cmdDir, "install_init"), 0o755);
+}
+
+test("upgrade_init redirects TRIM_TEMP_LOGFILE while probing main status", async (t) => {
+  const source = await readFile(path.join(cmd, "upgrade_init"), "utf8");
+  // The status probe must run with TRIM_TEMP_LOGFILE pointed at
+  // /dev/null so main's log_error() cannot pollute the fnpack UI.
+  assert.match(source, /TRIM_TEMP_LOGFILE=\/dev\/null[^\n]*"\$main" status/);
+});
+
+test("upgrade_init tolerates a missing Native users directory (Docker→Native transition)", async (t) => {
+  const { cmdDir, logFile, env } = await stageUpgradeFixture(t);
+  await writeStubInstallInit(cmdDir);
+  // Docker version is installed, Native has never run: TRIM_PKGVAR/users
+  // does not exist, and "main status" fails writing its complaint via
+  // log_error(). Both must be handled without user-visible failure.
+  await writeStubMain(cmdDir, { statusExit: 3 });
+
+  const result = spawnSync("bash", [path.join(cmdDir, "upgrade_init")], { encoding: "utf8", env });
+  assert.equal(result.status, 0, `upgrade_init should succeed on Docker→Native transition. stderr=${result.stderr} log=${await readFile(logFile, "utf8")}`);
+  const log = await readFile(logFile, "utf8");
+  // The user-facing surface must NOT contain the status probe's noise.
+  assert.doesNotMatch(log, /gateway process is not running/i);
+  // An informational note tells operators (and future us) what happened.
+  assert.match(log, /no Native users directory/i);
+});
+
+test("upgrade_init also handles the empty users directory case without invoking lifecycle.py", async (t) => {
+  const { cmdDir, pkgvar, logFile, env } = await stageUpgradeFixture(t);
+  await writeStubInstallInit(cmdDir);
+  await writeStubMain(cmdDir, { statusExit: 3 });
+  await mkdir(path.join(pkgvar, "users"));
+  // No lifecycle.py present under TRIM_APPDEST/runtime — if the
+  // script tried to invoke it the run would fail. It must not.
+
+  const result = spawnSync("bash", [path.join(cmdDir, "upgrade_init")], { encoding: "utf8", env });
+  assert.equal(result.status, 0, `upgrade_init should skip backup on an empty users dir. stderr=${result.stderr}`);
+  assert.match(await readFile(logFile, "utf8"), /empty/i);
+});
+
+test("upgrade_init parses under strict /bin/sh (dash on fnOS)", () => {
+  assert.equal(spawnSync("/bin/sh", ["-n", path.join(cmd, "upgrade_init")]).status, 0);
+});
+
+test("upgrade_init never exits silently — every non-zero exit writes a cause to TRIM_TEMP_LOGFILE", async (t) => {
+  // fnpack surfaces empty TRIM_TEMP_LOGFILE as the useless
+  // "执行脚本出错且原因未知" message. Whatever else changes about
+  // this script, that regression must not come back.
+  const { cmdDir, logFile, env } = await stageUpgradeFixture(t);
+  await writeStubInstallInit(cmdDir);
+  await writeStubMain(cmdDir, { statusExit: 3 });
+  // Force a failure at the first environment gate by clearing an
+  // essential fnpack variable. Any failure will do; we're asserting
+  // the *shape* of the log, not the specific message.
+  const result = spawnSync("bash", [path.join(cmdDir, "upgrade_init")], {
+    encoding: "utf8",
+    env: { ...env, TRIM_APPDEST: "" },
+  });
+  assert.notEqual(result.status, 0);
+  const log = await readFile(logFile, "utf8");
+  // Some concrete cause plus the aborting-with-status marker must
+  // be present so fnpack has real content to show the user.
+  assert.match(log, /upgrade_init:/);
+  assert.match(log, /TRIM_APPDEST/i);
+  assert.match(log, /aborting with status/i);
+});
+
+test("upgrade_init tolerates a Docker-era TRIM_APPDEST without lifecycle.py", async (t) => {
+  // fnpack may run upgrade_init BEFORE swapping the new package
+  // payload into TRIM_APPDEST, so runtime/lifecycle.py can be
+  // missing even when there IS Native user data. The script must
+  // not blow up python3 on a nonexistent lifecycle.py in that
+  // window — just skip the backup and let fnpack proceed.
+  const { cmdDir, pkgvar, logFile, env } = await stageUpgradeFixture(t);
+  await writeStubInstallInit(cmdDir);
+  await writeStubMain(cmdDir, { statusExit: 3 });
+  await mkdir(path.join(pkgvar, "users", "user-x"), { recursive: true });
+  // Note: fixture does NOT create appdest/runtime/lifecycle.py.
+
+  const result = spawnSync("bash", [path.join(cmdDir, "upgrade_init")], { encoding: "utf8", env });
+  assert.equal(result.status, 0, `stderr=${result.stderr} log=${await readFile(logFile, "utf8")}`);
+  assert.match(await readFile(logFile, "utf8"), /lifecycle\.py not present/i);
+});
+
+test("Native lifecycle shell scripts parse cleanly", () => {
+  for (const name of ["main", "install_init", "install_callback", "upgrade_init", "upgrade_callback", "uninstall_init", "uninstall_callback", "config_init", "config_callback"]) {
+    assert.equal(spawnSync("bash", ["-n", path.join(cmd, name)]).status, 0, name);
+  }
+});
+
+test("install_init parses under strict /bin/sh (dash) as well as bash", () => {
+  assert.equal(spawnSync("/bin/sh", ["-n", path.join(cmd, "install_init")]).status, 0);
+});
+
+// -----------------------------------------------------------------
+// .19: cross-user secret readability
+// -----------------------------------------------------------------
+// The .18 real-device failure was "SAG Native internal identity secret
+// is unavailable or has unsafe permissions" at start time. Root cause:
+// install_init runs as root but main runs as the sag package user; the
+// dir TRIM_PKGETC was left 0700 root:root by root's umask, so sag could
+// not even traverse it. The perms mismatch was invisible to install
+// (which returned 0) — it only surfaced hours later at start button.
+// These tests pin the fix so a future refactor cannot silently regress
+// back to a 0700-dir installation or a generic prepare_secret message.
+test("install_init forces TRIM_PKGVAR to 0755 and chowns it to the package user", async (t) => {
+  const source = await readFile(path.join(cmd, "install_init"), "utf8");
+  assert.match(source, /chmod 0755 "\$TRIM_PKGVAR"/);
+  assert.match(source, /chown "\$package_user" "\$TRIM_PKGVAR"/);
+});
+
+test("install_init self-checks that the package user can read the secret but does not abort on failure", async (t) => {
+  const source = await readFile(path.join(cmd, "install_init"), "utf8");
+  assert.match(source, /cross-user-selfcheck/);
+  assert.match(source, /runuser -u \$package_user --/);
+  assert.match(source, /su -s \/bin\/sh \$package_user -c/);
+  // .19 wanted this to `die`. .20 downgrades to a warning because
+  // main.prepare_secret self-heals in the same shot.
+  assert.match(source, /main\.start will self-heal/);
+});
+
+test("install_init cross-user self-check succeeds against the current user", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-selfcheck-"));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+
+  const logFile = path.join(fixture, "install.log");
+  await writeFile(logFile, "");
+  const result = run("install_init", baseEnv({ TRIM_PKGVAR: pkgvar, TRIM_TEMP_LOGFILE: logFile }));
+  assert.equal(result.status, 0, `stderr=${result.stderr} log=${await readFile(logFile, "utf8")}`);
+  assert.equal((await stat(pkgvar)).mode & 0o777, 0o755);
+  assert.equal((await stat(path.join(pkgvar, "internal-secret"))).mode & 0o777, 0o600);
+});
+
+test("main.prepare_secret self-heals a missing / unreadable / malformed secret", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  // .20: main is the single source of truth. It must recover, not
+  // itemise-and-die like .19 did.
+  assert.match(source, /prepare_secret returns 0 iff main can safely hand the secret/);
+  assert.match(source, /Slow \/ recovery path — regenerate/);
+  assert.match(source, /generate_secret_material/);
+  // The old .19 composite line that hid causes must not reappear.
+  assert.doesNotMatch(source, /internal identity secret is unavailable or has unsafe permissions/);
+});
+
+test("main.start splits the composite runtime-payload precondition into named checks", async () => {
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  assert.match(source, /python3 missing at \$runtime/);
+  assert.match(source, /node missing at \$node_runtime/);
+  assert.match(source, /web entry missing at \$web_entry/);
+  assert.match(source, /web root missing at \$web_root/);
+  assert.doesNotMatch(source, /test -x "\$runtime" && test -x "\$node_runtime"/);
+});
+
+test("main.prepare_secret regenerates in place when the file is missing", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-prep-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  const fns = source.match(/hex_ok\(\)[\s\S]*?prepare_secret\(\) \{[\s\S]*?\n\}/);
+  assert.ok(fns, "helpers + prepare_secret not found");
+  const logFile = path.join(fixture, "temp.log");
+  await writeFile(logFile, "");
+  const script = `
+    set -u
+    TRIM_PKGVAR="${pkgvar}"
+    TRIM_TEMP_LOGFILE="${logFile}"
+    secret="${pkgvar}/internal-secret"
+    log_error() { printf '%s\\n' "$1" >> "\${TRIM_TEMP_LOGFILE:-/dev/null}"; }
+    ${fns[0]}
+    prepare_secret; exit $?
+  `;
+  const result = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+  assert.equal(result.status, 0, `stderr=${result.stderr} log=${await readFile(logFile, "utf8")}`);
+  const material = await readFile(path.join(pkgvar, "internal-secret"), "utf8");
+  assert.match(material, /^[0-9a-f]{64}$/);
+  assert.equal((await stat(path.join(pkgvar, "internal-secret"))).mode & 0o777, 0o600);
+});
+
+test("main.prepare_secret refuses a symlinked secret rather than following it", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-prep-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  const target = path.join(fixture, "target");
+  await writeFile(target, "0".repeat(64));
+  await symlink(target, path.join(pkgvar, "internal-secret"));
+
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  const fns = source.match(/hex_ok\(\)[\s\S]*?prepare_secret\(\) \{[\s\S]*?\n\}/);
+  const logFile = path.join(fixture, "temp.log");
+  await writeFile(logFile, "");
+  const script = `
+    set -u
+    TRIM_PKGVAR="${pkgvar}"
+    TRIM_TEMP_LOGFILE="${logFile}"
+    secret="${pkgvar}/internal-secret"
+    log_error() { printf '%s\\n' "$1" >> "\${TRIM_TEMP_LOGFILE:-/dev/null}"; }
+    ${fns[0]}
+    prepare_secret; exit $?
+  `;
+  const result = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(await readFile(logFile, "utf8"), /symlink; refusing/i);
+});
+
+test("main.prepare_secret regenerates a malformed secret without operator intervention", async (t) => {
+  const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-prep-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  const pkgvar = path.join(fixture, "pkgvar");
+  await mkdir(pkgvar);
+  await writeFile(path.join(pkgvar, "internal-secret"), "garbage");
+
+  const source = await readFile(path.join(cmd, "main"), "utf8");
+  const fns = source.match(/hex_ok\(\)[\s\S]*?prepare_secret\(\) \{[\s\S]*?\n\}/);
+  const logFile = path.join(fixture, "temp.log");
+  await writeFile(logFile, "");
+  const script = `
+    set -u
+    TRIM_PKGVAR="${pkgvar}"
+    TRIM_TEMP_LOGFILE="${logFile}"
+    secret="${pkgvar}/internal-secret"
+    log_error() { printf '%s\\n' "$1" >> "\${TRIM_TEMP_LOGFILE:-/dev/null}"; }
+    ${fns[0]}
+    prepare_secret; exit $?
+  `;
+  const result = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const material = await readFile(path.join(pkgvar, "internal-secret"), "utf8");
+  assert.match(material, /^[0-9a-f]{64}$/);
 });
 
 test("native main only starts loopback Next before the UDS gateway", async () => {
@@ -135,8 +708,3 @@ test("native main only starts loopback Next before the UDS gateway", async () =>
   assert.doesNotMatch(source, /docker /);
 });
 
-test("Native lifecycle shell scripts parse cleanly", () => {
-  for (const name of ["main", "install_init", "install_callback", "upgrade_init", "upgrade_callback", "uninstall_init", "uninstall_callback", "config_init", "config_callback"]) {
-    assert.equal(spawnSync("bash", ["-n", path.join(cmd, name)]).status, 0, name);
-  }
-});

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -11,13 +11,22 @@ test("fnOS delivery is a single manual publish flow guarded by explicit confirma
   // Manual-only trigger: no push branch, only workflow_dispatch.
   assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.match(workflow, /workflow_dispatch:/);
-  // Version is a required input, not read from the stale Docker manifest.
+  // Version input exists but is OPTIONAL — auto-derived from the latest
+  // main semver tag + the next available fnos build number.
   assert.match(workflow, /version:/);
   assert.match(workflow, /inputs\.version/);
   assert.doesNotMatch(workflow, /packages\/fnos\/sag\/manifest/);
   // Guardrails: only from fnos/develop and only after PUBLISH confirmation.
   assert.match(workflow, /refs\/heads\/fnos\/develop/);
   assert.match(workflow, /inputs\.publish_confirmation.*PUBLISH/);
+  // Version auto-derivation from git tags + release listing.
+  assert.match(workflow, /git tag -l/);
+  assert.match(workflow, /gh release list/);
+  // Validate format: <semver>-fnos.<int> (regex in YAML has escaped dots)
+  assert.match(workflow, /\[1-9\]\[0-9\]\*/);
+  // Two-phase: resolve-version job feeds version to native-x86 job.
+  assert.match(workflow, /resolve-version/);
+  assert.match(workflow, /needs:.*resolve-version/);
   // The build environment must disable window scaling for fnOS.
   assert.match(workflow, /NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0/);
   // fnpack is pinned to the official 1.2.3 binary and verified before use.
@@ -28,8 +37,7 @@ test("fnOS delivery is a single manual publish flow guarded by explicit confirma
   assert.match(workflow, /\$GITHUB_PATH/);
   // Structural tests may shell out to the verified fnpack binary.
   assert.match(workflow, /SAG_FNPACK_TESTS: "1"/);
-  // uv is pinned to a release that resolves current PyPI wheel metadata
-  // (0.6.14 rejected greenlet 3.5.3 manylinux wheels).
+  // uv is pinned to a release that resolves current PyPI wheel metadata.
   assert.match(workflow, /setup-uv@v5/);
   assert.match(workflow, /version: "0\.10\.8"/);
   // Tests and packaging still run.
@@ -38,4 +46,6 @@ test("fnOS delivery is a single manual publish flow guarded by explicit confirma
   assert.match(workflow, /sha256sum/);
   // Release tag encodes the version explicitly.
   assert.match(workflow, /fnos-v\$SAG_VERSION/);
+  // Release notes include base version and SHA256 context.
+  assert.match(workflow, /Base version/);
 });


### PR DESCRIPTION
## 背景

基于真实 fnOS 硬件（N150）上 Docker 版 SAG 覆盖安装 Native 版时的一系列启动失败，以及 main 分支近期累积的多个 bugfix，本次 PR 做三层改进：

1. **安装/启动脚本自愈能力** — 根因是 Docker 版残留的 root:root 文件导致 sag 用户无法读写
2. **启动错误诊断** — 消除"没有任何日志"的静默失败路径
3. **main 分支 bugfix 同步** — 迁入消息落库、日志清理、DeepSeek 兼容

---

## 改动概要

### 1. 安装/启动脚本自愈

- **secret 迁到 TRIM_PKGVAR**：从 `@appconf` 迁到 `@appdata`（package-owned，sag 用户永远可写）
- **`install_init` 递归 chown -R sag**：覆盖 Docker 版残留的 root:root 文件，不破坏数据，best-effort 不阻断安装
- **擦 @appconf 残留**：`rm -f "$TRIM_PKGETC/internal-secret"` 清掉旧版遗留
- **`main.prepare_secret` 自愈**：secret 缺失/不可读/非 64-hex → 就地重生成
- **降级多项 install_init die 为 log**：缺 package user / cross-user 探针 EACCES 不再阻止安装，main 启动时自愈兜底

### 2. 启动错误诊断全覆盖

- **`wait_for_gateway_socket` 早检**：gateway 在 2s 后 valid_pid 失败立即 log_error + gateway.log tail，不再空等 15 秒
- **15s 超时 log_error**：socket 状态 + pid 存活性 + log tail
- **`start` 块 EXIT trap**：任何步骤的非零退出都写 UID/GID + gateway.log tail + secret stat
- **`touch "$gateway_log"` 预检**：log 不可写立即 die
- **socket 目录可写性预警**、**wait_for_web 失败 log_error**、**mkdir -p 返回值检查**

### 3. main 分支 bugfix 同步

| 来源 | 描述 |
|------|------|
| cherry-pick #68 | 失败/取消气泡落库持久化：新增 `MessageStatus` 枚举，`conversation-runtime.ts` 合并逻辑修正 |
| cherry-pick #65 | 「清除日志」按钮真正清空诊断缓冲：加 `diagnostics.clear()` + hook 暴露 |
| 手工合 #50 deepseek | DeepSeek 模型兼容：json_object 模式 + structured output fallback + 全局关闭 thinking |

**平台差异：** `config.py` 中 fnOS 专属字段（`fnos_uid`、`fnos_username` 等）完全保留；`test_units.py` 保留 fnOS 专属密码测试。

---

## 验证

| 层 | 结果 |
|---|---|
| ruff | 0 errors |
| pytest | 362 passed / 2 skipped |
| tsc | OK |
| vitest | 61 files / 433 passed |
| fnos-* shell | 249 passed / 4 skipped / 0 fail |
| FPK .23 首装实测 | ✅ 安装+启动正常 |

## 文件

23 files, +1968 / -103