### PR TITLE
fix(api): bound upload reads before size checks

### DIFF
--- a/apps/api/sag_api/api/v1/attachments.py
+++ b/apps/api/sag_api/api/v1/attachments.py
@@ -51,8 +51,9 @@ async def upload(
     media_type = _ALLOWED.get(ext)
     if media_type is None:
         raise ValidationError("仅支持图片附件（png / jpg / webp / gif）")
-    data = await file.read()
-    if len(data) > _MAX_MB * 1024 * 1024:
+    max_upload_bytes = _MAX_MB * 1024 * 1024
+    data = await file.read(max_upload_bytes + 1)
+    if len(data) > max_upload_bytes:
         raise ValidationError(f"图片过大（上限 {_MAX_MB}MB）")
     attachment_id = f"{uuid.uuid4().hex}{ext}"
     with open(os.path.join(_dir(), attachment_id), "wb") as f:

--- a/apps/api/sag_api/api/v1/documents.py
+++ b/apps/api/sag_api/api/v1/documents.py
@@ -67,10 +67,11 @@ async def upload(
 ) -> DocumentOut:
     source = await get_source(session, source_id)
     _check_extension(file.filename)
-    data = await file.read()
+    max_upload_bytes = settings.max_upload_mb * 1024 * 1024
+    data = await file.read(max_upload_bytes + 1)
     if not data:
         raise ValidationError("文件内容为空")
-    if len(data) > settings.max_upload_mb * 1024 * 1024:
+    if len(data) > max_upload_bytes:
         raise ValidationError(f"文件超过 {settings.max_upload_mb}MB 上限")
     document, _job = await create_document_from_upload(
         session,

--- a/apps/api/tests/test_upload_limits.py
+++ b/apps/api/tests/test_upload_limits.py
@@ -1,0 +1,59 @@
+"""上傳端點的記憶體容量防護。"""
+
+import pytest
+
+from sag_api.core.errors import ValidationError
+
+
+class RecordingUpload:
+    filename = "oversized.md"
+    content_type = "text/markdown"
+
+    def __init__(self) -> None:
+        self.read_sizes: list[int] = []
+
+    async def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        return b"x"
+
+
+@pytest.mark.asyncio
+async def test_document_upload_reads_only_limit_plus_one_byte(monkeypatch):
+    from sag_api.api.v1 import documents
+
+    async def get_source(_session, _source_id):
+        return object()
+
+    upload = RecordingUpload()
+    monkeypatch.setattr(documents, "get_source", get_source)
+    monkeypatch.setattr(documents.settings, "max_upload_mb", 0)
+
+    with pytest.raises(ValidationError, match="0MB"):
+        await documents.upload(
+            "source-id",
+            file=upload,
+            _user=object(),
+            session=object(),
+            job_queue=object(),
+        )
+
+    assert upload.read_sizes == [1]
+
+
+@pytest.mark.asyncio
+async def test_attachment_upload_reads_only_limit_plus_one_byte(monkeypatch):
+    from sag_api.api.v1 import attachments
+
+    upload = RecordingUpload()
+    upload.filename = "oversized.png"
+    upload.content_type = "image/png"
+    monkeypatch.setattr(attachments, "_MAX_MB", 0)
+
+    with pytest.raises(ValidationError, match="0MB"):
+        await attachments.upload(
+            file=upload,
+            _user=object(),
+            _session=object(),
+        )
+
+    assert upload.read_sizes == [1]


### PR DESCRIPTION
## Summary

- bound document upload reads to the configured limit plus one byte
- apply the same bounded-read behavior to image attachments
- add regression tests for both upload endpoints

## Root cause

Both endpoints called `await file.read()` without a size and checked the byte count only
afterward. An oversized upload could therefore be copied into application memory in full
before the configured 25 MB or 10 MB limit rejected it.

## Impact

Oversized uploads are now detected after reading at most `limit + 1` bytes into application
memory. Existing size limits, successful upload behavior, and validation messages remain
unchanged.

## Validation

- `uv run ruff check sag_api/ sag_agent/ tests/`
- `uv run python -m pytest -q` (`242 passed, 1 skipped`)
