### PR TITLE
ci(fnos): 去掉 Delivery workflow 的手填 version + PUBLISH

### DIFF
--- a/.github/workflows/fnos-release.yml
+++ b/.github/workflows/fnos-release.yml
@@ -2,18 +2,12 @@ name: fnOS Delivery
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: >
-          FPK version, e.g. 1.5.3-fnos.1.
-          Leave empty to auto-derive from the latest main release tag + next fnOS build number.
-        required: false
-        type: string
-        default: ""
-      publish_confirmation:
-        description: Type PUBLISH exactly to confirm a real Release will be created.
-        required: true
-        type: string
+    # No inputs: version is derived automatically from the latest semver
+    # base tag on the repo + the next available fnOS build number
+    # (highest existing `fnos-v<base>-fnos.N` release, incremented). The
+    # workflow still refuses to run from any branch other than
+    # fnos/develop, so an accidental trigger from a topic branch fails
+    # fast before doing any work.
 
 permissions:
   contents: read
@@ -26,6 +20,13 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       base_version: ${{ steps.resolve.outputs.base_version }}
     steps:
+      - name: Enforce fnos/develop trigger branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ github.ref }}" = "refs/heads/fnos/develop" \
+            || { echo "Publish must be triggered from fnos/develop (got ${{ github.ref }})"; exit 1; }
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -45,7 +46,7 @@ jobs:
           echo "Base version: $base"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve fpNOS version
+      - name: Resolve fnOS version
         id: resolve
         shell: bash
         env:
@@ -53,27 +54,25 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${{ steps.find-base.outputs.base }}"
-          MANUAL="${{ inputs.version }}"
 
-          if [ -n "$MANUAL" ]; then
-            VERSION="$MANUAL"
-            echo "Using manual version: $VERSION"
-          else
-            # Find the highest existing fnOS build number for this base.
-            N=1
-            existing="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
-            if [ -n "$existing" ]; then
-              highest="$(echo "$existing" | grep -E "^fnos-v${BASE//./\\.}-fnos\\.[0-9]+\$" \
-                | sed 's/^fnos-v.*-fnos\.//' \
-                | sort -n \
-                | tail -1 || true)"
-              if [ -n "$highest" ] && [ "$highest" -ge 1 ] 2>/dev/null; then
-                N=$((highest + 1))
-              fi
+          # Auto-increment the fnOS build number for this base. Start at
+          # 1 when no previous fnOS release exists for the current base
+          # (e.g. right after a base version bump). Otherwise: bump the
+          # highest existing `fnos-v<base>-fnos.N` release by one.
+          N=1
+          existing="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
+          highest=""
+          if [ -n "$existing" ]; then
+            highest="$(echo "$existing" | grep -E "^fnos-v${BASE//./\\.}-fnos\\.[0-9]+\$" \
+              | sed 's/^fnos-v.*-fnos\.//' \
+              | sort -n \
+              | tail -1 || true)"
+            if [ -n "$highest" ] && [ "$highest" -ge 1 ] 2>/dev/null; then
+              N=$((highest + 1))
             fi
-            VERSION="${BASE}-fnos.${N}"
-            echo "Auto-derived version: $VERSION (highest existing fnos build for $BASE: ${highest:-none})"
           fi
+          VERSION="${BASE}-fnos.${N}"
+          echo "Auto-derived version: $VERSION (highest existing fnos build for $BASE: ${highest:-none})"
 
           # Validate format: <semver>-fnos.<positive int>
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-fnos\.[1-9][0-9]*$'; then
@@ -126,10 +125,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Defense-in-depth: resolve-version already gates on this branch,
+          # but native-x86 checks out its own copy, so re-verify here.
           test "${{ github.ref }}" = "refs/heads/fnos/develop" \
             || { echo "Publish must be triggered from fnos/develop"; exit 1; }
-          test "${{ inputs.publish_confirmation }}" = "PUBLISH" \
-            || { echo "Confirmation must be exactly PUBLISH"; exit 1; }
           test -n "$SAG_VERSION"
           test -s docs/fnos/evidence/native-p0-x86.json \
             || { echo "Missing native-p0-x86.json evidence"; exit 1; }

--- a/scripts/tests/fnos-native-release-workflow.test.mjs
+++ b/scripts/tests/fnos-native-release-workflow.test.mjs
@@ -10,6 +10,8 @@ test("fnOS delivery builds only the Native x86 FPK", async () => {
   assert.match(workflow, /runs-on: ubuntu-24\.04/);
   assert.match(workflow, /--platform linux\/amd64/);
   assert.match(workflow, /--platform x86/);
-  assert.match(workflow, /publish_confirmation.*PUBLISH/s);
+  // No PUBLISH typo-trap: workflow_dispatch no longer takes any human
+  // input; the branch guard (fnos/develop only) is the sole gate.
+  assert.doesNotMatch(workflow, /publish_confirmation/);
   assert.doesNotMatch(workflow, /docker\/|docker build|build-push-action|ghcr\.io/i);
 });

--- a/scripts/tests/fnos-release-workflow.test.mjs
+++ b/scripts/tests/fnos-release-workflow.test.mjs
@@ -5,20 +5,27 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
-test("fnOS delivery is a single manual publish flow guarded by explicit confirmation", async () => {
+test("fnOS delivery is a single manual publish flow guarded by branch", async () => {
   const workflow = await readFile(path.join(root, ".github/workflows/fnos-release.yml"), "utf8");
   assert.match(workflow, /^name: fnOS Delivery$/m);
   // Manual-only trigger: no push branch, only workflow_dispatch.
   assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.match(workflow, /workflow_dispatch:/);
-  // Version input exists but is OPTIONAL — auto-derived from the latest
-  // main semver tag + the next available fnos build number.
-  assert.match(workflow, /version:/);
-  assert.match(workflow, /inputs\.version/);
+  // No human-entered inputs: the version is auto-derived and the
+  // PUBLISH confirmation typo-trap has been retired.
+  assert.doesNotMatch(workflow, /^\s*inputs:/m);
+  assert.doesNotMatch(workflow, /inputs\.version/);
+  assert.doesNotMatch(workflow, /inputs\.publish_confirmation/);
   assert.doesNotMatch(workflow, /packages\/fnos\/sag\/manifest/);
-  // Guardrails: only from fnos/develop and only after PUBLISH confirmation.
-  assert.match(workflow, /refs\/heads\/fnos\/develop/);
-  assert.match(workflow, /inputs\.publish_confirmation.*PUBLISH/);
+  // Only surviving guardrail: publish must run from fnos/develop, and
+  // it must be enforced in BOTH jobs (resolve-version + native-x86) so
+  // an accidental trigger from a topic branch fails fast in resolve-
+  // version before native-x86 even starts.
+  const branchGuards = workflow.match(/refs\/heads\/fnos\/develop/g) ?? [];
+  assert.ok(
+    branchGuards.length >= 2,
+    `expected the fnos/develop branch guard in both jobs, found ${branchGuards.length}`,
+  );
   // Version auto-derivation from git tags + release listing.
   assert.match(workflow, /git tag -l/);
   assert.match(workflow, /gh release list/);


### PR DESCRIPTION
## Summary

fnOS Delivery workflow 之前触发时要求人手输入两个 `workflow_dispatch` inputs：

- `version`（可空，默认 auto-derive）
- `publish_confirmation`（必填，且要精确等于 `PUBLISH`）

version 自动推导逻辑已经完备（`git tag` + `gh release list` 拿上一个 base + 上一个 `fnos.N` 自增），99% 的发布都不会手填；`PUBLISH` 则纯粹是防拼错的护栏，实操里每次都要盲敲一遍反而更容易漏敲。整体交互鸡肋而且人为出错空间更大。

本 PR：

- 从 `on.workflow_dispatch` 里删掉 `inputs.version` 和 `inputs.publish_confirmation`。
- `resolve-version` job 里去掉 `MANUAL` 分支，永远走「上一次 `fnos.N` + 1」的自增（首次 base bump 后从 `fnos.1` 起步）。
- 分支护栏（只允许 `refs/heads/fnos/develop`）保留，并且**提前**到 `resolve-version` 的第一步：误触发在预备阶段就 fail-fast，不再依赖 `native-x86` 的 Validate 步骤兜底。
- `native-x86` 的 Validate 步骤同样保留分支校验作为 defense-in-depth（该 job 独立 checkout，注释里也说明了原因）。
- 两个 workflow 快照测试同步更新：
  - `scripts/tests/fnos-release-workflow.test.mjs`：断言不再有 `inputs:` / `inputs.version` / `inputs.publish_confirmation`；断言 fnos/develop 分支护栏在两个 job 里都出现（≥ 2 次匹配）。
  - `scripts/tests/fnos-native-release-workflow.test.mjs`：断言 `publish_confirmation` 已消失。

发布后触发流程从「填 version → 敲 PUBLISH → 点 Run」简化为「点 Run」。

## Test plan

- [x] `node --test scripts/tests/fnos-*.test.mjs` — 253 pass / 4 skipped / 0 fail (workflow 两个测试均通过新的正/反向断言).
- [ ] Actions 页面确认下一次 `Run workflow` 表单没有任何输入框。
- [ ] Actions 页面从 `main` 分支尝试 `Run workflow`，应在 `resolve-version` 第一步就 fail-fast（分支护栏）。
- [ ] 正常从 `fnos/develop` 触发，产出 tag `fnos-v<base>-fnos.<N+1>`（N = 当前最高 fnos build number）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)