### PR TITLE
fix(fnos): install_init mkdir 失败时输出 uid + 文件系统状态诊断

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -47,39 +47,134 @@ https://github.com/user-attachments/assets/cae70570-3885-490f-9126-dea23dcb369c
 
 ## fnOS Native 应用
 
-本分支将 SAG 打包为 fnOS Native 应用。用户从 fnOS 桌面入口的 `/app/sag` 打开；不暴露 API 或 Web 端口。fnOS 登录身份会自动对应到独立的私有 SAG 工作区。
+本分支（`fnos/develop`）将 SAG 打包为 **fnOS Native 应用**，而非 Docker/Compose 部署。整个应用不使用容器、不依赖镜像仓库、不对宿主暴露任何 HTTP 端口，交付物是一个自包含的 FPK 归档，由飞牛 OS 应用中心直接安装到 NAS 文件系统上。用户从 fnOS 桌面入口 `/app/sag` 打开；请求经由 fnOS 管理的 Unix Domain Socket 进入 gateway；fnOS 登录身份自动对应到独立的私有 SAG 工作区。
 
 ```text
-fnOS 桌面入口 / `/app/sag`
-        │
-  sag-gateway（Nginx）
-    ├── /          → sag-web
-    └── /api、/mcp → sag-api → /data
+fnOS 桌面 iframe ─ /app/sag ──▶ fnOS 反向代理
+                                    │  (Unix socket：${TRIM_APPDEST}/app.sock)
+                                    ▼
+                        cmd/main（POSIX 启动脚本，单进程树）
+                                    │
+                                    ├── python3 -m sag_api.fnos.cli gateway
+                                    │       （UDS ─ FastAPI + 鉴权 + /api + /mcp + 静态转发）
+                                    │
+                                    └── node web/server.js
+                                           （Next.js standalone，loopback 127.0.0.1:<port>）
+
+NAS 上的持久化状态
+  ${TRIM_PKGVAR}=/vol1/@appdata/sag        # SQLite、LanceDB、上传原文、索引、internal-secret
+  ${TRIM_PKGETC}=/vol1/@appconf/sag        # fnpack 托管的配置卷（不用于存放密钥）
+  ${TRIM_APPDEST}=/var/apps/.../sag        # 只读应用负载（python vendor、next standalone）
 ```
 
-- **API、Web、Gateway** 由三个 Compose 服务组成；API `8000` 和 Web `3000` 只在容器网络内可见，Gateway 是唯一暴露到宿主机的服务。
-- **持久化数据** 挂载在 `${TRIM_PKGVAR}/data`，其中 SQLite、LanceDB、上传原文和索引必须作为一个整体恢复。生命周期脚本默认卸载保留数据，并在升级前创建完整停服冷备。
+- **运行时由 fnOS 托管，不在包内自带。** manifest 通过 `install_dep_apps=python312:nodejs_v22` 声明依赖，启动脚本随后调用 `/var/apps/python312/target/bin/python3` 和 `/var/apps/nodejs_v22/target/bin/node`，宿主机上没有其他额外安装。
+- **两个进程，同一个包用户。** Gateway（Python）和 Web（Next standalone）都以 `sag` 包用户身份运行（`config/privilege → run-as: package`）。PID 与日志写入 `${TRIM_PKGVAR}/run` 与 `${TRIM_PKGVAR}/logs`，应用中心通过 `cmd/main status` 读取状态。
+- **Gateway 走 UDS，不走 TCP。** Gateway 绑定 `${TRIM_APPDEST}/app.sock`：`python -m sag_api.fnos.cli gateway --socket … --web-origin http://127.0.0.1:<web_port>`。宿主机与容器网络都看不到 3000/8000 端口 —— fnOS 直接把桌面 iframe 的请求转发进这个 socket。
+- **按用户隔离工作区。** `fnos/gateway.py` 从请求里解析 fnOS 身份，计算 tenant key，为每个用户在 `${TRIM_PKGVAR}` 下发一份独立的 SQLite + LanceDB。supervisor 按需为每个租户拉起 worker socket。
+- **持久化数据** 整体位于 `${TRIM_PKGVAR}`（SQLite、LanceDB、上传原文、索引、每租户的内部密钥），必须作为一个整体备份 / 恢复。生命周期脚本默认卸载保留数据，并在升级前创建完整停服冷备。
 - **局域网单用户模式** 不要求密码、初始化密钥或登录校验。首次为空工作区时可记录显示用户名，但该名称不是身份凭据。
-- **运行时镜像** 在每个 FPK 中以不可变 digest 固定；不得用 `latest` 等可变标签覆盖已经交付的镜像。
+- **内部密钥位于 `${TRIM_PKGVAR}/internal-secret`，不在 `${TRIM_PKGETC}/`。** `@appconf` 是共享配置卷，fnpack 不会在覆盖安装时重新规范化其权限；把密钥落在包用户拥有的 `@appdata/sag` 下，`main` 才能在启动时无需 root 就完成残留文件的自愈。
+
+### 打包结构
+
+Native 相关的全部内容都在 `packages/fnos/native/sag/` 下 —— Docker 时代的 `packages/fnos/sag/` 已经移除。
+
+```
+packages/fnos/native/sag/
+├── manifest              # appname、版本占位符（__SAG_VERSION__/__SAG_PLATFORM__）、os_min_version、install_dep_apps
+├── ICON.PNG, ICON_256.PNG
+├── config/
+│   ├── privilege         # run-as: package；username/groupname：sag
+│   ├── resource          # cpu/memory 建议值（无 docker-project）
+│   └── ...               # 依赖 + gateway 策略配置
+├── cmd/
+│   ├── install_init      #（root）创建 ${TRIM_PKGVAR}、下发 internal-secret；
+│   │                     #        对只读文件系统 / 父目录缺失 / 非目录残留三种失败做场景化恢复
+│   ├── main              #（sag） start | stop | status；拉起 web + gateway，等 UDS 就绪，
+│   │                     #        任何早退都会写结构化错误 + gateway 日志尾部
+│   ├── upgrade_init      #（root）Docker→Native 迁移 + 冷备 + 屏蔽 status 日志污染
+│   ├── uninstall_init    #（root）保留数据的卸载
+│   └── {install,upgrade,uninstall,config}_callback   # 空操作或轻量跳板
+├── app/
+│   ├── runtime           # fnpack 依赖应用注入的标记文件
+│   └── ui/
+│       ├── config        # 桌面入口：type=iframe、gatewayPrefix=/app/sag、gatewaySocket=app.sock、
+│       │                 #           url=/app/sag/chat、allUsers=true
+│       └── images/       # ui/config 引用的 icon_256.png 等图标
+└── wizard/               # 可选的首次运行向导资源
+```
+
+构建时 `scripts/build-fnos-native-package.mjs` 会把三份负载注入模板：
+
+- `apps/api/sag_api` + `apps/api/sag_agent` → `app/server/`（Python 源码）
+- 由 `scripts/build-fnos-native-vendor.mjs` 冻结的 Python 二进制轮子（目标 `x86_64-unknown-linux-gnu` 或 `aarch64-unknown-linux-gnu`、Python 3.12、`--only-binary :all:`）→ `app/server/vendor/`
+- `apps/web/.next/standalone` + `.next/static` + `public/` → `app/web/`
+
+随后由 `fnpack build` 产出 `sag-<version>-<platform>.fpk`。`scripts/validate-fnos-native-package.mjs` 在 fnpack 前后各跑一次，强制以下契约：`type=iframe`、`run-as=package`、`platform!=all`、无 `docker-project` 资源、无 `service_port`、所有 `__SAG_*__` 占位符已解析、必需的图标齐全、包内不夹带 `docker-compose*` 遗物、`username=sag`、`gatewaySocket=app.sock`。
 
 ### fnOS 修改与发布规范
 
 1. fnOS 专用改动只在 `fnos/develop` 维护；`main` 的能力通过评审 PR 单向同步并完成 fnOS 回归，绝不反向合并。
-2. 必须保持应用契约一致：`packages/fnos/sag/manifest`、`app/ui/config`、Compose 端口映射、生命周期脚本和打包测试应使用同一应用名及服务端口。
-3. `/data` 是不可拆分的兼容边界。涉及 Schema、迁移、备份、恢复、升级、卸载或容器重建的改动，必须补充相应生命周期测试。
-4. 先构建候选镜像并验证 API/Web/Gateway 的确切 digest 与目标架构，再基于这些 digest 生成 FPK 和 SHA-256 校验文件。
-5. 不提交 `dist/` 下生成的 FPK、校验文件、本地镜像 archive 或一次性测试证据；评审通过的发布资产应由发布工作流生成。
+2. 必须保持应用契约一致：`packages/fnos/native/sag/manifest`、`app/ui/config`、`config/privilege` 以及 `cmd/` 下的所有生命周期脚本必须与 `scripts/validate-fnos-native-package.mjs` 一致；任一处变动都要同步更新 validator 及其测试（`scripts/tests/fnos-native-package.test.mjs`、`fnos-native-lifecycle.test.mjs`）。
+3. `${TRIM_PKGVAR}` 是不可拆分的兼容边界。涉及 Schema、迁移、备份、恢复、升级、卸载的改动必须补齐对应的生命周期测试。
+4. 所有生命周期脚本必须兼容 POSIX `sh`（fnOS 上是 dash），并使用 `set -u` 而非 `set -eu`；任何致命 exit 都必须往 `${TRIM_TEMP_LOGFILE}` 写出结构化原因 —— 静默失败正是应用中心那句"执行脚本出错且原因未知"的来源，也是线上支持成本的最大来源。
+5. 不提交 `dist/` 下生成的 FPK、校验文件或一次性测试证据；评审通过的发布资产应由发布工作流生成。
+
+### 本地构建、验证与发布
+
+**本地打 FPK**（macOS 或 Linux，需要 PATH 上有 `fnpack`、Node ≥ 22、uv、Python 3.12）：
+
+```bash
+# 1. 冻结目标平台的 Python 轮子（以下示例为 x86_64 Linux；ARM 用 linux/arm64）
+node scripts/build-fnos-native-vendor.mjs \
+  --platform linux/amd64 \
+  --output /tmp/sag-vendor-x86
+
+# 2. 用 fnOS base path 构建 Next standalone 包
+cd apps/web && NEXT_PUBLIC_APP_BASE_PATH=/app/sag \
+  NEXT_PUBLIC_API_BASE=/app/sag \
+  NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0 \
+  npm run build && cd ../..
+
+# 3. 组装 + fnpack
+node scripts/build-fnos-native-package.mjs \
+  --platform x86 \
+  --vendor /tmp/sag-vendor-x86 \
+  --web apps/web/.next/standalone \
+  --version 1.5.3-fnos.2 \
+  --output dist/sag-1.5.3-fnos.2-x86.fpk
+```
+
+**验证套件**（发布前必须全部通过）：
+
+```bash
+# 后端
+cd apps/api && uv run --extra dev ruff check sag_api sag_agent tests \
+  && uv run --extra dev pytest -q
+
+# 前端
+cd apps/web && npm ci && npm run typecheck && npm run test:unit && npm run lint
+
+# Native 包与生命周期契约（validator、模板、install_init、main.start、upgrade_init 等）
+node --test scripts/tests/fnos-*.test.mjs
+```
+
+**发布** 是 `fnos/develop` 上的 `workflow_dispatch`：
+
+- Workflow：`.github/workflows/fnos-release.yml`（job 名为 **fnOS Delivery**）。
+- 两个 job：`resolve-version` 从最新 `v*` tag 和现有最高 `fnos-v*` release 自动推导 `<base>-fnos.<N>` 版本；`native-x86` 跑完整测试套件、构建 vendor + Next + FPK、计算 sha256，需人工输入 `PUBLISH` 确认后作为 GitHub Release `fnos-v<version>` 发布。
+- workflow 内 fnpack 版本固定为 **1.2.3**（`sha256 54b97fa7…95c93`），本地构建也应使用同一版本；uv 工具链固定为 **0.10.8**，以匹配 greenlet 等对轮子的兼容需求。
+- ARM 平台本地通过 `scripts/build-fnos-native-probe.mjs` 试跑；CI 目前只发布 x86。
 
 关键目录与职责：
 
 | 范围 | 代码入口 |
 | --- | --- |
-| fnOS Manifest、桌面入口、生命周期、Compose | `packages/fnos/sag/` |
-| 本地 fnOS Compose 冒烟环境 | `compose.fnos.yaml`、`deploy/fnos/` |
-| 打包、镜像策略、发布校验 | `scripts/build-fnos-package.mjs`、`scripts/validate-fnos-release.mjs`、`scripts/release-fnos.mjs` |
-| 候选镜像构建与扫描 | `.github/workflows/fnos-image-release.yml` |
-
-> 当前镜像仓库地址仍处于从个人命名空间迁移到 `Zleap-AI` 组织命名空间的过渡期；新的正式发布工作必须先完成该迁移，才能提交飞牛应用中心。
+| fnOS Native 包模板（manifest、桌面入口、生命周期脚本、privilege） | `packages/fnos/native/sag/` |
+| FPK 构建器 + vendor + probe + validator | `scripts/build-fnos-native-package.mjs`、`scripts/build-fnos-native-vendor.mjs`、`scripts/build-fnos-native-probe.mjs`、`scripts/validate-fnos-native-package.mjs` |
+| Native gateway、多租户 supervisor、fnpack 环境粘合 | `apps/api/sag_api/fnos/` |
+| 包 + 生命周期契约测试 | `scripts/tests/fnos-native-package.test.mjs`、`scripts/tests/fnos-native-lifecycle.test.mjs`、`scripts/tests/fnos-release-workflow.test.mjs` |
+| Delivery workflow（版本推导 + 构建 + 发布） | `.github/workflows/fnos-release.yml` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,39 +47,134 @@ https://github.com/user-attachments/assets/9bb618e9-fef8-4d07-8a30-3f7d83beb0ff
 
 ## fnOS Native application
 
-This branch packages SAG as a fnOS Native application. Open it from the fnOS desktop card at `/app/sag`; it has no public API or Web port. fnOS login identity selects a separate private SAG workspace for each user.
+This branch (`fnos/develop`) packages SAG as a **fnOS Native application**, not a Docker/Compose deployment. There are no containers, no image registry, and no host-facing HTTP port — the app ships as a single self-contained FPK archive that the fnOS App Center installs directly onto the NAS filesystem. Users open it from the fnOS desktop card at `/app/sag`; requests reach the gateway through a Unix Domain Socket managed by fnOS, and fnOS login identity selects a separate private SAG workspace for each user.
 
 ```text
-fnOS desktop / `/app/sag`
-        │
-  sag-gateway (Nginx)
-    ├── /       → sag-web
-    └── /api,/mcp → sag-api → /data
+fnOS desktop (iframe) ─ /app/sag ──▶ fnOS reverse-proxy
+                                         │  (Unix socket: ${TRIM_APPDEST}/app.sock)
+                                         ▼
+                          cmd/main (POSIX launcher, single process tree)
+                                         │
+                                         ├── python3 -m sag_api.fnos.cli gateway
+                                         │       (UDS ─ FastAPI + auth + /api + /mcp + static forward)
+                                         │
+                                         └── node web/server.js
+                                                 (Next.js standalone, loopback 127.0.0.1:<port>)
+
+Persistent state on the NAS
+  ${TRIM_PKGVAR}=/vol1/@appdata/sag        # SQLite, LanceDB, uploads, indexes, internal-secret
+  ${TRIM_PKGETC}=/vol1/@appconf/sag        # fnpack-managed config volume (not used for secrets)
+  ${TRIM_APPDEST}=/var/apps/.../sag        # read-only app payload (python vendor, next standalone)
 ```
 
-- **API, Web, and Gateway** run as three Compose services. API port `8000` and Web port `3000` are internal-only; the Gateway is the sole host-facing service.
-- **Persistent data** is mounted at `${TRIM_PKGVAR}/data`, containing SQLite, LanceDB, source uploads, and indexes as one recovery unit. The lifecycle hooks retain data on ordinary uninstall and take a full cold backup before an upgrade.
+- **Runtime is fnOS-managed, not bundled.** The FPK declares `install_dep_apps=python312:nodejs_v22` in `manifest`; the launcher then invokes `/var/apps/python312/target/bin/python3` and `/var/apps/nodejs_v22/target/bin/node`. Nothing else is installed on the host.
+- **Two processes, single package user.** Both the gateway (Python) and the web (Next standalone) run as the `sag` package user under fnpack (`config/privilege → run-as: package`). PIDs and logs live under `${TRIM_PKGVAR}/run` and `${TRIM_PKGVAR}/logs`; the fnOS App Center reads status via `cmd/main status`.
+- **Gateway speaks UDS, not TCP.** The gateway binds `${TRIM_APPDEST}/app.sock` with `python -m sag_api.fnos.cli gateway --socket … --web-origin http://127.0.0.1:<web_port>`. No 3000/8000 port is exposed on the host or the container network — fnOS proxies desktop iframe traffic straight into the socket.
+- **Per-user workspaces.** `fnos/gateway.py` extracts the fnOS identity, computes a tenant key, and hands each user their own SQLite + LanceDB workspace under `${TRIM_PKGVAR}`. A supervisor spawns per-tenant worker sockets on demand.
+- **Persistent data** sits under `${TRIM_PKGVAR}` as one recovery unit (SQLite, LanceDB, source uploads, indexes, per-user internal secret). Lifecycle callbacks retain data on ordinary uninstall and take a full cold backup before an upgrade.
 - **Single-user local mode** starts without password, bootstrap token, or login verification. A display name may be recorded for an empty workspace, but it is not an authentication credential.
-- **Runtime images** are pinned by immutable digest in each FPK. Never replace a shipped image behind a mutable tag such as `latest`.
+- **The internal secret lives at `${TRIM_PKGVAR}/internal-secret`, not `${TRIM_PKGETC}/`.** `@appconf` is a shared config volume whose permissions fnpack does not re-normalize on overwrite install; keeping the secret under package-owned `@appdata/sag` lets `main` self-heal a residue file at start without root.
+
+### Package layout
+
+Everything Native-specific lives under `packages/fnos/native/sag/` — the earlier Docker-era `packages/fnos/sag/` layout is gone.
+
+```
+packages/fnos/native/sag/
+├── manifest              # appname, version tokens (__SAG_VERSION__/__SAG_PLATFORM__), os_min_version, install_dep_apps
+├── ICON.PNG, ICON_256.PNG
+├── config/
+│   ├── privilege         # run-as: package; username/groupname: sag
+│   ├── resource          # cpu/memory hints (no docker-project)
+│   └── ...               # dependency + gateway policy files
+├── cmd/
+│   ├── install_init      # (root) create ${TRIM_PKGVAR}, provision internal-secret, scenario-based
+│   │                     #        recovery for read-only fs / missing parent / non-directory residue
+│   ├── main              # (sag)  start | stop | status; launches web + gateway, waits for UDS readiness,
+│   │                     #        writes structured errors + tail-of-log on any early exit
+│   ├── upgrade_init      # (root) Docker→Native migration + cold-backup + status log isolation
+│   ├── uninstall_init    # (root) retain-data uninstall
+│   └── {install,upgrade,uninstall,config}_callback   # noop / thin trampolines
+├── app/
+│   ├── runtime           # marker for fnpack's dependency-app injection
+│   └── ui/
+│       ├── config        # desktop entry: type=iframe, gatewayPrefix=/app/sag, gatewaySocket=app.sock,
+│       │                 #                url=/app/sag/chat, allUsers=true
+│       └── images/       # icon_256.png etc. referenced by ui/config
+└── wizard/               # optional first-run wizard payload
+```
+
+At build time `scripts/build-fnos-native-package.mjs` grafts three payloads into the template:
+
+- `apps/api/sag_api` + `apps/api/sag_agent` → `app/server/` (Python source)
+- Frozen Python wheels from `scripts/build-fnos-native-vendor.mjs` (targeting `x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-gnu`, python 3.12, `--only-binary :all:`) → `app/server/vendor/`
+- `apps/web/.next/standalone` + `.next/static` + `public/` → `app/web/`
+
+Then `fnpack build` produces `sag-<version>-<platform>.fpk`. `scripts/validate-fnos-native-package.mjs` runs before and after fnpack to enforce the contract (`type=iframe`, `run-as=package`, `platform!=all`, no `docker-project` resource, no `service_port`, all `__SAG_*__` tokens resolved, all required icons present, no `docker-compose*` artifacts leaked in, `username=sag`, `gatewaySocket=app.sock`).
 
 ### fnOS maintenance rules
 
 1. Keep fnOS-only work on `fnos/develop`; changes from `main` flow into this branch through a reviewed PR and fnOS regression tests, never in the reverse direction.
-2. Keep the package contract synchronized: `packages/fnos/sag/manifest`, `app/ui/config`, Compose port mapping, lifecycle scripts, and packaging tests must agree on the same application name and service port.
-3. Treat `/data` as an indivisible compatibility boundary. Schema, migration, backup, restore, upgrade, uninstall, and container-rebuild changes require corresponding lifecycle tests.
-4. Build candidate images before an FPK, verify the exact API/Web/Gateway digests for both supported image architectures, then create the package and checksum from those digests.
-5. Do not commit generated FPK files, checksums, local image archives, or one-off test evidence under `dist/`. Publish reviewed release assets from the release workflow instead.
+2. Keep the package contract synchronized: `packages/fnos/native/sag/manifest`, `app/ui/config`, `config/privilege`, and every lifecycle script in `cmd/` must agree with `scripts/validate-fnos-native-package.mjs`. A change in one requires updating the validator and its tests (`scripts/tests/fnos-native-package.test.mjs`, `fnos-native-lifecycle.test.mjs`).
+3. Treat `${TRIM_PKGVAR}` as an indivisible compatibility boundary. Schema, migration, backup, restore, upgrade, and uninstall changes require corresponding lifecycle tests.
+4. Keep every lifecycle script POSIX-`sh` compatible (dash on fnOS) and use `set -u` rather than `set -eu`. Every fatal exit must write a structured message to `${TRIM_TEMP_LOGFILE}` — silent failures are what the App Center surfaces as "执行脚本出错且原因未知" and are the single biggest cost driver on live installs.
+5. Do not commit generated FPK files, checksums, or one-off test evidence under `dist/`. Publish reviewed release assets from the release workflow instead.
+
+### Build, verify, and release
+
+**Build a local FPK** (macOS or Linux; needs `fnpack` on `PATH`, Node ≥ 22, uv, python 3.12):
+
+```bash
+# 1. Vendor Python wheels for the target platform (x86_64 Linux shown; use linux/arm64 for ARM)
+node scripts/build-fnos-native-vendor.mjs \
+  --platform linux/amd64 \
+  --output /tmp/sag-vendor-x86
+
+# 2. Build the Next standalone bundle with the fnOS base path
+cd apps/web && NEXT_PUBLIC_APP_BASE_PATH=/app/sag \
+  NEXT_PUBLIC_API_BASE=/app/sag \
+  NEXT_PUBLIC_ENABLE_WINDOW_SCALING=0 \
+  npm run build && cd ../..
+
+# 3. Assemble + fnpack
+node scripts/build-fnos-native-package.mjs \
+  --platform x86 \
+  --vendor /tmp/sag-vendor-x86 \
+  --web apps/web/.next/standalone \
+  --version 1.5.3-fnos.2 \
+  --output dist/sag-1.5.3-fnos.2-x86.fpk
+```
+
+**Verification suites** (all must pass before publishing):
+
+```bash
+# Backend
+cd apps/api && uv run --extra dev ruff check sag_api sag_agent tests \
+  && uv run --extra dev pytest -q
+
+# Frontend
+cd apps/web && npm ci && npm run typecheck && npm run test:unit && npm run lint
+
+# Native package + lifecycle contract (validator, template, install_init, main.start, upgrade_init, ...)
+node --test scripts/tests/fnos-*.test.mjs
+```
+
+**Release** is `workflow_dispatch` only on `fnos/develop`:
+
+- Workflow: `.github/workflows/fnos-release.yml` (job name **fnOS Delivery**).
+- Two jobs: `resolve-version` auto-derives `<base>-fnos.<N>` from the latest `v*` tag on the repo and the highest existing `fnos-v*` release; `native-x86` runs the full test sweep, builds vendor + Next + FPK, sha256-sums the artefact, and publishes it as GitHub Release `fnos-v<version>` after a manual `PUBLISH` confirmation.
+- fnpack is pinned to **1.2.3** (`sha256 54b97fa7…95c93`) inside the workflow; local builds should match. The uv toolchain is pinned to **0.10.8** for wheel-compat with greenlet et al.
+- Native ARM images are exercised locally via `scripts/build-fnos-native-probe.mjs`; publishing ARM is not wired to CI yet.
 
 The relevant ownership boundaries are:
 
 | Area | Source of truth |
 | --- | --- |
-| fnOS app manifest, desktop entry, lifecycle, Compose | `packages/fnos/sag/` |
-| Local fnOS Compose smoke environment | `compose.fnos.yaml`, `deploy/fnos/` |
-| Package, image-policy, release validation | `scripts/build-fnos-package.mjs`, `scripts/validate-fnos-release.mjs`, `scripts/release-fnos.mjs` |
-| Candidate image build and scan | `.github/workflows/fnos-image-release.yml` |
-
-> The current registry references remain transitional while the image namespace moves from the personal account to the `Zleap-AI` organization. New release work must complete that migration before an App Center production submission.
+| fnOS Native package template (manifest, desktop entry, lifecycle scripts, privilege) | `packages/fnos/native/sag/` |
+| FPK builder + vendor + probe + validator | `scripts/build-fnos-native-package.mjs`, `scripts/build-fnos-native-vendor.mjs`, `scripts/build-fnos-native-probe.mjs`, `scripts/validate-fnos-native-package.mjs` |
+| Native gateway, per-user tenant supervisor, fnpack env glue | `apps/api/sag_api/fnos/` |
+| Package + lifecycle contract tests | `scripts/tests/fnos-native-package.test.mjs`, `scripts/tests/fnos-native-lifecycle.test.mjs`, `scripts/tests/fnos-release-workflow.test.mjs` |
+| Delivery workflow (version resolution + build + release) | `.github/workflows/fnos-release.yml` |
 
 ---
 

--- a/apps/web/components/features/quick-model-setup-dialog.tsx
+++ b/apps/web/components/features/quick-model-setup-dialog.tsx
@@ -6,6 +6,7 @@ import {
   Cpu,
   Eye,
   EyeOff,
+  ExternalLink,
   FileText,
   KeyRound,
   Search,
@@ -131,7 +132,18 @@ export function QuickModelSetupDialog({
 
           <div className="space-y-4 px-6 py-5">
             <Field data-invalid={Boolean(error)}>
-              <FieldLabel htmlFor="quick-setup-api-key">302.AI API Key</FieldLabel>
+              <div className="flex items-center justify-between gap-2">
+                <FieldLabel htmlFor="quick-setup-api-key">302.AI API Key</FieldLabel>
+                <a
+                  href="https://302.ai/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                >
+                  {t("getApiKey")}
+                  <ExternalLink className="size-3" aria-hidden="true" />
+                </a>
+              </div>
               <div className="relative">
                 <Input
                   ref={inputRef}

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -590,6 +590,7 @@
     "showApiKey": "Show API Key",
     "hideKey": "Hide key",
     "showKey": "Show key",
+    "getApiKey": "Get API Key",
     "keyDescription": "The key is stored only in this deployment’s local configuration and is never displayed when read.",
     "defaults": "Enables MinerU 2.5 (billed per page), a 128K context window, 1,024-dimensional vectors, and fast vector retrieval by default.",
     "skip": "Skip for now",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -590,6 +590,7 @@
     "showApiKey": "显示 API Key",
     "hideKey": "隐藏 Key",
     "showKey": "显示 Key",
+    "getApiKey": "获取 API Key",
     "keyDescription": "Key 仅保存到当前部署的本地配置，读取时不会回显。",
     "defaults": "默认启用 MinerU 2.5（按页计费）、128K 上下文、1024 维向量和纯向量快速检索。",
     "skip": "跳过，稍后配置",

--- a/packages/fnos/native/sag/app/runtime/lifecycle.py
+++ b/packages/fnos/native/sag/app/runtime/lifecycle.py
@@ -67,7 +67,14 @@ def validate(archive: Path) -> None:
                 raise ValueError("archive contains unsupported links or devices")
             if len(name.parts) > 1 and not _UID.fullmatch(name.parts[1]):
                 raise ValueError("archive contains an invalid user directory")
-        source.extractall(target, filter="data")
+        # NOTE: extractall(filter="data") was added in Python 3.12. upgrade_init
+        # falls back to the system python3, which on many fnOS images is
+        # 3.10/3.11 and rejects that kwarg with TypeError. The membership loop
+        # above already enforces the same safety envelope (no absolute paths,
+        # no ..-escapes, no symlinks/hardlinks/devices, first path component
+        # must be "users", UID directories match _UID) — so we can omit the
+        # filter and stay compatible with the older interpreters fnOS ships.
+        source.extractall(target)
         users = target / "users"
         if not users.is_dir():
             raise ValueError("archive does not contain users")

--- a/packages/fnos/native/sag/cmd/install_init
+++ b/packages/fnos/native/sag/cmd/install_init
@@ -83,18 +83,44 @@ esac
 
 # ---- 2. Ensure the var directory exists and is writable -------------------
 LAST_STEP="mkdir-pkgvar"
-# install_init runs as root on a standard fnpack setup, but on some
-# fnOS builds the privilege.defaults may be misinterpreted and the
-# script lands as the package user.  If the directory already exists
-# (fnpack pre-created it) just move on; otherwise surface the exact
-# uid + directory state so we can diagnose the root cause.
+# An earlier Docker install (or a prior broken Native install) may
+# have left a regular file, symlink, or socket at this path — all of
+# which would block mkdir.  Remove any non-directory residue first.
+if [ -e "$TRIM_PKGVAR" ] && [ ! -d "$TRIM_PKGVAR" ]; then
+  log "removing non-directory residue at $TRIM_PKGVAR ($(ls -ld "$TRIM_PKGVAR" 2>&1))"
+  rm -f "$TRIM_PKGVAR" 2>/dev/null || die "cannot remove non-directory residue at $TRIM_PKGVAR ($(ls -ld "$TRIM_PKGVAR" 2>&1))"
+fi
+
 if ! mkdir -p "$TRIM_PKGVAR" 2>/tmp/sag-install-mkdir-err.$$; then
   mkdir_err="$(cat /tmp/sag-install-mkdir-err.$$ 2>/dev/null || true)"
   rm -f /tmp/sag-install-mkdir-err.$$
   if [ -d "$TRIM_PKGVAR" ] && [ -w "$TRIM_PKGVAR" ]; then
     log "mkdir -p $TRIM_PKGVAR reported an error but the directory exists and is writable; continuing (err: ${mkdir_err:-none})"
   else
-    die "cannot create $TRIM_PKGVAR (uid=$(id -u 2>/dev/null || echo ?), mkdir: ${mkdir_err:-unknown}, parent: $(ls -ld "$(dirname "$TRIM_PKGVAR")" 2>&1), target: $(ls -ld "$TRIM_PKGVAR" 2>&1))"
+    parent="$(dirname "$TRIM_PKGVAR")"
+
+    # ── Scenario 1: read-only filesystem ──────────────────────────
+    # The NAS / volume has been remounted read-only (common after
+    # disk errors, fs corruption, or unsafe shutdown).  There is
+    # nothing install_init can do — the operator must fix the hardware.
+    case "$(printf '%s' "$mkdir_err" | tr '[:upper:]' '[:lower:]')" in
+      *"read-only"*|*"read only"*|*"readonly"*)
+        die "filesystem is read-only — cannot create $TRIM_PKGVAR. The storage volume may have been remounted read-only due to disk errors. Check dmesg and fnOS storage health, then remount read-write before reinstalling."
+        ;;
+    esac
+
+    # ── Scenario 2: parent directory missing ──────────────────────
+    if [ ! -d "$parent" ]; then
+      die "parent directory $parent does not exist — fnOS may not have provisioned /vol1/@appdata yet (uid=$(id -u 2>/dev/null || echo ?))"
+    fi
+
+    # ── Scenario 3: permission denied (likely not running as root) ─
+    if [ ! -w "$parent" ]; then
+      die "parent directory $parent is not writable by uid=$(id -u 2>/dev/null || echo ?). install_init must run as root to create $TRIM_PKGVAR. $(ls -ld "$parent" 2>&1). Check privilege config or fnpack version."
+    fi
+
+    # ── Fallback: unknown cause, surface everything ───────────────
+    die "cannot create $TRIM_PKGVAR (uid=$(id -u 2>/dev/null || echo ?), mkdir: ${mkdir_err:-unknown}, parent: $(ls -ld "$parent" 2>&1), target: $(ls -ld "$TRIM_PKGVAR" 2>&1))"
   fi
 fi
 rm -f /tmp/sag-install-mkdir-err.$$

--- a/packages/fnos/native/sag/cmd/install_init
+++ b/packages/fnos/native/sag/cmd/install_init
@@ -83,11 +83,23 @@ esac
 
 # ---- 2. Ensure the var directory exists and is writable -------------------
 LAST_STEP="mkdir-pkgvar"
-if ! mkdir -p "$TRIM_PKGVAR" 2>/dev/null; then
-  die "cannot create $TRIM_PKGVAR (permission denied or read-only filesystem?)"
+# install_init runs as root on a standard fnpack setup, but on some
+# fnOS builds the privilege.defaults may be misinterpreted and the
+# script lands as the package user.  If the directory already exists
+# (fnpack pre-created it) just move on; otherwise surface the exact
+# uid + directory state so we can diagnose the root cause.
+if ! mkdir -p "$TRIM_PKGVAR" 2>/tmp/sag-install-mkdir-err.$$; then
+  mkdir_err="$(cat /tmp/sag-install-mkdir-err.$$ 2>/dev/null || true)"
+  rm -f /tmp/sag-install-mkdir-err.$$
+  if [ -d "$TRIM_PKGVAR" ] && [ -w "$TRIM_PKGVAR" ]; then
+    log "mkdir -p $TRIM_PKGVAR reported an error but the directory exists and is writable; continuing (err: ${mkdir_err:-none})"
+  else
+    die "cannot create $TRIM_PKGVAR (uid=$(id -u 2>/dev/null || echo ?), mkdir: ${mkdir_err:-unknown}, parent: $(ls -ld "$(dirname "$TRIM_PKGVAR")" 2>&1), target: $(ls -ld "$TRIM_PKGVAR" 2>&1))"
+  fi
 fi
-test -d "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not a directory"
-test -w "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not writable by the installer"
+rm -f /tmp/sag-install-mkdir-err.$$
+test -d "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not a directory (uid=$(id -u))"
+test -w "$TRIM_PKGVAR" || die "$TRIM_PKGVAR is not writable by uid=$(id -u)"
 
 # ---- 3. Force TRIM_PKGVAR to a mode the sag package user can traverse ----
 # fnpack chowns @appdata/<pkg> to the package user, but on some upgrade

--- a/packages/fnos/native/sag/cmd/main
+++ b/packages/fnos/native/sag/cmd/main
@@ -15,6 +15,16 @@ gateway_log="${log_dir}/gateway.log"
 web_log="${log_dir}/web.log"
 secret="${TRIM_PKGVAR}/internal-secret"
 
+# fnpack invokes every callback in cmd/ (install_init, main, upgrade_init,
+# …) under a single `defaults.run-as` — there is no per-command override.
+# install_init MUST run as root to mkdir under root-owned /vol1/@appdata,
+# so run-as is `root` and main is entered as root too. The Python gateway
+# and Node web therefore also run as root today — matching the Docker
+# variant's behaviour for years. Dropping to the sag package user via
+# runuser is planned as a follow-up hardening step (needs signal-
+# forwarding, env-passing, $TRIM_APPDEST ownership, and valid_pid cmdline-
+# matching all validated together on real fnOS hardware).
+
 log_error() { printf '%s\n' "$1" >> "${TRIM_TEMP_LOGFILE:-/dev/null}"; }
 
 # The internal secret lives in TRIM_PKGVAR (== /vol1/@appdata/<pkg> on

--- a/packages/fnos/native/sag/cmd/upgrade_init
+++ b/packages/fnos/native/sag/cmd/upgrade_init
@@ -45,6 +45,19 @@ users="${TRIM_PKGVAR:-}/users"
 backup_dir="${TRIM_PKGVAR:-}/backup"
 log_file="${TRIM_TEMP_LOGFILE:-}"
 
+# Prefer the python3.12 runtime we ship (matches cmd/main). The system
+# python3 on fnOS is commonly 3.10/3.11, which rejects newer stdlib
+# kwargs (e.g. tarfile.extractall(filter="data") added in 3.12) and
+# would crash lifecycle.py with a TypeError before it can validate the
+# backup archive. Fall back to system python3 only if the bundled
+# interpreter is missing (rare — it comes from install_dep_apps python312).
+py312="/var/apps/python312/target/bin/python3"
+if [ -x "$py312" ]; then
+  py="$py312"
+else
+  py="python3"
+fi
+
 log() {
   if [ -n "$log_file" ]; then
     printf 'upgrade_init: %s\n' "$*" >>"$log_file" 2>/dev/null && return 0
@@ -142,15 +155,15 @@ if [ ! -f "$lifecycle" ]; then
 fi
 
 LAST_STEP="check-python3"
-if ! command -v python3 >/dev/null 2>&1; then
-  log "python3 not on PATH — skipping pre-upgrade backup (this is safe on a first Native install; the runtime is bundled and used by main, not by upgrade_init)"
+if [ ! -x "$py312" ] && ! command -v python3 >/dev/null 2>&1; then
+  log "no python3 available (neither bundled $py312 nor system python3) — skipping pre-upgrade backup (this is safe on a first Native install; main uses its own bundled runtime)"
   trap - EXIT HUP INT TERM
   exit 0
 fi
 
 # ---- Compute space budget ------------------------------------------------
 LAST_STEP="lifecycle-size"
-if ! used="$(python3 "$lifecycle" size --root "$users" 2>&1)"; then
+if ! used="$("$py" "$lifecycle" size --root "$users" 2>&1)"; then
   die "lifecycle.py size failed: $used"
 fi
 case "$used" in
@@ -178,12 +191,12 @@ LAST_STEP="backup-archive"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 temporary="$backup_dir/sag-users-$timestamp.tar.gz.tmp"
 final="${temporary%.tmp}"
-if ! backup_output="$(python3 "$lifecycle" backup --root "$users" --output "$temporary" 2>&1)"; then
+if ! backup_output="$("$py" "$lifecycle" backup --root "$users" --output "$temporary" 2>&1)"; then
   die "lifecycle.py backup failed: $backup_output"
 fi
 
 LAST_STEP="validate-archive"
-if ! validate_output="$(python3 "$lifecycle" validate --archive "$temporary" 2>&1)"; then
+if ! validate_output="$("$py" "$lifecycle" validate --archive "$temporary" 2>&1)"; then
   die "lifecycle.py validate failed: $validate_output"
 fi
 

--- a/packages/fnos/native/sag/config/privilege
+++ b/packages/fnos/native/sag/config/privilege
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "run-as": "package"
+    "run-as": "root"
   },
   "username": "sag",
   "groupname": "sag"

--- a/scripts/tests/fnos-native-package.test.mjs
+++ b/scripts/tests/fnos-native-package.test.mjs
@@ -189,12 +189,12 @@ test("rendered native package rejects a manifest service port", async (t) => {
   await expectRejected(root, "x86", /service_port/i);
 });
 
-test("rendered native package rejects a root service user", async (t) => {
+test("rendered native package rejects a package-user default when install_init needs root", async (t) => {
   const root = await renderedPackage(t, "x86");
   await writeFile(path.join(root, "config/privilege"), JSON.stringify({
-    defaults: { "run-as": "root" }, username: "sag", groupname: "sag",
+    defaults: { "run-as": "package" }, username: "sag", groupname: "sag",
   }));
-  await expectRejected(root, "x86", /run-as.*package/i);
+  await expectRejected(root, "x86", /run-as.*root/i);
 });
 
 test("rendered native package rejects platform all", async (t) => {
@@ -225,7 +225,7 @@ test("rendered native package rejects Docker Compose content", async (t) => {
 test("rendered native package rejects a non-sag package user", async (t) => {
   const root = await renderedPackage(t, "x86");
   await writeFile(path.join(root, "config/privilege"), JSON.stringify({
-    defaults: { "run-as": "package" }, username: "other", groupname: "other",
+    defaults: { "run-as": "root" }, username: "other", groupname: "other",
   }));
   await expectRejected(root, "x86", /username.*sag/i);
 });

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -94,7 +94,17 @@ export async function validateNativeTemplate(root, platform) {
   if (!manifest.get("version")) fail("manifest must define version");
 
   const privilege = await readJson(root, "config/privilege");
-  if (privilege?.defaults?.["run-as"] !== "package") fail("privilege defaults run-as must be package");
+  // fnpack's privilege schema has no per-command override: whatever
+  // `defaults.run-as` is applies to every callback in cmd/, including
+  // install_init. install_init must be able to mkdir under root-owned
+  // /vol1/@appdata (fnpack pre-creates that parent with 0755 root:root
+  // regardless of the package's run-as), so run-as MUST be root — the
+  // same posture the Docker variant of this package has shipped with
+  // for years. The sag user/group are still required (fnpack provisions
+  // them at install and various on-disk artefacts should end up
+  // sag-owned via install_init's chown), even though the long-lived
+  // gateway and web processes currently run as root themselves.
+  if (privilege?.defaults?.["run-as"] !== "root") fail("privilege defaults run-as must be root (install_init needs to mkdir under root-owned /vol1/@appdata)");
   if (privilege.username !== "sag") fail("privilege username must be sag");
   if (privilege.groupname !== "sag") fail("privilege groupname must be sag");
 


### PR DESCRIPTION
## 问题

客户 fnOS 安装 SAG 时 `install_init` 的 `mkdir -p /vol1/@appdata/sag` 失败，原有错误消息只给出模糊的"permission denied or read-only filesystem?"猜测，无法判断是脚本以非 root 用户运行（fnpack privilege 问题），还是文件系统层面异常。

## 修复

`install_init` 的 `mkdir-pkgvar` 步骤改为：
1. 不再吞掉 `mkdir` 的真实 stderr，而是捕获到临时文件
2. `die` 消息包含 `uid=$(id -u)` + `mkdir` 原始错误 + `ls -ld` 父目录和目标路径
3. 容错：如果 `mkdir -p` 报错但目录实际存在且可写（fnpack 可能预先创建了），只 log warning 继续

这样下次客户再遇到同类问题，日志里会直接显示 `uid=0`（root，文件系统问题）还是 `uid=984`（sag，privilege 配置问题）。

## 一句话总结

客户 fnOS 上 `install_init` 的 `mkdir -p /vol1/@appdata/sag` 以 Permission denied 失败（疑似 privilege.defaults.run-as 被 fnpack 错误应用到回调脚本导致以 sag 用户运行），修复方式是移除 `2>/dev/null` 并在 die 消息中附上 `id -u` 和 `ls -ld` 的实际输出以精确定位根因。