### PR TITLE
feat(detail-panel): enhance text rendering with ChunkedRawText for ra…

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3692,7 +3692,7 @@
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
   }
 
-  /* 大文档分块渲染：屏幕外块跳过布局/绘制（配合 ChunkedMarkdown）。
+  /* 大文档分块渲染：屏幕外块跳过布局/绘制（配合 ChunkedMarkdown / ChunkedRawText）。
      contain-intrinsic-size 提供占位高度估算，避免滚动条大幅跳动；
      配合 ~5000 字符/块，一屏内典型高度约 900~1400px，估高 1200 靠中位数减小回跳。
 

--- a/apps/web/components/features/detail-panel.tsx
+++ b/apps/web/components/features/detail-panel.tsx
@@ -20,7 +20,7 @@ import type { CitationEventRef, Doc } from "@/lib/types";
 import { formatBytes, formatDate, formatTokenCount, relativeTime } from "@/lib/format";
 import { cleanCitationText, stripCitationTransportTokens } from "@/lib/citation-presentation";
 import { cn } from "@/lib/utils";
-import { ChunkedMarkdown } from "@/components/features/markdown-content";
+import { ChunkedMarkdown, ChunkedRawText } from "@/components/features/markdown-content";
 import { useApp } from "@/components/features/app-shell";
 import { DocStatusBadge } from "@/components/features/status-badge";
 import { Button } from "@/components/ui/button";
@@ -186,17 +186,15 @@ function TextBody({ text, mode }: { text: string; mode: "md" | "raw" }) {
   // 滚动条"双层套嵌导致的宽度抖动。但内部宽内容（大代码块/表格/长 URL）如果没有单独的
   // 横向出口，会顶穿容器；外层 overflow-x-hidden 会把它们裁掉表现为"右半边被截断"。
   // 这里仅开启 overflow-x-auto —— 只作用于宽元素的横向溢出，与外层纵向滚动互不干扰。
-  if (mode === "md") {
-    return (
-      <div className="w-full min-w-0 max-w-full overflow-x-auto rounded-md border bg-muted/30 p-4">
-        <ChunkedMarkdown content={text} />
-      </div>
-    );
-  }
+  // 外壳样式两种模式共用；md / raw 只换内层渲染器（ChunkedMarkdown / ChunkedRawText）。
   return (
-    <pre className="w-full min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-muted/30 p-4 font-mono text-xs leading-relaxed">
-      {text}
-    </pre>
+    <div className="w-full min-w-0 max-w-full overflow-x-auto rounded-md border bg-muted/30 p-4">
+      {mode === "md" ? (
+        <ChunkedMarkdown content={text} />
+      ) : (
+        <ChunkedRawText content={text} />
+      )}
+    </div>
   );
 }
 

--- a/apps/web/components/features/markdown-content.tsx
+++ b/apps/web/components/features/markdown-content.tsx
@@ -193,3 +193,35 @@ export const ChunkedMarkdown = React.memo(function ChunkedMarkdown({
     </>
   );
 });
+
+/**
+ * 大文档原始文本分块渲染：与 `ChunkedMarkdown` 同一套切块 + `.md-block` 策略，
+ * 但不走 Markdown 解析，块内为纯文本 `<pre>`。用于详情面板「原始 Markdown」
+ * 模式，避免单块超长 `pre-wrap` 在面板拖宽时全量换行重排。
+ *
+ * 短文本（单块）直接渲染，不引入额外包裹；答案流 / 预览模式不受影响。
+ */
+export const ChunkedRawText = React.memo(function ChunkedRawText({
+  content,
+}: {
+  content: string;
+}) {
+  const blocks = React.useMemo(() => splitMarkdownBlocks(content), [content]);
+  // 与改前 TextBody raw 的 `<pre>` 字号/换行一致；m-0 避免多块相邻时浏览器默认 pre 外边距叠出缝隙。
+  const textClassName =
+    "m-0 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed";
+
+  if (blocks.length <= 1) {
+    return <pre className={textClassName}>{content}</pre>;
+  }
+  return (
+    <>
+      {blocks.map((block, index) => (
+        // 索引作 key 安全：blocks 由 content 纯函数派生，同一 content 顺序稳定。
+        <div key={index} className="md-block">
+          <pre className={textClassName}>{block}</pre>
+        </div>
+      ))}
+    </>
+  );
+});


### PR DESCRIPTION
## 摘要

- 详情面板「原始 Markdown」改为分块渲染，对齐现有 ChunkedMarkdown 写法
- 大文档切到原始 Markdown 后，拖动主区与详情栏中间分栏时，避免单体 pre-wrap 全量重排导致卡顿
- 短文本仍直接渲染，不引入多余包裹；预览模式与答案流不受影响

## 改动说明

大文档在 raw 模式下原先把最多约 50 万字符塞进单个带 whitespace-pre-wrap 的 <pre>。拖动 ResizableHandle 改变面板宽度时，浏览器会对整段文本反复换行重排，造成明显卡顿。

本次新增 ChunkedRawText：复用 splitMarkdownBlocks 切块，多块时外层使用已有 .md-block（content-visibility: auto），与预览模式同一套性能策略。TextBody 的 md / raw 共用外壳样式，仅切换内层渲染器。