### PR TITLE
follow-up(bugfix): 收口检索 Top-K 排除隐藏文档并清理 reprocess 冗余参数

### DIFF
--- a/apps/api/sag_api/api/v1/documents.py
+++ b/apps/api/sag_api/api/v1/documents.py
@@ -215,7 +215,6 @@ async def reprocess(
     _user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
-    engine_manager: EngineManager = Depends(get_engine_manager),
 ) -> JobOut:
     source = await get_source(session, source_id)
     job = await reprocess_document(
@@ -223,7 +222,6 @@ async def reprocess(
         source,
         document_id,
         job_queue=job_queue,
-        engine_manager=engine_manager,
     )
     return JobOut.model_validate(job)
 

--- a/apps/api/sag_api/services/document_service.py
+++ b/apps/api/sag_api/services/document_service.py
@@ -14,7 +14,6 @@ from sag_api.db.models import Document, Job, Source
 from sag_api.enums import DocumentStatus, JobStatus, JobType
 from sag_api.jobs import JobQueue
 from sag_api.jobs.scheduling import DELETE_PRIORITY, RESUME_PRIORITY, set_scheduler
-from sag_api.sag import EngineManager
 
 
 async def list_documents(session: AsyncSession, source_id: str) -> list[Document]:
@@ -133,7 +132,6 @@ async def reprocess_document(
     document_id: str,
     *,
     job_queue: JobQueue,
-    engine_manager: EngineManager,
 ) -> Job:
     document = await get_document(session, source, document_id)
     if document.status in {DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED}:

--- a/apps/api/sag_api/services/retrieval_service.py
+++ b/apps/api/sag_api/services/retrieval_service.py
@@ -369,17 +369,27 @@ async def retrieve_relevant_sections(
     """One retrieval contract for search UI and the Agent's search_context tool."""
 
     requested_limit = max(1, min(int(top_k or settings.search_top_k), 50))
-    candidate_limit = min(50, max(requested_limit * 3, requested_limit + 8))
+    base_candidate_limit = min(50, max(requested_limit * 3, requested_limit + 8))
     targets = [(source.sag_source_config_id, source) for source in sources]
-    outcome, lexical, hidden = await asyncio.gather(
+    # 先并行拿到 hidden 与 lexical——hidden 只是几条本地 DB 查询,通常 <50ms。
+    # 拿到之后再触发 semantic recall,以便根据被删/删除失败的文档数量放大候选池,
+    # 避免"删除失败的大文档占据 Top-N,把同信源正常文档全挤出候选池"这种情形。
+    hidden_task = asyncio.create_task(_hidden_document_derivatives(sources))
+    lexical_task = asyncio.create_task(_lexical_sections(engine_manager, sources, query))
+    hidden = await hidden_task
+    # 每一条 hidden source_id 都可能"占据"候选池中的多个 chunk（一个文档拆多个块）。
+    # 用一个保守的放大系数,兼顾召回质量与 ES kNN 的延迟上限。
+    hidden_source_count = len(hidden.source_ids) + len(hidden.source_config_ids)
+    hidden_headroom = min(150, hidden_source_count * 3)
+    candidate_limit = min(200, base_candidate_limit + hidden_headroom)
+    outcome, lexical = await asyncio.gather(
         engine_manager.search_many(
             targets,
             query,
             strategy=strategy,
             top_k=candidate_limit,
         ),
-        _lexical_sections(engine_manager, sources, query),
-        _hidden_document_derivatives(sources),
+        lexical_task,
     )
     def visible(section: RetrievedSection) -> bool:
         if section.source_id:
@@ -399,6 +409,9 @@ async def retrieve_relevant_sections(
         **outcome.stats,
         "requested_top_k": requested_limit,
         "candidate_top_k": candidate_limit,
+        "candidate_top_k_base": base_candidate_limit,
+        "candidate_top_k_headroom": hidden_headroom,
+        "hidden_sources": hidden_source_count,
         "candidates": reranked.candidate_count,
         "relevant": reranked.relevant_count,
         "filtered_irrelevant": reranked.filtered_count,

--- a/apps/api/tests/test_document_resume.py
+++ b/apps/api/tests/test_document_resume.py
@@ -1111,7 +1111,6 @@ async def test_reprocess_ready_document_replaces_all_previous_derived_data():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=engine,
         )
 
         assert engine.deleted == []
@@ -1362,7 +1361,6 @@ async def test_concurrent_reprocess_requests_share_one_cleanup_job():
                 source,
                 document_id,
                 job_queue=queue,
-                engine_manager=object(),
             )
 
     first, second = await asyncio.gather(retry(), retry())
@@ -1444,7 +1442,6 @@ async def test_retrying_failed_reprocess_cleanup_stays_in_maintenance_flow():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=object(),
         )
 
         assert retried.type == JobType.REPROCESS_DOCUMENT
@@ -1511,7 +1508,6 @@ async def test_delete_after_reprocess_request_uses_maintenance_cleanup():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=object(),
         )
         delete_job = await delete_document(
             session,


### PR DESCRIPTION
## 背景

PR #74(文档上传任务进度打断操作 Bugfix)已合入 main。本 PR 收口交接文档里剩余的 2 个小项。

## 改动

### 1. 检索 Top-K:候选池按"隐藏文档数量"动态放大 —— `apps/api/sag_api/services/retrieval_service.py`

**问题**:一个信源里如果存在 `DELETING / DELETE_FAILED` 状态的大文档,由于 zleap_sag 底层 ES kNN 只支持 include 过滤、不支持 exclude,这些"应该隐藏"的文档会先进入 Top-K 候选池、再被 Python 侧过滤掉,导致同信源的正常文档被挤出候选池、召回不完整。

**做法**:
- 先并行拉起 `hidden_task`(读隐藏文档的 sag_source_id / sag_source_config_id)与 `lexical_task`。
- `await hidden_task` 拿到隐藏信源数量后,把 semantic 召回的 `candidate_limit` 动态放大:
  - `base = min(50, max(top_k*3, top_k+8))`(与 PR#74 一致的保底)
  - `headroom = min(150, hidden_source_count * 3)`(每个隐藏信源保守估计占 3 个 chunk)
  - `candidate_limit = min(200, base + headroom)`(硬上限 200,兜住单次 kNN 延迟)
- `stats` 里加 `candidate_top_k_base` / `candidate_top_k_headroom` / `hidden_sources`,便于线上调优观察。

**回归风险**:无隐藏文档时 `headroom = 0`,行为与 PR#74 完全一致。

### 2. 清理 `reprocess_document()` 冗余 `engine_manager` 参数

PR#74 之后 `reprocess_document()` 函数体已不再引用 `engine_manager`,本次同步清理:

- `apps/api/sag_api/services/document_service.py`:去掉形参与顶部 `from sag_api.sag import EngineManager` 导入。
- `apps/api/sag_api/api/v1/documents.py`:`reprocess` 路由去掉 `engine_manager` 依赖注入与调用参数(`EngineManager` 导入保留,同文件其他路由仍在用)。
- `apps/api/tests/test_document_resume.py`:4 处 caller 同步去掉 `engine_manager=...` 关键字实参。

### 交接文档第 3 项(删 `SAG_DOCUMENT_CONTROL_PRIORITY_ENABLED` 环境变量)

PR#74 收尾时已在全仓清除,grep 0 命中,本 PR 无需再动。

## 影响范围

- **对上层调用者**:`reprocess_document()` 签名去掉 1 个 keyword-only 参数;全仓仅 1 个 API 路由 + 4 处测试引用,已同步更新。
- **对检索行为**:候选池最大值 50 → 200(仅在存在隐藏文档时才放大),rerank 与最终截断到 `requested_limit` 的逻辑不变,结果字段不变。
- **对延迟**:hidden 查询是本地 DB 索引查询,通常 <50ms;从"三路并行"改为"hidden 先返回、semantic/lexical 再并行"的最坏路径增加几毫秒串行开销,可忽略。
- **对下游(rerank / MCP / Agent)**:无变更。
- **schema / 迁移 / 环境变量 / 依赖**:均无。
- **zleap_sag 引擎**:未改动。

## 验证

| 检查 | 结果 |
|---|---|
| 受影响用例(`test_document_resume` + `test_retrieval_relevance` + `test_search_strategy`) | 41 passed |
| `apps/api` 全量 pytest | 291 passed, 1 skipped |
| `ruff check sag_api tests` | All checks passed |
| Docker compose 本地重建 | api / web 均 healthy(`/api/v1/system/ready` 200) |

## 手动测试建议

1. **隐藏文档不再挤占检索**:找一个既有正常 READY、又有 `DELETING / DELETE_FAILED` 文档的信源,发起问答,确认能召回正常文档的内容。
2. **重新处理入口**:对失败/就绪文档点"重新处理",确认任务能正常入队。
3. 回归 PR#74 的 4 个交互:抽取中删除、抽取中暂停/继续、删除失败重试、刷新一致性。