### PR TITLE
fix(fnos): run native package as package user

### DIFF
--- a/packages/fnos/native/sag/cmd/install_callback
+++ b/packages/fnos/native/sag/cmd/install_callback
@@ -2,18 +2,16 @@
 # install_callback — provision $TRIM_PKGVAR ownership, perms, and the
 # internal identity secret.
 #
-# Runs as ROOT (config/privilege defaults.run-as=root). By this point in
+# Runs as the sag package user (config/privilege defaults.run-as=package). By this point in
 # the lifecycle the fnpack framework has materialized $TRIM_PKGVAR
 # (== /vol1/@appdata/<pkg>) — it did not exist when install_init ran.
 # This callback:
 #
-#   1. Ensures $TRIM_PKGVAR exists, is owned by sag:sag, and is mode 0700
+#   1. Ensures $TRIM_PKGVAR exists and is mode 0700
 #      (so per-user data under $TRIM_PKGVAR/users/<key>/ is not
 #      traversable by other local accounts).
 #   2. Provisions $TRIM_PKGVAR/internal-secret as a 64-hex random blob
-#      owned by sag:sag, mode 0600. cmd/main exports this file to the
-#      gateway; the sag user must own it because main drops privileges
-#      to sag before exec'ing the gateway.
+#      with mode 0600.
 #   3. Scrubs any legacy residue at $TRIM_PKGETC/internal-secret. A
 #      prior release wrote the secret there; @appconf is a shared
 #      config volume whose perms fnpack does not re-normalize, so
@@ -84,12 +82,9 @@ case "$TRIM_PKGVAR" in
   *) die "TRIM_PKGVAR ($TRIM_PKGVAR) is not an absolute path" ;;
 esac
 
-# ---- 2. Materialize $TRIM_PKGVAR under sag:sag mode 0700 -----------------
+# ---- 2. Materialize $TRIM_PKGVAR under mode 0700 --------------------------
 LAST_STEP="pkgvar-mkdir"
 mkdir -p "$TRIM_PKGVAR" || die "cannot create $TRIM_PKGVAR (parent: $(ls -ld "$(dirname "$TRIM_PKGVAR")" 2>&1))"
-
-LAST_STEP="pkgvar-chown"
-chown sag:sag "$TRIM_PKGVAR" 2>/dev/null || log "chown sag:sag $TRIM_PKGVAR failed (non-fatal; may be a rare NAS ACL case)"
 
 LAST_STEP="pkgvar-chmod"
 chmod 0700 "$TRIM_PKGVAR" || die "cannot chmod 0700 $TRIM_PKGVAR"
@@ -121,21 +116,11 @@ if ! secret_ok "$secret"; then
   printf '%s' "$material" >"$secret" || die "cannot write $secret (disk full or read-only?)"
 fi
 
-# ---- 6. Ownership + mode on the secret ------------------------------------
-LAST_STEP="secret-chown"
-chown sag:sag "$secret" 2>/dev/null || log "chown sag:sag $secret failed (non-fatal)"
-
+# ---- 6. Mode on the secret -------------------------------------------------
 LAST_STEP="secret-chmod"
 chmod 0600 "$secret" || die "cannot chmod 0600 $secret"
 
-# ---- 7. Fixup ownership on any pre-existing subtree ----------------------
-# Overwrite installs from a prior root-era release may have left
-# root-owned dirs/files under $TRIM_PKGVAR. Recursive chown so the sag
-# runtime can read/write everything under its own data root.
-LAST_STEP="pkgvar-recursive-chown"
-chown -R sag:sag "$TRIM_PKGVAR" 2>/dev/null || log "recursive chown of $TRIM_PKGVAR failed (non-fatal)"
-
-# ---- 8. Post-condition ----------------------------------------------------
+# ---- 7. Post-condition ----------------------------------------------------
 LAST_STEP="post-condition"
 size="$(wc -c <"$secret" 2>/dev/null | tr -d ' \n\t')"
 case "$size" in
@@ -143,5 +128,5 @@ case "$size" in
   *) die "post-condition failed: internal-secret is $size bytes (want 64)" ;;
 esac
 
-log "install_callback complete (pkgvar=$TRIM_PKGVAR mode 0700 sag:sag, internal-secret 0600 sag:sag)"
+log "install_callback complete (pkgvar=$TRIM_PKGVAR mode 0700, internal-secret 0600)"
 exit 0

--- a/packages/fnos/native/sag/cmd/install_init
+++ b/packages/fnos/native/sag/cmd/install_init
@@ -13,8 +13,7 @@
 # behind by an unclean uninstall of a previous version. Everything here
 # is best-effort — a fresh install with no residue must exit 0.
 #
-# Runs as root (config/privilege defaults.run-as=root). cmd/main drops to
-# the sag package user before launching gateway/web via setpriv.
+# Runs as the sag package user (config/privilege defaults.run-as=package).
 
 set -u
 

--- a/packages/fnos/native/sag/cmd/main
+++ b/packages/fnos/native/sag/cmd/main
@@ -18,12 +18,8 @@ secret="${TRIM_PKGVAR}/internal-secret"
 # fnpack invokes every callback in cmd/ (install_init, install_callback,
 # main, upgrade_init, uninstall_callback, ...) under a single
 # `defaults.run-as` — there is no per-command override. This package
-# sets run-as=root: install_init/install_callback do the chown+perm
-# work as root (see cmd/install_callback), and main drops privileges to
-# the sag package user via setpriv before exec'ing the gateway (python
-# uvicorn) and web (node) daemons. Root is retained ONLY for start-time
-# setup (mkdir, chown of runtime state files) and for stop/status
-# (kill + /proc reads). The long-lived daemons run as sag.
+# uses run-as=package, so its lifecycle commands and long-lived
+# gateway/web daemons all run directly as the sag package user.
 #
 # The internal secret lives in TRIM_PKGVAR (== /vol1/@appdata/<pkg> on
 # fnOS), NOT in TRIM_PKGETC (== /vol1/@appconf/<pkg>). fnpack treats
@@ -35,9 +31,7 @@ secret="${TRIM_PKGVAR}/internal-secret"
 #
 # The gateway UDS lives at $TRIM_APPDEST/app.sock — fnpack's own
 # gateway proxy reads from there based on the `gatewaySocket` field in
-# app/ui/config. TRIM_APPDEST itself is created by fnpack root-owned;
-# start-time we chown it to sag:sag so the uvicorn child (running as
-# sag) can bind the socket there.
+# app/ui/config. fnpack grants the package user access to package paths.
 
 log_error() { printf '%s\n' "$1" >> "${TRIM_TEMP_LOGFILE:-/dev/null}"; }
 
@@ -72,16 +66,14 @@ drop_priv() {
 }
 
 # prepare_secret returns 0 iff main can safely hand the secret to the
-# gateway. Called under root at the top of start. Under root we can
-# always self-heal:
+# gateway. Called as the package user at the top of start. It can heal
+# package-owned residue:
 #
 #   * missing / malformed / truncated → rewrite
-#   * root-owned residue from a prior release → rewrite then chown sag:sag
 #   * refuse a symlink (won't chase into someone else's dir)
 #
-# The write is 0600, owner sag:sag, so the sag-privileged uvicorn
-# child (SAG_FNOS_INTERNAL_SECRET_FILE=$secret) can read it after
-# drop_priv.
+# The write is 0600, so the gateway can read it through
+# SAG_FNOS_INTERNAL_SECRET_FILE.
 hex_ok() {
   case "$1" in
     "") return 1 ;;
@@ -121,10 +113,6 @@ prepare_secret() {
     return 1
   fi
   if secret_content_ok "$secret" && [ -r "$secret" ]; then
-    # Even on the fast path make sure ownership/mode are correct so a
-    # prior root-era write doesn't leave a root:root file that the sag
-    # child cannot read.
-    chown sag:sag "$secret" 2>/dev/null || :
     chmod 600 "$secret" 2>/dev/null || :
     return 0
   fi
@@ -144,7 +132,6 @@ prepare_secret() {
     log_error "SAG Native cannot write internal secret at $secret. $(ls -ld "$(dirname "$secret")" 2>&1)."
     return 1
   fi
-  chown sag:sag "$secret" 2>/dev/null || :
   chmod 600 "$secret" 2>/dev/null || :
   return 0
 }
@@ -274,37 +261,6 @@ case "${1:-}" in
       log_error "SAG Native cannot create run/log dirs under $TRIM_PKGVAR. UID=$(id -u 2>/dev/null || echo ?). Parent dir: $(ls -ld "$TRIM_PKGVAR" 2>&1)."
       exit 1
     }
-    # main runs as root; the daemons run as sag. Make sure sag can
-    # write into the run/log dirs (mostly redundant with the recursive
-    # chown in install_callback, but idempotent and cheap — and covers
-    # the case where main creates a subdir on first start after a
-    # release that didn't have it).
-    chown -R sag:sag "$run_dir" "$log_dir" 2>/dev/null || :
-
-    # TRIM_APPDEST holds the gateway UDS ($TRIM_APPDEST/app.sock). It
-    # is created by fnpack root-owned; the sag-privileged uvicorn
-    # child needs to bind a socket there. chown just the directory so
-    # sag can create the socket file, without touching the read-only
-    # payload files fnpack laid down.
-    if [ -n "${TRIM_APPDEST:-}" ] && [ -d "$TRIM_APPDEST" ]; then
-      chown sag:sag "$TRIM_APPDEST" 2>/dev/null || :
-    fi
-
-    # TRIM_PKGTMP holds per-user worker UDS files
-    # ($TRIM_PKGTMP/workers/<uid>-<name>.sock) plus the workers/
-    # directory itself, both created lazily by the sag-privileged
-    # gateway on the first API request for each fnOS user. fnpack
-    # materializes TRIM_PKGTMP root-owned mode 0700 (same as PKGVAR,
-    # confirmed on 1.2.0302), so without this chown the mkdir in
-    # WorkspacePaths.prepare() raises UnsafeWorkspacePath and every
-    # /app/sag/api/* call returns 503 "SAG is initializing". Chown
-    # just the directory (not recursive) — nothing under it is created
-    # by fnpack, everything is written at runtime by sag.
-    if [ -n "${TRIM_PKGTMP:-}" ] && [ -d "$TRIM_PKGTMP" ]; then
-      chown sag:sag "$TRIM_PKGTMP" 2>/dev/null || :
-      chmod 0700 "$TRIM_PKGTMP" 2>/dev/null || :
-    fi
-
     # Verify the gateway log is writable BEFORE we launch anything that
     # redirects into it. A silent redirect failure (read-only fs, wrong
     # owner, missing parent dir) would otherwise swallow the real error
@@ -314,11 +270,6 @@ case "${1:-}" in
       log_error "SAG Native cannot write gateway/web log at $log_dir. UID=$(id -u 2>/dev/null || echo ?). Dir: $(ls -ld "$log_dir" 2>&1)."
       exit 1
     fi
-    # Log files must be owned by sag: main opens the fd here (as root)
-    # and the daemon writes to it (as sag). Different processes append
-    # over time — the fd is short-lived, but the file persists.
-    chown sag:sag "$gateway_log" "$web_log" 2>/dev/null || :
-
     # Warm the operator if the socket dir is not writable by us so the
     # eventual PermissionError in uvicorn is not a surprise.
     _START_STEP="check-socket-dir"
@@ -349,16 +300,9 @@ case "${1:-}" in
     else
       web_port="$(select_web_port)" || { log_error "No free local port for SAG Native web service."; exit 1; }
       cd "$web_root"
-      # Launch the node child as sag via drop_priv in a subshell. The
-      # outer shell owns the redirect fd (>> "$web_log"), the subshell
-      # exec's setpriv/su which replaces itself with the node process
-      # under uid=sag. Env vars set on the command line propagate
-      # through setpriv (setpriv preserves env by default) and su
-      # (accepts an env prefix on the -c command).
-      ( SAG_NATIVE_SERVICE="web" HOSTNAME=127.0.0.1 PORT="$web_port" drop_priv "$node_runtime" "$web_entry" ) >> "$web_log" 2>&1 &
+      ( SAG_NATIVE_SERVICE="web" HOSTNAME=127.0.0.1 PORT="$web_port" "$node_runtime" "$web_entry" ) >> "$web_log" 2>&1 &
       write_pid "$web_pid" "$!"
       write_pid "$web_port_file" "$web_port"
-      chown sag:sag "$web_pid" "$web_port_file" 2>/dev/null || :
     fi
 
     _START_STEP="wait-web"
@@ -371,15 +315,9 @@ case "${1:-}" in
     _START_STEP="start-gateway"
     if ! valid_pid "$gateway_pid" "sag_api.fnos.cli"; then
       rm -f "$gateway_socket"
-      # Launch the python child as sag via drop_priv in a subshell,
-      # same pattern as the web launch above. Environment set by the
-      # outer shell (PATH / PYTHONPATH / SAG_FNOS_* exports below the
-      # check-socket-dir step) propagates because setpriv preserves
-      # env by default and su -c inherits the parent's environment.
-      ( drop_priv "$runtime" -m sag_api.fnos.cli gateway --socket "$gateway_socket" --web-origin "http://127.0.0.1:${web_port}" ) >> "$gateway_log" 2>&1 &
+      ( "$runtime" -m sag_api.fnos.cli gateway --socket "$gateway_socket" --web-origin "http://127.0.0.1:${web_port}" ) >> "$gateway_log" 2>&1 &
       gw_pid=$!
       write_pid "$gateway_pid" "$gw_pid"
-      chown sag:sag "$gateway_pid" 2>/dev/null || :
       # Give Python ~1s to import + settle, then check it is still alive.
       # A quick death (permission denied on sqlite, missing native dep,
       # config parse error, secret mode != 0600, etc.) would otherwise be

--- a/packages/fnos/native/sag/cmd/upgrade_callback
+++ b/packages/fnos/native/sag/cmd/upgrade_callback
@@ -1,12 +1,11 @@
 #!/bin/sh
 # upgrade_callback — heal ownership/perm drift after an upgrade.
 #
-# Runs as ROOT (config/privilege defaults.run-as=root). fnpack invokes
+# Runs as the sag package user (config/privilege defaults.run-as=package). fnpack invokes
 # this callback after swapping in the new package payload. Delegate to
 # install_callback so an upgrade from any prior release lands with the
-# same guarantees a fresh install would: $TRIM_PKGVAR mode 0700 sag:sag,
-# internal-secret 0600 sag:sag, no root-owned residues under the data
-# root that would break sag's runtime access.
+# same guarantees a fresh install would: $TRIM_PKGVAR mode 0700 and
+# internal-secret 0600.
 
 set -u
 

--- a/packages/fnos/native/sag/cmd/upgrade_init
+++ b/packages/fnos/native/sag/cmd/upgrade_init
@@ -2,7 +2,7 @@
 # upgrade_init — pre-upgrade backup + install-side prep.
 #
 # fnpack invokes this callback under the same run-as as install_init
-# and main (this package: run-as=root). Two things went wrong in
+# and main (this package: run-as=package). Two things went wrong in
 # earlier upgrade paths that this script keeps guarding:
 #
 #   1. "$main" status writes its failure text ("SAG Native gateway
@@ -90,8 +90,8 @@ LAST_STEP="env-check"
 # Since install_init no longer touches $TRIM_PKGVAR (fnpack does not
 # guarantee it exists at that stage), the secret / perm work lives in
 # install_callback. Re-invoke it here so an upgrade path also converges
-# on the same $TRIM_PKGVAR mode 0700 sag:sag / internal-secret 0600
-# sag:sag guarantees a fresh install produces. Idempotent.
+# on the same $TRIM_PKGVAR mode 0700 / internal-secret 0600 guarantees
+# a fresh install produces. Idempotent.
 LAST_STEP="install_callback"
 if ! "$command_dir/install_callback"; then
   die "install_callback failed (see preceding install_callback lines in this log)"

--- a/packages/fnos/native/sag/config/privilege
+++ b/packages/fnos/native/sag/config/privilege
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "run-as": "root"
+    "run-as": "package"
   },
   "username": "sag",
   "groupname": "sag"

--- a/scripts/build-fnos-native-probe.mjs
+++ b/scripts/build-fnos-native-probe.mjs
@@ -69,39 +69,16 @@ runtime="/var/apps/python312/target/bin/python3"
 server="$TRIM_APPDEST/server"
 vendor="$server/vendor"
 log="$TRIM_PKGVAR/native-p0.log"
-# Probe main enters as root (package privilege defaults.run-as=root)
-# and must drop to the sag package user before exec'ing the probe
-# server. Same setpriv-preferred / su-fallback drop pattern as the
-# release cmd/main uses. See scripts/validate-fnos-native-package.mjs
-# — the validator requires this pattern to be present.
-drop_priv() {
-  if command -v setpriv >/dev/null 2>&1; then
-    exec setpriv --reuid sag --regid sag --init-groups -- "$@"
-  elif command -v su >/dev/null 2>&1; then
-    _quoted=""
-    for _arg in "$@"; do
-      _q="\${_arg//\\'/\\'\\\\'\\'}"
-      _quoted="$_quoted '$_q'"
-    done
-    exec su -s /bin/sh sag -c "$_quoted"
-  else
-    echo "native probe cannot drop privileges: neither setpriv nor su present" >> "$log"
-    exit 1
-  fi
-}
 case "\${1:-}" in
   start)
     mkdir -p "$TRIM_PKGVAR"
-    chown sag:sag "$TRIM_PKGVAR" 2>/dev/null || :
-    if [ -d "$TRIM_APPDEST" ]; then chown sag:sag "$TRIM_APPDEST" 2>/dev/null || :; fi
-    touch "$log"; chown sag:sag "$log" 2>/dev/null || :
+    touch "$log"
     if ! test -x "$runtime" || ! test -d "$server" || ! test -d "$vendor"; then
       echo "native probe prerequisites unavailable" >> "$log"
       exit 1
     fi
-    ( PYTHONPATH="$vendor:$server\${PYTHONPATH:+:$PYTHONPATH}" drop_priv "$runtime" "$server/fnos-native-probe.py" serve --socket "$TRIM_APPDEST/app.sock" --output "$TRIM_PKGVAR/native-p0.json" ) >> "$log" 2>&1 &
+    ( PYTHONPATH="$vendor:$server\${PYTHONPATH:+:$PYTHONPATH}" "$runtime" "$server/fnos-native-probe.py" serve --socket "$TRIM_APPDEST/app.sock" --output "$TRIM_PKGVAR/native-p0.json" ) >> "$log" 2>&1 &
     echo $! > "$pid_file"
-    chown sag:sag "$pid_file" 2>/dev/null || :
     ;;
   status)
     test -f "$pid_file"

--- a/scripts/tests/fnos-native-lifecycle.test.mjs
+++ b/scripts/tests/fnos-native-lifecycle.test.mjs
@@ -12,15 +12,10 @@ const cmd = path.join(root, "packages/fnos/native/sag/cmd");
 const chatPage = path.join(root, "apps/web/app/(app)/chat/[[...id]]/page.tsx");
 const appSidebar = path.join(root, "apps/web/components/features/app-sidebar.tsx");
 
-// The package runs its callbacks as root (config/privilege
-// defaults.run-as=root). Rationale + community evidence: fnpack does
-// not guarantee $TRIM_PKGVAR exists during install_init, and the
-// framework materializes it before install_callback. install_callback
-// therefore owns mkdir/chown/perms/secret; install_init only reaps
-// stale processes/sockets from a prior install. main enters as root,
-// fixes up runtime-state ownership, then exec's the gateway (python)
-// and web (node) daemons via setpriv (or su fallback) so neither
-// long-lived process holds root.
+// The package runs every lifecycle callback as the sag package user
+// (config/privilege defaults.run-as=package). fnpack materializes the
+// package-owned data directory between install_init and install_callback,
+// so the callback can provision its secret without elevated privileges.
 
 function baseEnv(extra = {}) {
   return { ...process.env, ...extra };
@@ -84,10 +79,7 @@ test("install_init removes a stale $TRIM_APPDEST/app.sock left by a crashed prio
 });
 
 // -----------------------------------------------------------------
-// install_callback — owns $TRIM_PKGVAR mkdir/chown/perms and the
-// internal secret. Runs as root in production; tests run as a
-// non-root uid so chown is best-effort (non-fatal) and we only
-// verify the pieces that survive without root.
+// install_callback — owns $TRIM_PKGVAR mkdir/perms and the internal secret.
 // -----------------------------------------------------------------
 test("install_callback creates $TRIM_PKGVAR at mode 0700 and provisions the internal-secret", async (t) => {
   const fixture = await mkdtemp(path.join(os.tmpdir(), "sag-native-lifecycle-"));
@@ -202,13 +194,9 @@ test("install_callback scrubs a residue secret from the legacy @appconf path", a
   assert.match(await readFile(path.join(pkgvar, "internal-secret"), "utf8"), /^[0-9a-f]{64}$/);
 });
 
-test("install_callback recursively chowns $TRIM_PKGVAR (heals root-era residue subtrees)", async () => {
-  // The chown -R sag:sag runs after the secret is placed. This is
-  // what makes an upgrade FROM a root-era install actually usable: a
-  // subtree of root-owned files left behind by cmd/main running as
-  // root would otherwise stay unreadable to the sag daemons.
+test("install_callback does not require ownership-changing commands", async () => {
   const source = await readFile(path.join(cmd, "install_callback"), "utf8");
-  assert.match(source, /chown -R sag:sag "\$TRIM_PKGVAR"/);
+  assert.doesNotMatch(source, /chown -R sag:sag "\$TRIM_PKGVAR"/);
 });
 
 // -----------------------------------------------------------------
@@ -225,48 +213,21 @@ test("upgrade_callback under strict /bin/sh (dash on fnOS)", () => {
 });
 
 // -----------------------------------------------------------------
-// cmd/main — the privilege-drop is what keeps SAG's long-lived
-// daemons out of root even though main enters as root.
+// cmd/main launches daemons directly because fnpack already invokes it
+// as the package user.
 // -----------------------------------------------------------------
-test("cmd/main drops privileges to sag before exec'ing the gateway and web daemons", async () => {
+test("cmd/main launches the gateway and web daemons without a privilege drop", async () => {
   const source = await readFile(path.join(cmd, "main"), "utf8");
-  // The drop helper is called before each daemon launch. Grep for
-  // the actual invocation, not just the definition — a helper that
-  // exists but is never called would still ship root daemons.
-  assert.match(source, /drop_priv "\$node_runtime" "\$web_entry"/);
-  assert.match(source, /drop_priv "\$runtime" -m sag_api\.fnos\.cli gateway/);
+  assert.match(source, /HOSTNAME=127\.0\.0\.1 PORT="\$web_port" "\$node_runtime" "\$web_entry"/);
+  assert.match(source, /"\$runtime" -m sag_api\.fnos\.cli gateway/);
+  assert.doesNotMatch(source, /drop_priv "\$node_runtime"/);
 });
 
-test("cmd/main's drop_priv prefers setpriv and falls back to su (verified present on fnOS 1.2.0302)", async () => {
+test("main.prepare_secret self-heals a package-owned internal secret", async () => {
   const source = await readFile(path.join(cmd, "main"), "utf8");
-  assert.match(source, /command -v setpriv/);
-  assert.match(source, /setpriv --reuid sag --regid sag --init-groups --/);
-  assert.match(source, /command -v su/);
-  assert.match(source, /su -s \/bin\/sh sag -c/);
-  // runuser is intentionally NOT reached at runtime — the user
-  // confirmed it is not shipped on their 1.2.0302 box. Grepping for
-  // the bare word would also match main's own explanatory comment,
-  // so anchor to the two forms it would take if it were actually used.
-  assert.doesNotMatch(source, /command -v runuser/);
-  assert.doesNotMatch(source, /\brunuser --/);
-});
-
-test("cmd/main chowns run/log dirs and TRIM_APPDEST to sag before dropping (daemons need to write into them)", async () => {
-  const source = await readFile(path.join(cmd, "main"), "utf8");
-  assert.match(source, /chown -R sag:sag "\$run_dir" "\$log_dir"/);
-  assert.match(source, /chown sag:sag "\$TRIM_APPDEST"/);
-  assert.match(source, /chown sag:sag "\$gateway_log" "\$web_log"/);
-});
-
-test("main.prepare_secret self-heals the internal secret (root can rewrite root-era residue as sag)", async () => {
-  const source = await readFile(path.join(cmd, "main"), "utf8");
-  // main is the last line of defense even after install_callback.
-  // If a prior release left a root-owned or malformed secret,
-  // prepare_secret regenerates and chowns to sag so the drop child
-  // can actually read it.
   assert.match(source, /prepare_secret returns 0 iff main can safely hand the secret/);
   assert.match(source, /generate_secret_material/);
-  assert.match(source, /chown sag:sag "\$secret"/);
+  assert.doesNotMatch(source, /chown sag:sag "\$secret"/);
   // The old .19 composite line that hid causes must not reappear.
   assert.doesNotMatch(source, /internal identity secret is unavailable or has unsafe permissions/);
 });

--- a/scripts/tests/fnos-native-package.test.mjs
+++ b/scripts/tests/fnos-native-package.test.mjs
@@ -179,23 +179,12 @@ test("rendered native package rejects a manifest service port", async (t) => {
   await expectRejected(root, "x86", /service_port/i);
 });
 
-test("rendered native package rejects a package run-as default (must be root so install_callback can chown $TRIM_PKGVAR to sag)", async (t) => {
+test("rendered native package rejects a root run-as default", async (t) => {
   const root = await renderedPackage(t, "x86");
   await writeFile(path.join(root, "config/privilege"), JSON.stringify({
-    defaults: { "run-as": "package" }, username: "sag", groupname: "sag",
+    defaults: { "run-as": "root" }, username: "sag", groupname: "sag",
   }));
-  await expectRejected(root, "x86", /run-as.*root/i);
-});
-
-test("rendered native package rejects cmd/main missing the privilege drop", async (t) => {
-  const root = await renderedPackage(t, "x86");
-  const mainPath = path.join(root, "cmd/main");
-  const original = await readFile(mainPath, "utf8");
-  // Strip both fallbacks so no drop tool is referenced. The rest of
-  // the file stays intact; validator should now reject.
-  const stripped = original.replace(/\bsetpriv\b/g, "no_such_tool").replace(/\bsu\s+-s\b/g, "no_such_tool ");
-  await writeFile(mainPath, stripped);
-  await expectRejected(root, "x86", /setpriv|drop privileges/i);
+  await expectRejected(root, "x86", /run-as.*package/i);
 });
 
 test("rendered native package rejects platform all", async (t) => {
@@ -226,7 +215,7 @@ test("rendered native package rejects Docker Compose content", async (t) => {
 test("rendered native package rejects a non-sag package user", async (t) => {
   const root = await renderedPackage(t, "x86");
   await writeFile(path.join(root, "config/privilege"), JSON.stringify({
-    defaults: { "run-as": "root" }, username: "other", groupname: "other",
+    defaults: { "run-as": "package" }, username: "other", groupname: "other",
   }));
   await expectRejected(root, "x86", /username.*sag/i);
 });

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -94,37 +94,12 @@ export async function validateNativeTemplate(root, platform) {
   if (!manifest.get("version")) fail("manifest must define version");
 
   const privilege = await readJson(root, "config/privilege");
-  // fnpack's privilege schema has no per-command override: whatever
-  // `defaults.run-as` is applies to every callback in cmd/, including
-  // install_init, install_callback, main, upgrade_init, and
-  // uninstall_callback. This package sets run-as=root so that:
-  //   * install_init runs BEFORE fnpack materializes $TRIM_PKGVAR and
-  //     stays out of it (see cmd/install_init).
-  //   * install_callback (root) mkdirs $TRIM_PKGVAR, chowns sag:sag,
-  //     and provisions the internal-secret file (see cmd/install_callback).
-  //   * main enters as root, sets up runtime state files, then drops
-  //     privileges to the sag user via setpriv (or su as fallback)
-  //     before exec'ing the long-lived gateway (python uvicorn) and
-  //     web (node) daemons. Neither daemon holds root.
-  // fnOS's own guidance is "优先使用 package 用户权限级别" — root is
-  // permitted when the install callbacks need it, and many upstream
-  // apps ship that way (Fndesk, 1Panel, EasyTier-Web, mihomo, ...).
-  // We enforce here that: privilege declares root, the sag user is
-  // still requested (fnpack auto-creates it), and cmd/main actually
-  // wires the privilege drop for its daemon exec paths.
-  if (privilege?.defaults?.["run-as"] !== "root") fail("privilege defaults run-as must be root (install_callback needs root to chown $TRIM_PKGVAR to sag; main drops to sag via setpriv before exec)");
+  // fnpack applies defaults.run-as to every lifecycle callback. Run all
+  // callbacks as the package user so neither installation nor runtime
+  // commands receive root privileges.
+  if (privilege?.defaults?.["run-as"] !== "package") fail("privilege defaults run-as must be package");
   if (privilege.username !== "sag") fail("privilege username must be sag");
   if (privilege.groupname !== "sag") fail("privilege groupname must be sag");
-
-  const mainSource = await readFile(path.join(root, "cmd/main"), "utf8");
-  // main runs as root but MUST drop to sag before exec'ing the
-  // gateway and web daemons. Guard the two well-known drop tools
-  // shipped on fnOS 1.2.x (setpriv verified present, su as fallback).
-  // A run-as=root package that forgets this ships root-owned daemons,
-  // which is the exact security regression we changed the privilege
-  // model to avoid.
-  if (!/\bsetpriv\b/.test(mainSource) && !/\bsu\s+-s\b/.test(mainSource))
-    fail("cmd/main must drop privileges via setpriv or su before exec'ing gateway/web daemons (run-as=root means main is entered as root)");
 
   const resource = await readJson(root, "config/resource");
   if (Object.hasOwn(resource, "docker-project")) fail("native package resource must not define docker-project");


### PR DESCRIPTION
## Summary
- run all native package lifecycle commands as the sag package user
- update the validator, probe builder, and lifecycle tests for run-as: package
- remove root-only ownership transitions from the package runtime

## Validation
- node --test scripts/tests/fnos-*.test.mjs