### PR TITLE
fix: 收口文档控制竞态与删除隔离

### DIFF
--- a/apps/api/sag_api/api/v1/documents.py
+++ b/apps/api/sag_api/api/v1/documents.py
@@ -24,7 +24,7 @@ from sag_api.schemas.job import JobOut
 from sag_api.services.document_service import (
     create_document_from_upload,
     delete_document,
-    get_document,
+    get_public_document,
     ingest_content,
     list_documents,
     pause_document,
@@ -115,7 +115,9 @@ async def get_(
     session: AsyncSession = Depends(get_session),
 ) -> DocumentOut:
     source = await get_source(session, source_id)
-    return DocumentOut.model_validate(await get_document(session, source, document_id))
+    return DocumentOut.model_validate(
+        await get_public_document(session, source, document_id)
+    )
 
 
 @router.get("/{document_id}/file")
@@ -133,7 +135,7 @@ async def get_file(
     from sag_api.core.errors import NotFoundError
 
     source = await get_source(session, source_id)
-    document = await get_document(session, source, document_id)
+    document = await get_public_document(session, source, document_id)
     if not document.storage_path or not os.path.isfile(document.storage_path):
         raise NotFoundError("原始文件不存在或已被清理")
     return FileResponse(
@@ -157,7 +159,7 @@ async def get_preview(
     from fastapi.responses import FileResponse, Response
 
     source = await get_source(session, source_id)
-    document = await get_document(session, source, document_id)
+    document = await get_public_document(session, source, document_id)
     if not document.storage_path or not os.path.isfile(document.storage_path):
         raise NotFoundError("原始文件不存在或已被清理")
     if is_text_preview(document.filename, document.content_type):
@@ -190,7 +192,7 @@ async def get_parsed(
     from fastapi.responses import Response
 
     source = await get_source(session, source_id)
-    document = await get_document(session, source, document_id)
+    document = await get_public_document(session, source, document_id)
     if document.status != DocumentStatus.READY:
         if document.status == DocumentStatus.FAILED:
             raise ConflictError(document.error or "文档解析失败，暂无解析内容")
@@ -215,7 +217,6 @@ async def reprocess(
     _user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
-    engine_manager: EngineManager = Depends(get_engine_manager),
 ) -> JobOut:
     source = await get_source(session, source_id)
     job = await reprocess_document(
@@ -223,7 +224,6 @@ async def reprocess(
         source,
         document_id,
         job_queue=job_queue,
-        engine_manager=engine_manager,
     )
     return JobOut.model_validate(job)
 

--- a/apps/api/sag_api/api/v1/knowledge.py
+++ b/apps/api/sag_api/api/v1/knowledge.py
@@ -17,7 +17,7 @@ from sag_api.schemas.chunk import (
     OutlineOut,
     ReadResponse,
 )
-from sag_api.services.document_service import get_document
+from sag_api.services.document_service import get_public_document
 from sag_api.services.source_service import get_source
 
 router = APIRouter(prefix="/sources/{source_id}", tags=["knowledge"])
@@ -33,7 +33,7 @@ async def outline(
 ) -> OutlineOut:
     """文档大纲：标题 + chunk_id，按阅读顺序排列。"""
     source = await get_source(session, source_id)
-    document = await get_document(session, source, document_id)
+    document = await get_public_document(session, source, document_id)
     if not document.sag_source_id:
         raise NotFoundError("文档尚无大纲，可能仍在处理中")
     rows = await engine_manager.list_chunk_headings(
@@ -92,7 +92,7 @@ async def read(
 ) -> ReadResponse:
     """按行分页读取原始文件。"""
     source = await get_source(session, source_id)
-    document = await get_document(session, source, document_id)
+    document = await get_public_document(session, source, document_id)
     if not document.storage_path or not os.path.isfile(document.storage_path):
         raise NotFoundError("原始文件不存在或已清理")
     try:

--- a/apps/api/sag_api/jobs/inproc.py
+++ b/apps/api/sag_api/jobs/inproc.py
@@ -39,6 +39,7 @@ log = get_logger("jobs")
 _BACKOFF_BASE_SECONDS = 2.0
 _RECOVERY_LOCK_RETRIES = 4
 _MAINTENANCE_CLOSE_RETRY_SECONDS = 0.5
+_RETRY_ENQUEUE_RETRY_SECONDS = 0.5
 _MAINTENANCE_JOB_TYPES = {
     JobType.DELETE_DOCUMENT,
     JobType.REPROCESS_DOCUMENT,
@@ -51,7 +52,10 @@ def _now() -> datetime:
 
 def _is_retryable(exc: Exception) -> bool:
     """瞬时故障（限流/超时/上游暂不可用）可重试；输入/配置类错误不重试。"""
-    return isinstance(exc, (ServiceUnavailableError, UpstreamError))
+    return isinstance(
+        exc,
+        (ServiceUnavailableError, UpstreamError, OperationalError),
+    )
 
 
 async def _mark_document_waiting_retry(session, job) -> None:
@@ -63,6 +67,34 @@ async def _mark_document_waiting_retry(session, job) -> None:
         return
     document.status = DocumentStatus.PENDING
     document.error = None
+
+
+async def _mark_reprocess_failed(session, document_id: str, message: str) -> None:
+    """Record reprocess failure without reviving a concurrent delete."""
+    await session.execute(
+        update(Document)
+        .where(
+            Document.id == document_id,
+            Document.status.not_in(
+                [DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED]
+            ),
+        )
+        .values(status=DocumentStatus.FAILED, error=message)
+    )
+
+
+async def _converge_document_paused(session, job) -> None:
+    """Finish a won pause transition without overwriting a concurrent resume."""
+    if job.type != JobType.PROCESS_DOCUMENT or not job.document_id:
+        return
+    await session.execute(
+        update(Document)
+        .where(
+            Document.id == job.document_id,
+            Document.status == DocumentStatus.PAUSING,
+        )
+        .values(status=DocumentStatus.PAUSED, error=None)
+    )
 
 
 class InProcessAsyncQueue(JobQueue):
@@ -132,6 +164,16 @@ class InProcessAsyncQueue(JobQueue):
                     raise
                 await asyncio.sleep(0.08 * (2**attempt))
 
+    async def enqueue_durably(self, job_id: str) -> None:
+        """Dispatch now when possible and supervise a retry after any failure."""
+        try:
+            await self.enqueue(job_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - durable row remains recoverable
+            log.exception("持久化任务首次派发失败，转后台重排 job=%s", job_id)
+            self._schedule_retry(job_id, 0.0)
+
     def begin_source_maintenance(self, source_id: str, job_id: str) -> None:
         self._source_maintenance_jobs.setdefault(source_id, set()).add(job_id)
 
@@ -153,6 +195,71 @@ class InProcessAsyncQueue(JobQueue):
                 self._source_maintenance_tasks.pop(source_id, None)
 
         task.add_done_callback(discard)
+
+    async def _record_source_maintenance_window_failure(
+        self,
+        source_id: str,
+        error: Exception,
+    ) -> bool:
+        """Bound maintenance admission failures and persist their final state."""
+        from sag_api.db.models import Job
+
+        registered_ids = set(self._source_maintenance_jobs.get(source_id, set()))
+        if not registered_ids:
+            return False
+
+        message = getattr(error, "message", None) or str(error)
+        retry_ids: set[str] = set()
+        async with self._session_factory() as session:
+            jobs = list(
+                (
+                    await session.scalars(
+                        select(Job).where(
+                            Job.id.in_(registered_ids),
+                            Job.source_id == source_id,
+                            Job.type.in_(_MAINTENANCE_JOB_TYPES),
+                            Job.status.in_([JobStatus.QUEUED, JobStatus.RUNNING]),
+                        )
+                    )
+                ).all()
+            )
+            for job in jobs:
+                job.attempts += 1
+                if _is_retryable(error) and job.attempts < settings.job_max_attempts:
+                    job.status = JobStatus.QUEUED
+                    job.finished_at = None
+                    job.error = (
+                        f"第 {job.attempts} 次建立信源维护窗口失败，将重试：{message}"
+                    )
+                    retry_ids.add(job.id)
+                    if job.type == JobType.DELETE_DOCUMENT and job.document_id:
+                        document = await session.get(Document, job.document_id)
+                        if document is not None:
+                            document.status = DocumentStatus.DELETING
+                            document.error = None
+                    continue
+
+                job.status = JobStatus.FAILED
+                job.error = message
+                job.finished_at = _now()
+                if job.type == JobType.DELETE_DOCUMENT and job.document_id:
+                    document = await session.get(Document, job.document_id)
+                    if document is not None:
+                        document.status = DocumentStatus.DELETE_FAILED
+                        document.error = message
+                elif job.type == JobType.REPROCESS_DOCUMENT and job.document_id:
+                    await _mark_reprocess_failed(session, job.document_id, message)
+            await session.commit()
+
+        active = self._source_maintenance_jobs.get(source_id)
+        if active is None:
+            return False
+        terminal_ids = registered_ids - retry_ids
+        active.difference_update(terminal_ids)
+        dispatched = self._source_maintenance_dispatched.get(source_id)
+        if dispatched in terminal_ids:
+            self._source_maintenance_dispatched.pop(source_id, None)
+        return bool(active)
 
     async def _coordinate_source_maintenance(self, source_id: str) -> None:
         """Wait for a maintenance window without consuming a job worker."""
@@ -210,9 +317,9 @@ class InProcessAsyncQueue(JobQueue):
                 else:
                     self._source_maintenance_ready.discard(source_id)
                 raise
-            except Exception:  # noqa: BLE001 - coordinator retries off-worker
-                log.exception("等待信源维护窗口失败，后台重试 source=%s", source_id)
+            except Exception as error:  # noqa: BLE001 - coordinator retries off-worker
                 if window_open and source is not None:
+                    log.exception("信源维护窗口内协调失败 source=%s", source_id)
                     self._source_maintenance_ready.add(source_id)
                     while source_id in self._source_maintenance_ready:
                         try:
@@ -231,6 +338,25 @@ class InProcessAsyncQueue(JobQueue):
                             await asyncio.sleep(delay)
                 else:
                     self._source_maintenance_ready.discard(source_id)
+
+                try:
+                    retry = await self._record_source_maintenance_window_failure(
+                        source_id,
+                        error,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001 - preserve fence until persisted
+                    log.exception(
+                        "持久化信源维护窗口失败状态异常，后台重试 source=%s",
+                        source_id,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 30.0)
+                    continue
+                if not retry:
+                    await self._close_source_maintenance(source_id)
+                    return
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, 30.0)
 
@@ -444,7 +570,7 @@ class InProcessAsyncQueue(JobQueue):
             else:
                 self._source_maintenance_jobs.pop(source_id, None)
             for ready_id in ready_ids:
-                await self.enqueue(ready_id)
+                await self.enqueue_durably(ready_id)
         finally:
             # Never leave a source permanently fenced if database or engine
             # cleanup is cancelled during shutdown.
@@ -470,7 +596,17 @@ class InProcessAsyncQueue(JobQueue):
         async def _later() -> None:
             try:
                 await asyncio.sleep(delay)
-                await self.enqueue(job_id)
+                retry_delay = _RETRY_ENQUEUE_RETRY_SECONDS
+                while True:
+                    try:
+                        await self.enqueue(job_id)
+                        return
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:  # noqa: BLE001 - durable row needs dispatch
+                        log.exception("延迟重排入队失败，后台重试 job=%s", job_id)
+                        await asyncio.sleep(retry_delay)
+                        retry_delay = min(max(retry_delay * 2, 0.0), 60.0)
             except asyncio.CancelledError:
                 pass
 
@@ -807,12 +943,23 @@ class InProcessAsyncQueue(JobQueue):
             if claim.rowcount != 1:
                 return
             await session.refresh(job)
+            claimed_started_at = job.started_at
 
             handler = TASK_HANDLERS.get(job.type)
             if handler is None:
-                job.status = JobStatus.FAILED
-                job.error = f"未知任务类型：{job.type}"
-                job.finished_at = _now()
+                await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == JobStatus.RUNNING,
+                        Job.started_at == claimed_started_at,
+                    )
+                    .values(
+                        status=JobStatus.FAILED,
+                        error=f"未知任务类型：{job.type}",
+                        finished_at=_now(),
+                    )
+                )
                 await session.commit()
                 return
 
@@ -820,14 +967,28 @@ class InProcessAsyncQueue(JobQueue):
             claimed_source_id = job.source_id
             release_source_maintenance = False
             retry_source_maintenance = False
+            retry_delay_to_schedule: float | None = None
 
             try:
                 await handler(session, job, engine_manager=self._engine_manager, job_queue=self)
-                job.status = JobStatus.SUCCEEDED
-                job.progress = 1.0
-                job.finished_at = _now()
-                job.error = None
-                release_source_maintenance = claimed_type in _MAINTENANCE_JOB_TYPES
+                succeeded = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == JobStatus.RUNNING,
+                        Job.started_at == claimed_started_at,
+                    )
+                    .values(
+                        status=JobStatus.SUCCEEDED,
+                        progress=1.0,
+                        finished_at=_now(),
+                        error=None,
+                    )
+                )
+                release_source_maintenance = bool(
+                    succeeded.rowcount
+                    and claimed_type in _MAINTENANCE_JOB_TYPES
+                )
             except asyncio.CancelledError:
                 raise
             except JobDeleted:
@@ -837,81 +998,162 @@ class InProcessAsyncQueue(JobQueue):
             except JobYielded as yielded:
                 await session.rollback()
                 job = await session.get(Job, job_id)
-                if job is not None:
-                    job.payload = set_scheduler(
+                if (
+                    job is not None
+                    and job.status == JobStatus.PAUSED
+                    and job.started_at == claimed_started_at
+                ):
+                    await _converge_document_paused(session, job)
+                    log.info("任务已被并发暂停，忽略让行信号 job=%s", job_id)
+                elif job is not None:
+                    payload = set_scheduler(
                         job.payload,
                         blocked_reason=yielded.reason,
                     )
-                    job.status = JobStatus.QUEUED
-                    job.finished_at = None
-                    job.error = None
-                    log.info("任务临时让行 job=%s reason=%s", job_id, yielded.reason)
+                    yielded_update = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == JobStatus.RUNNING,
+                            Job.started_at == claimed_started_at,
+                        )
+                        .values(
+                            payload=payload,
+                            status=JobStatus.QUEUED,
+                            finished_at=None,
+                            error=None,
+                        )
+                    )
+                    if yielded_update.rowcount:
+                        log.info(
+                            "任务临时让行 job=%s reason=%s",
+                            job_id,
+                            yielded.reason,
+                        )
             except JobPaused:
                 await session.rollback()
                 job = await session.get(Job, job_id)
                 if job is not None:
-                    payload = dict(job.payload or {})
-                    payload.pop("pause_requested", None)
-                    job.payload = payload
-                    job.status = JobStatus.PAUSED
-                    job.finished_at = None
-                    job.error = None
-                    log.info("任务已暂停 job=%s progress=%.0f%%", job_id, job.progress * 100)
+                    paused = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status.in_([JobStatus.RUNNING, JobStatus.PAUSED]),
+                            Job.started_at == claimed_started_at,
+                        )
+                        .values(
+                            status=JobStatus.PAUSED,
+                            finished_at=None,
+                            error=None,
+                        )
+                    )
+                    if paused.rowcount:
+                        await _converge_document_paused(session, job)
+                        log.info(
+                            "任务已暂停 job=%s progress=%.0f%%",
+                            job_id,
+                            job.progress * 100,
+                        )
             except Exception as e:  # noqa: BLE001
                 await session.rollback()
                 job = await session.get(Job, job_id)
+                if (
+                    job is not None
+                    and job.status == JobStatus.PAUSED
+                    and job.started_at == claimed_started_at
+                ):
+                    await _converge_document_paused(session, job)
+                    log.info("任务已被并发暂停，忽略 handler 失败 job=%s", job_id)
+                    await session.commit()
+                    return
                 msg = getattr(e, "message", None) or str(e)
                 attempts = job.attempts if job is not None else settings.job_max_attempts
                 delete_cleanup = bool(
                     job is not None and job.type == JobType.DELETE_DOCUMENT
                 )
                 retry = job is not None and (
-                    delete_cleanup
-                    or (
-                        _is_retryable(e)
-                        and attempts < settings.job_max_attempts
-                    )
+                    _is_retryable(e)
+                    and attempts < settings.job_max_attempts
                 )
-                if job is not None:
+                if job is not None and job.status == JobStatus.RUNNING:
                     if retry:
                         # 退避重排：状态回 QUEUED，延迟 base**attempts 秒后重新入队
-                        job.status = JobStatus.QUEUED
-                        job.progress = 0.0
-                        job.error = f"第 {attempts} 次失败，将重试：{msg}"
-                        await _mark_document_waiting_retry(session, job)
-                        if delete_cleanup and job.document_id:
-                            document = await session.get(Document, job.document_id)
-                            if document is not None:
-                                document.status = DocumentStatus.DELETING
-                                document.error = None
                         delay = min(_BACKOFF_BASE_SECONDS ** min(attempts, 10), 60.0)
-                        self._schedule_retry(job_id, delay)
-                        retry_source_maintenance = claimed_type in _MAINTENANCE_JOB_TYPES
-                        release_source_maintenance = bool(
-                            delete_cleanup and claimed_source_id
+                        retry_update = await session.execute(
+                            update(Job)
+                            .where(
+                                Job.id == job_id,
+                                Job.status == JobStatus.RUNNING,
+                                Job.started_at == claimed_started_at,
+                            )
+                            .values(
+                                status=JobStatus.QUEUED,
+                                progress=0.0,
+                                error=f"第 {attempts} 次失败，将重试：{msg}",
+                            )
                         )
-                        log.warning(
-                            "任务可重试 job=%s（第 %d/%d 次），%.1fs 后重排：%s",
-                            job_id, attempts, settings.job_max_attempts, delay, msg,
-                        )
+                        if retry_update.rowcount:
+                            await _mark_document_waiting_retry(session, job)
+                            if delete_cleanup and job.document_id:
+                                document = await session.get(Document, job.document_id)
+                                if document is not None:
+                                    document.status = DocumentStatus.DELETING
+                                    document.error = None
+                            retry_delay_to_schedule = delay
+                            retry_source_maintenance = (
+                                claimed_type in _MAINTENANCE_JOB_TYPES
+                            )
+                            release_source_maintenance = bool(
+                                delete_cleanup and claimed_source_id
+                            )
+                            log.warning(
+                                "任务可重试 job=%s（第 %d/%d 次），%.1fs 后重排：%s",
+                                job_id,
+                                attempts,
+                                settings.job_max_attempts,
+                                delay,
+                                msg,
+                            )
                     else:
-                        job.status = JobStatus.FAILED
-                        job.error = msg
-                        job.finished_at = _now()
-                        if job.type == JobType.DELETE_DOCUMENT and job.document_id:
-                            document = await session.get(Document, job.document_id)
-                            if document is not None:
-                                document.status = DocumentStatus.DELETE_FAILED
-                                document.error = msg
-                            release_source_maintenance = bool(claimed_source_id)
-                        elif job.type == JobType.REPROCESS_DOCUMENT and job.document_id:
-                            document = await session.get(Document, job.document_id)
-                            if document is not None:
-                                document.status = DocumentStatus.FAILED
-                                document.error = msg
-                            release_source_maintenance = bool(claimed_source_id)
-                        log.warning("任务失败 job=%s（尝试 %d 次）：%s", job_id, attempts, msg)
+                        failed_update = await session.execute(
+                            update(Job)
+                            .where(
+                                Job.id == job_id,
+                                Job.status == JobStatus.RUNNING,
+                                Job.started_at == claimed_started_at,
+                            )
+                            .values(
+                                status=JobStatus.FAILED,
+                                error=msg,
+                                finished_at=_now(),
+                            )
+                        )
+                        if failed_update.rowcount:
+                            if job.type == JobType.DELETE_DOCUMENT and job.document_id:
+                                document = await session.get(Document, job.document_id)
+                                if document is not None:
+                                    document.status = DocumentStatus.DELETE_FAILED
+                                    document.error = msg
+                                release_source_maintenance = bool(claimed_source_id)
+                            elif (
+                                job.type == JobType.REPROCESS_DOCUMENT
+                                and job.document_id
+                            ):
+                                await _mark_reprocess_failed(
+                                    session,
+                                    job.document_id,
+                                    msg,
+                                )
+                                release_source_maintenance = bool(claimed_source_id)
+                            log.warning(
+                                "任务失败 job=%s（尝试 %d 次）：%s",
+                                job_id,
+                                attempts,
+                                msg,
+                            )
             await session.commit()
+            if retry_delay_to_schedule is not None:
+                self._schedule_retry(job_id, retry_delay_to_schedule)
             if retry_source_maintenance and claimed_source_id:
                 if self._source_maintenance_dispatched.get(claimed_source_id) == job_id:
                     self._source_maintenance_dispatched.pop(claimed_source_id, None)

--- a/apps/api/sag_api/jobs/queue.py
+++ b/apps/api/sag_api/jobs/queue.py
@@ -14,6 +14,10 @@ class JobQueue(ABC):
     async def enqueue(self, job_id: str) -> None:
         """把一个已持久化的 Job 投入队列等待执行。"""
 
+    async def enqueue_durably(self, job_id: str) -> None:
+        """派发已提交任务；支持后台重排的队列可覆盖此默认实现。"""
+        await self.enqueue(job_id)
+
     @abstractmethod
     def begin_source_maintenance(self, source_id: str, job_id: str) -> None:
         """登记某个信源存在需要优先处理的维护任务。"""

--- a/apps/api/sag_api/jobs/tasks.py
+++ b/apps/api/sag_api/jobs/tasks.py
@@ -49,6 +49,31 @@ _DELETE_CONTROL_STATES = {
 }
 
 
+async def _yield_after_document_transition_lost(
+    session: AsyncSession,
+    document: Document,
+) -> None:
+    """Converge a winning pause/delete intent without overwriting it."""
+    document_id = document.id
+    await session.rollback()
+    current = await session.get(Document, document_id, populate_existing=True)
+    if current is not None and current.status == DocumentStatus.PAUSING:
+        paused = await session.execute(
+            update(Document)
+            .where(
+                Document.id == document_id,
+                Document.status == DocumentStatus.PAUSING,
+            )
+            .values(status=DocumentStatus.PAUSED, error=None)
+            .execution_options(synchronize_session=False)
+        )
+        if paused.rowcount == 1:
+            await session.commit()
+        else:
+            await session.rollback()
+    raise JobPaused()
+
+
 def _classify_document_failure(
     e: Exception, current_status: DocumentStatus
 ) -> tuple[ErrorLayer, ErrorStage]:
@@ -136,7 +161,9 @@ async def process_document(
             current_job = await control_session.get(Job, job.id)
             if current_job is None:
                 return True
-            if (current_job.payload or {}).get("pause_requested"):
+            if current_job.status == JobStatus.PAUSED or (
+                current_job.payload or {}
+            ).get("pause_requested"):
                 scheduler_yield_reason = None
                 return True
         if job_queue is not None and job_queue.source_maintenance_requested(source.id):
@@ -183,27 +210,54 @@ async def process_document(
                 raise JobYielded(SOURCE_MAINTENANCE)
             if document.status in _DELETE_CONTROL_STATES:
                 raise JobPaused()
-            document.status = DocumentStatus.PAUSED
-            document.error = None
+            expected_status = document.status
+            paused = await session.execute(
+                update(Document)
+                .where(
+                    Document.id == document.id,
+                    Document.status == expected_status,
+                )
+                .values(status=DocumentStatus.PAUSED, error=None)
+                .execution_options(synchronize_session=False)
+            )
+            if paused.rowcount != 1:
+                await _yield_after_document_transition_lost(session, document)
             await session.commit()
             raise JobPaused()
     except (JobPaused, JobYielded):
         raise
     except Exception as e:  # noqa: BLE001 - 记录到文档后再上抛给 worker
         await session.refresh(document)
-        if document.status in _DELETE_CONTROL_STATES:
-            raise JobPaused() from e
+        if (
+            document.status in _CONTROL_TRANSITION_STATES
+            or document.status == DocumentStatus.PAUSED
+        ):
+            await _yield_after_document_transition_lost(session, document)
         layer, stage = _classify_document_failure(e, document.status)
-        document.status = DocumentStatus.FAILED
-        document.error = getattr(e, "message", None) or str(e)
-        document.error_layer = layer.value
-        document.error_stage = stage.value
+        expected_status = document.status
+        message = getattr(e, "message", None) or str(e)
+        failed = await session.execute(
+            update(Document)
+            .where(
+                Document.id == document.id,
+                Document.status == expected_status,
+            )
+            .values(
+                status=DocumentStatus.FAILED,
+                error=message,
+                error_layer=layer.value,
+                error_stage=stage.value,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if failed.rowcount != 1:
+            await _yield_after_document_transition_lost(session, document)
         log.warning(
             "文档处理失败 doc=%s layer=%s stage=%s error=%s",
             document.id,
             layer.value,
             stage.value,
-            document.error,
+            message,
         )
         await session.commit()
         raise
@@ -215,13 +269,31 @@ async def process_document(
         document.status = DocumentStatus.PAUSED
         await session.commit()
         raise JobPaused()
-    document.status = DocumentStatus.READY
-    document.chunk_count = outcome.chunk_count
-    document.event_count = outcome.event_count
-    document.sag_source_id = outcome.source_id
-    document.progress = 100
-    document.token_usage = outcome.token_usage
-    document.error = None
+    completed = await session.execute(
+        update(Document)
+        .where(
+            Document.id == document.id,
+            Document.status.in_(
+                [
+                    DocumentStatus.PENDING,
+                    DocumentStatus.LOADING,
+                    DocumentStatus.EXTRACTING,
+                ]
+            ),
+        )
+        .values(
+            status=DocumentStatus.READY,
+            chunk_count=outcome.chunk_count,
+            event_count=outcome.event_count,
+            sag_source_id=outcome.source_id,
+            progress=100,
+            token_usage=outcome.token_usage,
+            error=None,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    if completed.rowcount != 1:
+        await _yield_after_document_transition_lost(session, document)
     # 信源聚合计数用原子 SQL 更新，避免并发读改写丢失
     await session.execute(
         update(Source)
@@ -381,7 +453,9 @@ async def reprocess_document_task(
     await session.commit()
     await session.refresh(process_job)
     if job_queue is not None:
-        await job_queue.enqueue(process_job.id)
+        from sag_api.services.document_service import _enqueue_persisted_job
+
+        await _enqueue_persisted_job(job_queue, process_job.id)
 
 
 async def sync_source(session: AsyncSession, job: Job, *, engine_manager=None, job_queue=None) -> None:

--- a/apps/api/sag_api/sag/engine_manager.py
+++ b/apps/api/sag_api/sag/engine_manager.py
@@ -222,6 +222,8 @@ class _EngineLifecycleGate:
 
 
 class EngineManager:
+    supports_document_source_exclusions = True
+
     def __init__(self, settings: Settings):
         self._settings = settings
         self._slots: dict[str, _Slot] = {}
@@ -910,6 +912,7 @@ class EngineManager:
         *,
         strategy: str | None = None,
         top_k: int | None = None,
+        exclude_source_ids_by_config: dict[str, tuple[str, ...]] | None = None,
     ) -> SearchOutcome:
         """在统一候选与并发边界内检索；单源失败不影响整体结果。"""
         strategy = self._effective_search_strategy(strategy)
@@ -917,15 +920,32 @@ class EngineManager:
         per_source_k = max(top_k, 4)
         requested_sources = len(targets)
         targets = targets[: self._settings.search_source_candidate_limit]
+        has_exclusions = any(
+            source_ids
+            for source_ids in (exclude_source_ids_by_config or {}).values()
+        )
 
-        if strategy == "vector" and targets:
+        if (strategy == "vector" or has_exclusions) and targets:
             try:
-                return await self._search_chunk_vectors(
+                outcome = await self._search_chunk_vectors(
                     targets,
                     query,
                     top_k=top_k,
                     requested_sources=requested_sources,
+                    exclude_source_ids_by_config=exclude_source_ids_by_config,
                 )
+                if has_exclusions and strategy != "vector":
+                    return SearchOutcome(
+                        query=outcome.query,
+                        sections=outcome.sections,
+                        stats={
+                            **outcome.stats,
+                            "requested_strategy": strategy,
+                            "effective_strategy": "vector",
+                            "fallback_used": True,
+                        },
+                    )
+                return outcome
             except asyncio.CancelledError:
                 raise
             except TimeoutError:
@@ -941,10 +961,33 @@ class EngineManager:
                         "sources_requested": requested_sources,
                         "source_limit_applied": requested_sources > len(targets),
                         "candidates": 0,
-                        "chunk_recall": "batch-vector-timeout",
+                        "chunk_recall": (
+                            "batch-vector-prefilter-timeout"
+                            if has_exclusions
+                            else "batch-vector-timeout"
+                        ),
                     },
                 )
             except Exception as error:  # noqa: BLE001
+                if has_exclusions:
+                    log.warning(
+                        "带删除屏障的批量块召回失败，不回退未过滤检索：%s",
+                        error,
+                    )
+                    return SearchOutcome(
+                        query=query,
+                        sections=[],
+                        stats={
+                            "sources": len(targets),
+                            "sources_requested": requested_sources,
+                            "source_limit_applied": requested_sources > len(targets),
+                            "candidates": 0,
+                            "requested_strategy": strategy,
+                            "effective_strategy": "vector",
+                            "fallback_used": True,
+                            "chunk_recall": "batch-vector-prefilter-failed",
+                        },
+                    )
                 # Keep the established per-source engine path as a compatibility
                 # fallback for storage providers that cannot do a filtered batch kNN.
                 log.warning("批量块向量召回失败，回退逐信源检索：%s", error)
@@ -1014,6 +1057,7 @@ class EngineManager:
         *,
         top_k: int,
         requested_sources: int,
+        exclude_source_ids_by_config: dict[str, tuple[str, ...]] | None = None,
     ) -> SearchOutcome:
         """Recall chunks across all selected sources with one query embedding."""
 
@@ -1034,11 +1078,59 @@ class EngineManager:
             timings["vector.embedding"] = round((time.perf_counter() - t0) * 1000, 2)
             repository = SourceChunkRepository(get_es_client())
             t1 = time.perf_counter()
-            docs = await repository.search_similar_by_content(
-                query_vector=query_vector,
-                k=top_k,
-                source_config_ids=source_config_ids,
-            )
+            exclusions = {
+                source_config_id: tuple(
+                    sorted(
+                        {
+                            value.strip()
+                            for value in source_ids
+                            if isinstance(value, str) and value.strip()
+                        }
+                    )
+                )
+                for source_config_id in source_config_ids
+                if (
+                    source_ids := (exclude_source_ids_by_config or {}).get(
+                        source_config_id,
+                        (),
+                    )
+                )
+            }
+            exclusions = {
+                source_config_id: source_ids
+                for source_config_id, source_ids in exclusions.items()
+                if source_ids
+            }
+            if exclusions:
+                from zleap.sag.core.storage.query import Q
+
+                filter_query = Q(
+                    "bool",
+                    filter=[Q("terms", source_config_id=source_config_ids)],
+                    must_not=[
+                        Q(
+                            "bool",
+                            filter=[
+                                Q("term", source_config_id=source_config_id),
+                                Q("terms", source_id=list(source_ids)),
+                            ],
+                        )
+                        for source_config_id, source_ids in exclusions.items()
+                    ],
+                ).to_dict()
+                docs = await repository.es_client.vector_search(
+                    index=repository.INDEX_NAME,
+                    field="content_vector",
+                    vector=query_vector,
+                    size=top_k,
+                    filter_query=filter_query,
+                )
+            else:
+                docs = await repository.search_similar_by_content(
+                    query_vector=query_vector,
+                    k=top_k,
+                    source_config_ids=source_config_ids,
+                )
             timings["vector.es_search"] = round((time.perf_counter() - t1) * 1000, 2)
             timings["vector.total"] = round((time.perf_counter() - t0) * 1000, 2)
             return docs, timings
@@ -2889,6 +2981,7 @@ class EngineManager:
         *,
         source: Source | None = None,
         limit: int = 20,
+        exclude_source_ids: tuple[str, ...] = (),
     ) -> list[dict]:
         """精确文本匹配（LIKE，大小写不敏感）：语义检索之外的确定性查找。"""
         await self._ensure_read_runtime({source_config_id: source})
@@ -2897,6 +2990,21 @@ class EngineManager:
         from zleap.sag.db.models import SourceChunk
 
         needle = pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        excluded = tuple(
+            sorted(
+                {
+                    value.strip()
+                    for value in exclude_source_ids
+                    if isinstance(value, str) and value.strip()
+                }
+            )
+        )
+        conditions = [
+            SourceChunk.source_config_id == source_config_id,
+            SourceChunk.content.ilike(f"%{needle}%", escape="\\"),
+        ]
+        if excluded:
+            conditions.append(SourceChunk.source_id.not_in(excluded))
         stmt = (
             select(
                 SourceChunk.id,
@@ -2904,10 +3012,7 @@ class EngineManager:
                 SourceChunk.content,
                 SourceChunk.source_id,
             )
-            .where(
-                SourceChunk.source_config_id == source_config_id,
-                SourceChunk.content.ilike(f"%{needle}%", escape="\\"),
-            )
+            .where(*conditions)
             .order_by(SourceChunk.rank)
             .limit(limit)
         )

--- a/apps/api/sag_api/services/document_service.py
+++ b/apps/api/sag_api/services/document_service.py
@@ -14,7 +14,15 @@ from sag_api.db.models import Document, Job, Source
 from sag_api.enums import DocumentStatus, JobStatus, JobType
 from sag_api.jobs import JobQueue
 from sag_api.jobs.scheduling import DELETE_PRIORITY, RESUME_PRIORITY, set_scheduler
-from sag_api.sag import EngineManager
+
+
+async def _enqueue_persisted_job(job_queue: JobQueue, job_id: str) -> None:
+    """Dispatch a committed job with queue-level retry supervision when available."""
+    durable = getattr(job_queue, "enqueue_durably", None)
+    if callable(durable):
+        await durable(job_id)
+        return
+    await job_queue.enqueue(job_id)
 
 
 async def list_documents(session: AsyncSession, source_id: str) -> list[Document]:
@@ -36,6 +44,21 @@ async def get_document(session: AsyncSession, source: Source, document_id: str) 
     if doc is None or doc.source_id != source.id:
         raise NotFoundError("文档不存在")
     return doc
+
+
+async def get_public_document(
+    session: AsyncSession,
+    source: Source,
+    document_id: str,
+) -> Document:
+    """Resolve a document for public reads after the logical-delete barrier."""
+    document = await get_document(session, source, document_id)
+    if document.status in {
+        DocumentStatus.DELETING,
+        DocumentStatus.DELETE_FAILED,
+    }:
+        raise NotFoundError("文档不存在")
+    return document
 
 
 async def create_document_from_upload(
@@ -80,7 +103,7 @@ async def create_document_from_upload(
     await session.refresh(document)
     await session.refresh(job)
 
-    await job_queue.enqueue(job.id)
+    await _enqueue_persisted_job(job_queue, job.id)
     return document, job
 
 
@@ -133,7 +156,6 @@ async def reprocess_document(
     document_id: str,
     *,
     job_queue: JobQueue,
-    engine_manager: EngineManager,
 ) -> Job:
     document = await get_document(session, source, document_id)
     if document.status in {DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED}:
@@ -243,7 +265,7 @@ async def reprocess_document(
     await session.refresh(job)
     if requires_maintenance:
         job_queue.begin_source_maintenance(source.id, job.id)
-    await job_queue.enqueue(job.id)
+    await _enqueue_persisted_job(job_queue, job.id)
     return job
 
 
@@ -311,15 +333,85 @@ async def _refresh_source_counts(session: AsyncSession, source: Source) -> None:
     source.event_count = int(event_count)
 
 
+async def _commit_document_job_transition(
+    session: AsyncSession,
+    document: Document,
+    job: Job,
+    *,
+    expected_document_status: DocumentStatus,
+    document_values: dict,
+    expected_job_status: JobStatus,
+    job_values: dict,
+) -> bool:
+    """Atomically claim one document control transition and its process job."""
+    claimed_document = await session.execute(
+        update(Document)
+        .where(
+            Document.id == document.id,
+            Document.status == expected_document_status,
+        )
+        .values(**document_values)
+        .execution_options(synchronize_session=False)
+    )
+    if claimed_document.rowcount != 1:
+        await session.rollback()
+        return False
+
+    claimed_job = await session.execute(
+        update(Job)
+        .where(
+            Job.id == job.id,
+            Job.document_id == document.id,
+            Job.type == JobType.PROCESS_DOCUMENT,
+            Job.status == expected_job_status,
+        )
+        .values(**job_values)
+        .execution_options(synchronize_session=False)
+    )
+    if claimed_job.rowcount != 1:
+        await session.rollback()
+        return False
+
+    await session.commit()
+    await session.refresh(document)
+    await session.refresh(job)
+    return True
+
+
+async def _raise_document_control_conflict(
+    session: AsyncSession,
+    document_id: str,
+    *,
+    action: str,
+    fallback: str,
+) -> None:
+    """Report the winning concurrent transition after a failed control CAS."""
+    await session.rollback()
+    current = await session.get(Document, document_id, populate_existing=True)
+    if current is None:
+        raise ConflictError("文档已删除，请刷新后重试")
+    if current.status in {DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED}:
+        raise ConflictError(f"文档正在删除或删除失败，无法{action}")
+    raise ConflictError(fallback)
+
+
 async def pause_document(session: AsyncSession, source: Source, document_id: str) -> Job:
     """协作式暂停：已开始的分块跑完并保存断点，不再领取新分块。"""
     document = await get_document(session, source, document_id)
     if document.status in {DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED}:
         raise ConflictError("文档正在删除或删除失败，无法停止抽取")
+    if document.status not in {
+        DocumentStatus.PENDING,
+        DocumentStatus.LOADING,
+        DocumentStatus.EXTRACTING,
+    }:
+        raise ConflictError("抽取任务已经结束或状态已变化，无法停止")
+    document_record_id = document.id
+    expected_document_status = document.status
     job = await session.scalar(
         select(Job)
         .where(
-            Job.document_id == document.id,
+            Job.document_id == document_record_id,
             Job.type == JobType.PROCESS_DOCUMENT,
             Job.status.in_([JobStatus.QUEUED, JobStatus.RUNNING]),
         )
@@ -327,28 +419,49 @@ async def pause_document(session: AsyncSession, source: Source, document_id: str
         .limit(1)
     )
     if job is None:
-        raise ConflictError("当前文档没有可停止的抽取任务")
+        await _raise_document_control_conflict(
+            session,
+            document_record_id,
+            action="停止抽取",
+            fallback="当前文档没有可停止的抽取任务",
+        )
 
     if job.status == JobStatus.QUEUED:
-        paused = await session.execute(
-            update(Job)
-            .where(Job.id == job.id, Job.status == JobStatus.QUEUED)
-            .values(status=JobStatus.PAUSED)
-        )
-        if paused.rowcount == 1:
-            document.status = DocumentStatus.PAUSED
-            await session.commit()
-            await session.refresh(job)
+        if await _commit_document_job_transition(
+            session,
+            document,
+            job,
+            expected_document_status=expected_document_status,
+            document_values={"status": DocumentStatus.PAUSED},
+            expected_job_status=JobStatus.QUEUED,
+            job_values={"status": JobStatus.PAUSED},
+        ):
             return job
-        await session.refresh(job)
+        await _raise_document_control_conflict(
+            session,
+            document_record_id,
+            action="停止抽取",
+            fallback="文档或抽取任务状态已变化，请刷新后重试",
+        )
 
     if job.status != JobStatus.RUNNING:
         raise ConflictError("抽取任务已经结束，无法停止")
-    job.payload = {**(job.payload or {}), "pause_requested": True}
-    document.status = DocumentStatus.PAUSING
-    await session.commit()
-    await session.refresh(job)
-    return job
+    if await _commit_document_job_transition(
+        session,
+        document,
+        job,
+        expected_document_status=expected_document_status,
+        document_values={"status": DocumentStatus.PAUSING},
+        expected_job_status=JobStatus.RUNNING,
+        job_values={"status": JobStatus.PAUSED},
+    ):
+        return job
+    await _raise_document_control_conflict(
+        session,
+        document_record_id,
+        action="停止抽取",
+        fallback="文档或抽取任务状态已变化，请刷新后重试",
+    )
 
 
 async def resume_document(
@@ -362,10 +475,13 @@ async def resume_document(
     document = await get_document(session, source, document_id)
     if document.status in {DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED}:
         raise ConflictError("文档正在删除或删除失败，无法继续")
+    if document.status != DocumentStatus.PAUSED:
+        raise ConflictError("当前文档不是已暂停状态，无法继续")
+    document_record_id = document.id
     job = await session.scalar(
         select(Job)
         .where(
-            Job.document_id == document.id,
+            Job.document_id == document_record_id,
             Job.type == JobType.PROCESS_DOCUMENT,
             Job.status == JobStatus.PAUSED,
         )
@@ -373,26 +489,46 @@ async def resume_document(
         .limit(1)
     )
     if job is None:
-        raise ConflictError("当前文档没有可继续的暂停任务")
+        await _raise_document_control_conflict(
+            session,
+            document_record_id,
+            action="继续",
+            fallback="当前文档没有可继续的暂停任务",
+        )
 
     payload = dict(job.payload or {})
     payload.pop("pause_requested", None)
     payload["resume_requested"] = True
-    job.payload = set_scheduler(
+    resumed_payload = set_scheduler(
         payload,
         priority=RESUME_PRIORITY,
         blocked_reason=None,
     )
-    job.status = JobStatus.QUEUED
-    job.finished_at = None
-    job.error = None
-    document.status = (
+    resumed_status = (
         DocumentStatus.EXTRACTING if payload.get("process_checkpoint") else DocumentStatus.PENDING
     )
-    document.error = None
-    await session.commit()
-    await session.refresh(job)
-    await job_queue.enqueue(job.id)
+    if not await _commit_document_job_transition(
+        session,
+        document,
+        job,
+        expected_document_status=DocumentStatus.PAUSED,
+        document_values={"status": resumed_status, "error": None},
+        expected_job_status=JobStatus.PAUSED,
+        job_values={
+            "payload": resumed_payload,
+            "status": JobStatus.QUEUED,
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+        },
+    ):
+        await _raise_document_control_conflict(
+            session,
+            document_record_id,
+            action="继续",
+            fallback="文档或抽取任务状态已变化，请刷新后重试",
+        )
+    await _enqueue_persisted_job(job_queue, job.id)
     return job
 
 
@@ -457,6 +593,63 @@ async def delete_document(
     if metadata_only:
         path = document.storage_path
         target_document_id = document.id
+        candidate_job_ids = [candidate.id for candidate in active_jobs]
+        if candidate_job_ids:
+            fenced_jobs = await session.execute(
+                update(Job)
+                .where(
+                    Job.id.in_(candidate_job_ids),
+                    Job.document_id == target_document_id,
+                    Job.type == JobType.PROCESS_DOCUMENT,
+                    Job.status == JobStatus.QUEUED,
+                    Job.started_at.is_(None),
+                    Job.attempts == 0,
+                )
+                .values(status=JobStatus.PAUSED)
+                .execution_options(synchronize_session=False)
+            )
+            if fenced_jobs.rowcount != len(candidate_job_ids):
+                # A worker claimed the processor after the optimistic read.
+                # Roll back any partial fence and use cooperative deletion.
+                await session.rollback()
+                completed_jobs = list(
+                    (
+                        await session.scalars(
+                            select(Job)
+                            .where(
+                                Job.source_id == source_record_id,
+                                Job.type == JobType.DELETE_DOCUMENT,
+                                Job.status == JobStatus.SUCCEEDED,
+                            )
+                            .order_by(Job.created_at.desc(), Job.id.desc())
+                            .limit(100)
+                        )
+                    ).all()
+                )
+                completed = next(
+                    (
+                        candidate
+                        for candidate in completed_jobs
+                        if (candidate.payload or {}).get("target_document_id")
+                        == target_document_id
+                    ),
+                    None,
+                )
+                if completed is not None:
+                    return completed
+                current_source = await session.get(
+                    Source,
+                    source_record_id,
+                    populate_existing=True,
+                )
+                if current_source is None:
+                    raise NotFoundError("信源不存在")
+                return await delete_document(
+                    session,
+                    current_source,
+                    target_document_id,
+                    job_queue=job_queue,
+                )
         claimed = await session.execute(
             update(Document)
             .where(
@@ -551,7 +744,7 @@ async def delete_document(
                 raise ConflictError("文档状态已变化，请刷新后重试")
             if job_queue is not None:
                 job_queue.begin_source_maintenance(source_record_id, existing.id)
-                await job_queue.enqueue(existing.id)
+                await _enqueue_persisted_job(job_queue, existing.id)
             return existing
         await session.refresh(document)
 
@@ -567,7 +760,7 @@ async def delete_document(
         await session.refresh(existing)
         if job_queue is not None:
             job_queue.begin_source_maintenance(source.id, existing.id)
-            await job_queue.enqueue(existing.id)
+            await _enqueue_persisted_job(job_queue, existing.id)
         return existing
 
     delete_job = Job(
@@ -589,5 +782,5 @@ async def delete_document(
     await session.refresh(delete_job)
     if job_queue is not None:
         job_queue.begin_source_maintenance(source.id, delete_job.id)
-        await job_queue.enqueue(delete_job.id)
+        await _enqueue_persisted_job(job_queue, delete_job.id)
     return delete_job

--- a/apps/api/sag_api/services/retrieval_service.py
+++ b/apps/api/sag_api/services/retrieval_service.py
@@ -23,11 +23,13 @@ class SearchSource(Protocol):
 
 
 EventScoreMap = dict[tuple[str, str], float]
+DocumentSourceExclusions = dict[str, tuple[str, ...]]
 
 
 @dataclass(frozen=True, slots=True)
 class _HiddenDerivatives:
     source_ids: frozenset[str] = frozenset()
+    source_keys: frozenset[tuple[str, str]] = frozenset()
     source_config_ids: frozenset[str] = frozenset()
     event_keys: frozenset[tuple[str, str]] = frozenset()
 
@@ -50,6 +52,7 @@ async def _hidden_document_derivatives(
     }
     hidden_document_ids: set[str] = set()
     hidden_source_ids: set[str] = set()
+    hidden_source_keys: set[tuple[str, str]] = set()
     hidden_configs: set[str] = set()
     hidden_event_keys: set[tuple[str, str]] = set()
     async with SessionLocal() as session:
@@ -107,9 +110,11 @@ async def _hidden_document_derivatives(
             histories = []
 
     for document in documents:
+        config_id = config_by_source.get(document.source_id)
         if document.sag_source_id:
             hidden_source_ids.add(document.sag_source_id)
-        config_id = config_by_source.get(document.source_id)
+            if config_id:
+                hidden_source_keys.add((config_id, document.sag_source_id))
         if config_id:
             hidden_configs.add(config_id)
     for job in [*active_control_jobs, *histories]:
@@ -118,7 +123,11 @@ async def _hidden_document_derivatives(
         if isinstance(checkpoint, dict):
             value = checkpoint.get("source_id")
             if isinstance(value, str) and value.strip():
-                hidden_source_ids.add(value.strip())
+                normalized_source_id = value.strip()
+                hidden_source_ids.add(normalized_source_id)
+                config_id = config_by_source.get(job.source_id or "")
+                if config_id:
+                    hidden_source_keys.add((config_id, normalized_source_id))
             config_id = config_by_source.get(job.source_id or "")
             if config_id:
                 hidden_event_keys.update(
@@ -126,19 +135,37 @@ async def _hidden_document_derivatives(
                     for event_id in checkpoint.get("event_ids", [])
                     if isinstance(event_id, str) and event_id.strip()
                 )
-        hidden_source_ids.update(
+        derived_source_ids = {
             value.strip()
             for value in payload.get("derived_source_ids", [])
             if isinstance(value, str) and value.strip()
-        )
+        }
+        hidden_source_ids.update(derived_source_ids)
         config_id = config_by_source.get(job.source_id or "")
         if config_id:
+            hidden_source_keys.update(
+                (config_id, source_id) for source_id in derived_source_ids
+            )
             hidden_configs.add(config_id)
     return _HiddenDerivatives(
         source_ids=frozenset(hidden_source_ids),
+        source_keys=frozenset(hidden_source_keys),
         source_config_ids=frozenset(hidden_configs),
         event_keys=frozenset(hidden_event_keys),
     )
+
+
+def _document_source_exclusions(
+    hidden: _HiddenDerivatives,
+) -> DocumentSourceExclusions:
+    """Scope hidden engine article IDs to their owning source config."""
+    values: dict[str, set[str]] = {}
+    for source_config_id, source_id in hidden.source_keys:
+        values.setdefault(source_config_id, set()).add(source_id)
+    return {
+        source_config_id: tuple(sorted(source_ids))
+        for source_config_id, source_ids in values.items()
+    }
 
 
 _QUERY_NOISE = (
@@ -323,6 +350,8 @@ async def _lexical_sections(
     engine_manager: Any,
     sources: list[SearchSource],
     query: str,
+    *,
+    exclude_source_ids_by_config: DocumentSourceExclusions | None = None,
 ) -> list[RetrievedSection]:
     grep_chunks = getattr(engine_manager, "grep_chunks", None)
     terms = query_terms(query)
@@ -334,11 +363,28 @@ async def _lexical_sections(
     async def one(source: SearchSource, term: str) -> list[RetrievedSection]:
         async with semaphore:
             try:
+                options: dict[str, Any] = {
+                    "source": source,
+                    "limit": 2,
+                }
+                if (
+                    getattr(
+                        engine_manager,
+                        "supports_document_source_exclusions",
+                        False,
+                    )
+                    and exclude_source_ids_by_config
+                ):
+                    options["exclude_source_ids"] = (
+                        exclude_source_ids_by_config.get(
+                            source.sag_source_config_id,
+                            (),
+                        )
+                    )
                 rows = await grep_chunks(
                     source.sag_source_config_id,
                     term,
-                    source=source,
-                    limit=2,
+                    **options,
                 )
             except Exception:  # noqa: BLE001
                 return []
@@ -374,16 +420,33 @@ async def retrieve_relevant_sections(
     targets = [(source.sag_source_config_id, source) for source in sources]
     total_start = time.perf_counter()
     engine_start = time.perf_counter()
-    outcome, lexical, hidden = await asyncio.gather(
-        engine_manager.search_many(
-            targets,
+    hidden = await _hidden_document_derivatives(sources)
+    exclusions = _document_source_exclusions(hidden)
+    search_options: dict[str, Any] = {
+        "strategy": strategy,
+        "top_k": candidate_limit,
+    }
+    if (
+        getattr(
+            engine_manager,
+            "supports_document_source_exclusions",
+            False,
+        )
+        and exclusions
+    ):
+        search_options["exclude_source_ids_by_config"] = exclusions
+    outcome, lexical = await asyncio.gather(
+        engine_manager.search_many(targets, query, **search_options),
+        _lexical_sections(
+            engine_manager,
+            sources,
             query,
-            strategy=strategy,
-            top_k=candidate_limit,
+            exclude_source_ids_by_config=exclusions,
         ),
-        _lexical_sections(engine_manager, sources, query),
-        _hidden_document_derivatives(sources),
     )
+    # A delete can commit while either engine query is in flight. Re-read the
+    # persisted barrier before returning evidence so the delete is linearized.
+    hidden = await _hidden_document_derivatives(sources)
     engine_latency_ms = round((time.perf_counter() - engine_start) * 1000, 2)
     def visible(section: RetrievedSection) -> bool:
         if section.source_id:

--- a/apps/api/sag_api/services/source_service.py
+++ b/apps/api/sag_api/services/source_service.py
@@ -169,5 +169,7 @@ async def sync_source(session: AsyncSession, source_id: str, *, job_queue: JobQu
     session.add(job)
     await session.commit()
     await session.refresh(job)
-    await job_queue.enqueue(job.id)
+    from sag_api.services.document_service import _enqueue_persisted_job
+
+    await _enqueue_persisted_job(job_queue, job.id)
     return job

--- a/apps/api/tests/test_document_cleanup_coordinator.py
+++ b/apps/api/tests/test_document_cleanup_coordinator.py
@@ -1,6 +1,253 @@
 import asyncio
+from uuid import uuid4
 
 import pytest
+
+
+@pytest.mark.asyncio
+async def test_pending_fast_delete_falls_back_when_process_is_claimed_mid_request(
+    monkeypatch,
+    tmp_path,
+):
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select, update
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import delete_document
+
+    class QueueSpy:
+        def __init__(self):
+            self.maintenance: list[tuple[str, str]] = []
+            self.enqueued: list[str] = []
+
+        def begin_source_maintenance(self, source_id: str, job_id: str):
+            self.maintenance.append((source_id, job_id))
+
+        async def enqueue(self, job_id: str):
+            self.enqueued.append(job_id)
+
+    await init_db()
+    path = tmp_path / "claimed-during-delete.pdf"
+    path.write_bytes(b"%PDF-1.4")
+    async with SessionLocal() as session:
+        source = Source(
+            name="pending-fast-delete-claim-race",
+            sag_source_config_id=f"pending-fast-delete-{uuid4().hex}",
+            document_count=1,
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename=path.name,
+            content_type="application/pdf",
+            size_bytes=path.stat().st_size,
+            storage_path=str(path),
+            status=DocumentStatus.PENDING,
+        )
+        session.add(document)
+        await session.flush()
+        process_job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(process_job)
+        await session.commit()
+        source_id, document_id, process_job_id = (
+            source.id,
+            document.id,
+            process_job.id,
+        )
+
+        real_scalars = session.scalars
+        scalars_calls = 0
+
+        async def scalars_then_claim(statement, *args, **kwargs):
+            nonlocal scalars_calls
+            scalars_calls += 1
+            if scalars_calls == 3:
+                await session.commit()
+                async with SessionLocal() as worker_session:
+                    await worker_session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == process_job_id,
+                            Job.status == JobStatus.QUEUED,
+                        )
+                        .values(
+                            status=JobStatus.RUNNING,
+                            started_at=datetime.now(UTC),
+                            attempts=1,
+                        )
+                    )
+                    await worker_session.commit()
+            return await real_scalars(statement, *args, **kwargs)
+
+        monkeypatch.setattr(session, "scalars", scalars_then_claim)
+        queue = QueueSpy()
+        delete_job = await delete_document(
+            session,
+            source,
+            document_id,
+            job_queue=queue,
+        )
+
+    async with SessionLocal() as session:
+        deleting_document = await session.get(Document, document_id)
+        stopped_process = await session.get(Job, process_job_id)
+        delete_jobs = list(
+            (
+                await session.scalars(
+                    select(Job).where(
+                        Job.source_id == source_id,
+                        Job.type == JobType.DELETE_DOCUMENT,
+                    )
+                )
+            ).all()
+        )
+        assert deleting_document is not None
+        assert deleting_document.status == DocumentStatus.DELETING
+        assert stopped_process is not None
+        assert stopped_process.status == JobStatus.RUNNING
+        assert stopped_process.payload["pause_requested"] is True
+        assert delete_job.status == JobStatus.QUEUED
+        assert [candidate.id for candidate in delete_jobs] == [delete_job.id]
+        assert queue.maintenance == [(source_id, delete_job.id)]
+        assert queue.enqueued == [delete_job.id]
+    assert path.exists()
+
+
+@pytest.mark.asyncio
+async def test_permanent_maintenance_window_failure_becomes_delete_failed():
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+
+    class BrokenEngine:
+        async def begin_document_maintenance(self, *_args, **_kwargs):
+            raise ValueError("invalid maintenance configuration")
+
+        async def end_document_maintenance(self, *_args, **_kwargs):
+            raise AssertionError("a window that never opened must not be closed")
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="broken-maintenance-window",
+            sag_source_config_id=f"broken-window-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/delete.md",
+            status=DocumentStatus.DELETING,
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.DELETE_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(job)
+        await session.commit()
+        source_id, document_id, job_id = source.id, document.id, job.id
+
+    queue = InProcessAsyncQueue(SessionLocal, BrokenEngine(), concurrency=0)
+    queue.begin_source_maintenance(source_id, job_id)
+    queue._schedule_source_maintenance(source_id)
+    coordinator = queue._source_maintenance_tasks[source_id]
+    try:
+        await asyncio.wait_for(asyncio.shield(coordinator), timeout=1)
+        async with SessionLocal() as session:
+            failed_job = await session.get(Job, job_id)
+            failed_document = await session.get(Document, document_id)
+            assert failed_job.status == JobStatus.FAILED
+            assert failed_job.attempts == 1
+            assert failed_document.status == DocumentStatus.DELETE_FAILED
+            assert failed_document.error == "invalid maintenance configuration"
+        assert queue.source_maintenance_requested(source_id) is False
+    finally:
+        await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_retryable_maintenance_window_failure_is_bounded_and_retried():
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ServiceUnavailableError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+
+    class FlakyEngine:
+        def __init__(self):
+            self.begin_count = 0
+
+        async def begin_document_maintenance(self, *_args, **_kwargs):
+            self.begin_count += 1
+            if self.begin_count == 1:
+                raise ServiceUnavailableError("temporary maintenance outage")
+
+        async def end_document_maintenance(self, *_args, **_kwargs):
+            return None
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="flaky-maintenance-window",
+            sag_source_config_id=f"flaky-window-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/delete.md",
+            status=DocumentStatus.DELETING,
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.DELETE_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(job)
+        await session.commit()
+        source_id, document_id, job_id = source.id, document.id, job.id
+
+    engine = FlakyEngine()
+    queue = InProcessAsyncQueue(SessionLocal, engine, concurrency=0)
+    queue.begin_source_maintenance(source_id, job_id)
+    queue._schedule_source_maintenance(source_id)
+    coordinator = queue._source_maintenance_tasks[source_id]
+    try:
+        await asyncio.wait_for(asyncio.shield(coordinator), timeout=2)
+        async with SessionLocal() as session:
+            retried_job = await session.get(Job, job_id)
+            deleting_document = await session.get(Document, document_id)
+            assert retried_job.status == JobStatus.QUEUED
+            assert retried_job.attempts == 1
+            assert deleting_document.status == DocumentStatus.DELETING
+        assert engine.begin_count == 2
+        assert queue._source_maintenance_dispatched[source_id] == job_id
+        assert (await asyncio.wait_for(queue._queue.get(), timeout=1))[-1] == job_id
+    finally:
+        await queue.stop()
 
 
 @pytest.mark.asyncio
@@ -963,6 +1210,74 @@ async def test_stop_tracks_coordinator_while_it_closes_a_ghost_window():
     assert queue._source_maintenance_tasks == {}
     assert queue._source_maintenance_jobs == {}
     assert queue._source_maintenance_ready == set()
+
+
+@pytest.mark.asyncio
+async def test_maintenance_close_supervises_peer_enqueue_failure():
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.scheduling import SOURCE_MAINTENANCE, get_blocked_reason
+
+    class ReleasingEngine:
+        released = False
+
+        async def end_document_maintenance(self, *_args, **_kwargs):
+            self.released = True
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="durable-peer-release",
+            sag_source_config_id="durable-peer-release-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="peer.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/peer.md",
+            status=DocumentStatus.EXTRACTING,
+        )
+        session.add(document)
+        await session.flush()
+        peer = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+            payload={"_scheduler": {"blocked_reason": SOURCE_MAINTENANCE}},
+        )
+        session.add(peer)
+        await session.commit()
+        source_id, peer_job_id = source.id, peer.id
+
+    engine = ReleasingEngine()
+    queue = InProcessAsyncQueue(SessionLocal, engine, concurrency=1)
+    queue.begin_source_maintenance(source_id, "delete-completed")
+    queue._source_maintenance_ready.add(source_id)
+    scheduled: list[tuple[str, float]] = []
+
+    async def fail_enqueue(_job_id: str) -> None:
+        raise RuntimeError("transient enqueue failure")
+
+    queue.enqueue = fail_enqueue  # type: ignore[method-assign]
+    queue._schedule_retry = lambda job_id, delay: scheduled.append(  # type: ignore[method-assign]
+        (job_id, delay)
+    )
+
+    await queue.finish_source_maintenance(source_id, "delete-completed")
+
+    assert engine.released is True
+    assert scheduled == [(peer_job_id, 0.0)]
+    async with SessionLocal() as session:
+        resumed = await session.get(Job, peer_job_id)
+        assert resumed.status == JobStatus.QUEUED
+        assert get_blocked_reason(resumed.payload) is None
+        assert resumed.payload["resume_requested"] is True
     assert queue._source_maintenance_closing == set()
 
 

--- a/apps/api/tests/test_document_job_retry.py
+++ b/apps/api/tests/test_document_job_retry.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -47,6 +48,336 @@ async def test_non_document_retry_does_not_query_for_a_document():
         FakeSession(),
         SimpleNamespace(document_id=None, type=JobType.INDEX_UNIVERSE),
     )
+
+
+@pytest.mark.asyncio
+async def test_retryable_handler_failure_cannot_revive_concurrently_paused_job(
+    monkeypatch,
+):
+    from sqlalchemy import update
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ServiceUnavailableError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="pause-wins-retry-race",
+            sag_source_config_id=f"pause-wins-retry-race-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="pause.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/pause.md",
+            status=DocumentStatus.EXTRACTING,
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(job)
+        await session.commit()
+        document_id, job_id = document.id, job.id
+
+    entered = asyncio.Event()
+    fail_now = asyncio.Event()
+
+    async def retryable_handler(*_args, **_kwargs):
+        entered.set()
+        await fail_now.wait()
+        raise ServiceUnavailableError("transient extraction failure")
+
+    monkeypatch.setitem(TASK_HANDLERS, JobType.PROCESS_DOCUMENT, retryable_handler)
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=1)
+    scheduled = []
+    monkeypatch.setattr(
+        queue,
+        "_schedule_retry",
+        lambda queued_job_id, _delay: scheduled.append(queued_job_id),
+    )
+    running = asyncio.create_task(queue._run_job(job_id))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Job).where(Job.id == job_id).values(status=JobStatus.PAUSED)
+        )
+        await session.execute(
+            update(Document)
+            .where(Document.id == document_id)
+            .values(status=DocumentStatus.PAUSING)
+        )
+        await session.commit()
+
+    fail_now.set()
+    await asyncio.wait_for(running, timeout=1)
+
+    async with SessionLocal() as session:
+        paused_job = await session.get(Job, job_id)
+        paused_document = await session.get(Document, document_id)
+        assert paused_job.status == JobStatus.PAUSED
+        assert paused_document.status == DocumentStatus.PAUSED
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_job_paused_signal_cannot_undo_a_concurrent_resume(monkeypatch):
+    from sqlalchemy import update
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.control import JobPaused
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="resume-wins-stale-pause-signal",
+            sag_source_config_id=f"resume-wins-stale-pause-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="resume.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/resume.md",
+            status=DocumentStatus.EXTRACTING,
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(job)
+        await session.commit()
+        job_id = job.id
+
+    entered = asyncio.Event()
+    pause_now = asyncio.Event()
+
+    async def stale_pause_handler(*_args, **_kwargs):
+        entered.set()
+        await pause_now.wait()
+        raise JobPaused
+
+    monkeypatch.setitem(TASK_HANDLERS, JobType.PROCESS_DOCUMENT, stale_pause_handler)
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=1)
+    running = asyncio.create_task(queue._run_job(job_id))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    resumed_payload = {"resume_requested": True, "checkpoint_version": 7}
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Job)
+            .where(Job.id == job_id)
+            .values(
+                status=JobStatus.QUEUED,
+                started_at=None,
+                payload=resumed_payload,
+            )
+        )
+        await session.commit()
+
+    pause_now.set()
+    await asyncio.wait_for(running, timeout=1)
+
+    async with SessionLocal() as session:
+        resumed = await session.get(Job, job_id)
+        assert resumed.status == JobStatus.QUEUED
+        assert resumed.payload == resumed_payload
+
+
+@pytest.mark.asyncio
+async def test_job_yielded_signal_cannot_undo_a_concurrent_pause(monkeypatch):
+    from sqlalchemy import update
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.control import JobYielded
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="pause-wins-stale-yield",
+            sag_source_config_id=f"pause-wins-stale-yield-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="yield.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/yield.md",
+            status=DocumentStatus.EXTRACTING,
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+        )
+        session.add(job)
+        await session.commit()
+        document_id, job_id = document.id, job.id
+
+    entered = asyncio.Event()
+    yield_now = asyncio.Event()
+
+    async def stale_yield_handler(*_args, **_kwargs):
+        entered.set()
+        await yield_now.wait()
+        raise JobYielded("source_maintenance")
+
+    monkeypatch.setitem(TASK_HANDLERS, JobType.PROCESS_DOCUMENT, stale_yield_handler)
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=1)
+    running = asyncio.create_task(queue._run_job(job_id))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    paused_payload = {"checkpoint_version": 11}
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Job)
+            .where(Job.id == job_id)
+            .values(status=JobStatus.PAUSED, payload=paused_payload)
+        )
+        await session.execute(
+            update(Document)
+            .where(Document.id == document_id)
+            .values(status=DocumentStatus.PAUSING)
+        )
+        await session.commit()
+
+    yield_now.set()
+    await asyncio.wait_for(running, timeout=1)
+
+    async with SessionLocal() as session:
+        paused_job = await session.get(Job, job_id)
+        paused_document = await session.get(Document, document_id)
+        assert paused_job.status == JobStatus.PAUSED
+        assert paused_job.payload == paused_payload
+        assert paused_document.status == DocumentStatus.PAUSED
+
+
+@pytest.mark.asyncio
+async def test_stale_pause_signal_cannot_pause_a_new_worker_claim(monkeypatch):
+    from sqlalchemy import update
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Job
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.control import JobPaused
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+
+    await init_db()
+    async with SessionLocal() as session:
+        job = Job(type=JobType.PROCESS_DOCUMENT, status=JobStatus.QUEUED)
+        session.add(job)
+        await session.commit()
+        job_id = job.id
+
+    old_entered = asyncio.Event()
+    pause_old = asyncio.Event()
+    new_entered = asyncio.Event()
+    finish_new = asyncio.Event()
+    handler_calls = 0
+
+    async def handler(*_args, **_kwargs):
+        nonlocal handler_calls
+        handler_calls += 1
+        if handler_calls == 1:
+            old_entered.set()
+            await pause_old.wait()
+            raise JobPaused
+        new_entered.set()
+        await finish_new.wait()
+
+    monkeypatch.setitem(TASK_HANDLERS, JobType.PROCESS_DOCUMENT, handler)
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=2)
+    old_worker = asyncio.create_task(queue._run_job(job_id))
+    await asyncio.wait_for(old_entered.wait(), timeout=1)
+
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Job)
+            .where(Job.id == job_id)
+            .values(
+                status=JobStatus.QUEUED,
+                started_at=None,
+                payload={"resume_requested": True},
+            )
+        )
+        await session.commit()
+
+    new_worker = asyncio.create_task(queue._run_job(job_id))
+    await asyncio.wait_for(new_entered.wait(), timeout=1)
+    async with SessionLocal() as session:
+        newly_claimed = await session.get(Job, job_id)
+        new_claim_started_at = newly_claimed.started_at
+        assert newly_claimed.status == JobStatus.RUNNING
+        assert new_claim_started_at is not None
+
+    pause_old.set()
+    await asyncio.wait_for(old_worker, timeout=1)
+    async with SessionLocal() as session:
+        still_claimed = await session.get(Job, job_id)
+        assert still_claimed.status == JobStatus.RUNNING
+        assert still_claimed.started_at == new_claim_started_at
+
+    finish_new.set()
+    await asyncio.wait_for(new_worker, timeout=1)
+    async with SessionLocal() as session:
+        completed = await session.get(Job, job_id)
+        assert completed.status == JobStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_durable_enqueue_keeps_retrying_until_dispatch_succeeds(monkeypatch):
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+
+    queue = InProcessAsyncQueue(None, engine_manager=None, concurrency=0)
+    attempts = 0
+    delivered = asyncio.Event()
+
+    async def flaky_enqueue(job_id):
+        nonlocal attempts
+        assert job_id == "durable-job"
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("queue temporarily unavailable")
+        delivered.set()
+
+    monkeypatch.setattr(queue, "enqueue", flaky_enqueue)
+    monkeypatch.setattr("sag_api.jobs.inproc._RETRY_ENQUEUE_RETRY_SECONDS", 0.0)
+
+    await queue.enqueue_durably("durable-job")
+    await asyncio.wait_for(delivered.wait(), timeout=1)
+
+    assert attempts == 3
+    await queue.stop()
 
 
 @pytest.mark.asyncio
@@ -205,3 +536,170 @@ async def test_worker_keeps_non_retryable_document_failed(monkeypatch):
         assert failed_document.error == "invalid document"
         await session.delete(await session.get(Source, source_id))
         await session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_kind", ["permanent", "attempts_exhausted"])
+async def test_delete_job_stops_retrying_and_remains_hidden_on_terminal_failure(
+    monkeypatch,
+    failure_kind,
+):
+    from sag_api.core.config import settings
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ServiceUnavailableError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+    from sag_api.services.document_service import list_documents
+
+    await init_db()
+    initial_attempts = (
+        settings.job_max_attempts - 1
+        if failure_kind == "attempts_exhausted"
+        else 0
+    )
+    message = (
+        "cleanup temporarily unavailable"
+        if failure_kind == "attempts_exhausted"
+        else "invalid cleanup target"
+    )
+    async with SessionLocal() as session:
+        source = Source(
+            name=f"terminal-delete-{failure_kind}",
+            sag_source_config_id=f"terminal-delete-{failure_kind}-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="hidden-delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/hidden-delete.md",
+            status=DocumentStatus.DELETING,
+            sag_source_id="derived-hidden-delete",
+        )
+        session.add(document)
+        await session.flush()
+        job = Job(
+            type=JobType.DELETE_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+            attempts=initial_attempts,
+        )
+        session.add(job)
+        await session.commit()
+        source_id, document_id, job_id = source.id, document.id, job.id
+
+    async def fail_cleanup(*_args, **_kwargs):
+        if failure_kind == "attempts_exhausted":
+            raise ServiceUnavailableError(message)
+        raise ValueError(message)
+
+    monkeypatch.setitem(TASK_HANDLERS, JobType.DELETE_DOCUMENT, fail_cleanup)
+    scheduled: list[str] = []
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=1)
+    monkeypatch.setattr(
+        queue,
+        "_schedule_retry",
+        lambda queued_job_id, _delay: scheduled.append(queued_job_id),
+    )
+
+    try:
+        await queue._run_job(job_id)
+
+        async with SessionLocal() as session:
+            failed_job = await session.get(Job, job_id)
+            hidden_document = await session.get(Document, document_id)
+            visible_documents = await list_documents(session, source_id)
+            assert failed_job.status == JobStatus.FAILED
+            assert failed_job.attempts == initial_attempts + 1
+            assert failed_job.error == message
+            assert hidden_document.status == DocumentStatus.DELETE_FAILED
+            assert hidden_document.error == message
+            assert document_id not in {
+                document.id for document in visible_documents
+            }
+            assert scheduled == []
+    finally:
+        await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_reprocess_failure_cannot_override_concurrent_delete(monkeypatch):
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import JobStatus
+    from sag_api.jobs.inproc import InProcessAsyncQueue
+    from sag_api.jobs.tasks import TASK_HANDLERS
+    from sag_api.services.document_service import delete_document
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="delete-wins-reprocess-failure",
+            sag_source_config_id=f"delete-wins-reprocess-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="ready.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/ready.md",
+            status=DocumentStatus.READY,
+            sag_source_id="old-derived-source",
+        )
+        session.add(document)
+        await session.flush()
+        reprocess = Job(
+            type=JobType.REPROCESS_DOCUMENT,
+            status=JobStatus.QUEUED,
+            source_id=source.id,
+            document_id=document.id,
+            payload={"derived_source_ids": ["old-derived-source"]},
+        )
+        session.add(reprocess)
+        await session.commit()
+        source_id, document_id, reprocess_id = source.id, document.id, reprocess.id
+
+    entered = asyncio.Event()
+    fail_now = asyncio.Event()
+
+    async def failing_reprocess(*_args, **_kwargs):
+        entered.set()
+        await fail_now.wait()
+        raise ValueError("invalid reprocess payload")
+
+    monkeypatch.setitem(
+        TASK_HANDLERS,
+        JobType.REPROCESS_DOCUMENT,
+        failing_reprocess,
+    )
+    queue = InProcessAsyncQueue(SessionLocal, engine_manager=None, concurrency=1)
+    running = asyncio.create_task(queue._run_job(reprocess_id))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    async with SessionLocal() as session:
+        source = await session.get(Source, source_id)
+        delete_job = await delete_document(
+            session,
+            source,
+            document_id,
+            job_queue=None,
+        )
+        assert delete_job.status == JobStatus.QUEUED
+
+    fail_now.set()
+    await asyncio.wait_for(running, timeout=1)
+
+    async with SessionLocal() as session:
+        failed_reprocess = await session.get(Job, reprocess_id)
+        deleting = await session.get(Document, document_id)
+        assert failed_reprocess.status == JobStatus.FAILED
+        assert deleting.status == DocumentStatus.DELETING
+        assert deleting.error is None
+    await queue.stop()

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -398,6 +398,7 @@ async def test_concurrent_mineru_failure_creates_one_task_and_one_fallback(
 @pytest.mark.asyncio
 async def test_document_job_sends_parsed_markdown_to_engine(monkeypatch):
     from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus
     from sag_api.jobs import tasks
 
     document = SimpleNamespace(
@@ -429,7 +430,13 @@ async def test_document_job_sends_parsed_markdown_to_engine(monkeypatch):
             pass
 
         async def execute(self, _statement):
-            pass
+            document.status = DocumentStatus.READY
+            document.chunk_count = 2
+            document.event_count = 1
+            document.sag_source_id = "engine-doc"
+            document.progress = 100
+            document.token_usage = 2468
+            return SimpleNamespace(rowcount=1)
 
         async def refresh(self, _instance, attribute_names=None):
             pass

--- a/apps/api/tests/test_document_priority_queue.py
+++ b/apps/api/tests/test_document_priority_queue.py
@@ -712,11 +712,11 @@ async def test_delete_failure_releases_source_maintenance_and_retries_cleanup():
         deleting = await session.get(Document, deleting_id)
         blocked = await session.get(Job, blocked_job_id)
         delete_job = await session.get(Job, delete_job_id)
-        assert deleting.status == DocumentStatus.DELETING
-        assert delete_job.status == JobStatus.QUEUED
+        assert deleting.status == DocumentStatus.DELETE_FAILED
+        assert delete_job.status == JobStatus.FAILED
         assert blocked.payload["resume_requested"] is True
         assert blocked.payload["_scheduler"] == {"priority": 10}
-    assert queue._retry_tasks
+    assert not queue._retry_tasks
     await queue.stop()
 
 
@@ -979,8 +979,20 @@ async def test_deleting_one_active_document_temporarily_yields_and_resumes_its_p
         engine.release_initial_batch.set()
         engine.release_cleanup.set()
         await queue.stop()
-        async with SessionLocal() as session:
-            source = await session.get(Source, source_id)
-            if source is not None:
-                await session.delete(source)
-                await session.commit()
+        # SQLite can retain a writer briefly while cancelled background
+        # refresh jobs unwind. Retry test cleanup so it cannot pollute the
+        # following Universe contract test with this synthetic source.
+        from sqlalchemy.exc import OperationalError
+
+        for attempt in range(5):
+            try:
+                async with SessionLocal() as session:
+                    source = await session.get(Source, source_id)
+                    if source is not None:
+                        await session.delete(source)
+                        await session.commit()
+                break
+            except OperationalError as error:
+                if "database is locked" not in str(error).lower() or attempt == 4:
+                    raise
+                await asyncio.sleep(0.05 * (2**attempt))

--- a/apps/api/tests/test_document_resume.py
+++ b/apps/api/tests/test_document_resume.py
@@ -4,8 +4,46 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
+
+from sag_api.enums import DocumentStatus
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "hidden_status",
+    [DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED],
+)
+async def test_public_document_reads_hide_logically_deleted_rows(hidden_status):
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import NotFoundError
+    from sag_api.db.models import Document, Source
+    from sag_api.services.document_service import get_document, get_public_document
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name=f"hidden-read-{uuid4().hex}",
+            sag_source_config_id=f"hidden-read-config-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="hidden.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/hidden.md",
+            status=hidden_status,
+        )
+        session.add(document)
+        await session.commit()
+
+        assert await get_document(session, source, document.id) is not None
+        with pytest.raises(NotFoundError, match="文档不存在"):
+            await get_public_document(session, source, document.id)
 
 
 @pytest.mark.asyncio
@@ -636,12 +674,10 @@ async def test_pause_and_resume_document_service():
         await session.commit()
 
         paused_job = await pause_document(session, source, document.id)
-        assert paused_job.status == JobStatus.RUNNING
-        assert paused_job.payload["pause_requested"] is True
+        assert paused_job.status == JobStatus.PAUSED
         await session.refresh(document)
         assert document.status == DocumentStatus.PAUSING
 
-        paused_job.status = JobStatus.PAUSED
         document.status = DocumentStatus.PAUSED
         await session.commit()
 
@@ -1111,7 +1147,6 @@ async def test_reprocess_ready_document_replaces_all_previous_derived_data():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=engine,
         )
 
         assert engine.deleted == []
@@ -1362,7 +1397,6 @@ async def test_concurrent_reprocess_requests_share_one_cleanup_job():
                 source,
                 document_id,
                 job_queue=queue,
-                engine_manager=object(),
             )
 
     first, second = await asyncio.gather(retry(), retry())
@@ -1444,7 +1478,6 @@ async def test_retrying_failed_reprocess_cleanup_stays_in_maintenance_flow():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=object(),
         )
 
         assert retried.type == JobType.REPROCESS_DOCUMENT
@@ -1511,7 +1544,6 @@ async def test_delete_after_reprocess_request_uses_maintenance_cleanup():
             source,
             document.id,
             job_queue=queue,
-            engine_manager=object(),
         )
         delete_job = await delete_document(
             session,
@@ -1672,3 +1704,376 @@ async def test_duplicate_queue_entries_claim_job_once(monkeypatch):
         assert done.status == JobStatus.SUCCEEDED
         assert done.attempts == 1
         assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pause_cannot_overwrite_delete_that_commits_after_job_lookup(monkeypatch):
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ConflictError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import delete_document, pause_document
+
+    class FakeQueue:
+        def __init__(self):
+            self.ids: list[str] = []
+
+        async def enqueue(self, job_id: str):
+            self.ids.append(job_id)
+
+        def begin_source_maintenance(self, _source_id: str, _job_id: str):
+            return None
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="pause-delete-cas",
+            sag_source_config_id="pause-delete-cas-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="pause-delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/pause-delete.md",
+            status=DocumentStatus.EXTRACTING,
+            sag_source_id="engine-pause-delete",
+        )
+        session.add(document)
+        await session.flush()
+        process_job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            source_id=source.id,
+            document_id=document.id,
+            status=JobStatus.RUNNING,
+        )
+        session.add(process_job)
+        await session.commit()
+        source_id, document_id, process_job_id = (
+            source.id,
+            document.id,
+            process_job.id,
+        )
+
+        queue = FakeQueue()
+        real_scalar = session.scalar
+        delete_injected = False
+
+        async def scalar_then_delete(statement, *args, **kwargs):
+            nonlocal delete_injected
+            result = await real_scalar(statement, *args, **kwargs)
+            if (
+                not delete_injected
+                and isinstance(result, Job)
+                and result.id == process_job_id
+            ):
+                delete_injected = True
+                await session.commit()
+                async with SessionLocal() as delete_session:
+                    deleting_source = await delete_session.get(Source, source_id)
+                    await delete_document(
+                        delete_session,
+                        deleting_source,
+                        document_id,
+                        job_queue=queue,
+                    )
+            return result
+
+        monkeypatch.setattr(session, "scalar", scalar_then_delete)
+
+        with pytest.raises(ConflictError, match="删除|状态"):
+            await pause_document(session, source, document_id)
+
+        await session.refresh(document)
+        assert document.status == DocumentStatus.DELETING
+
+
+@pytest.mark.asyncio
+async def test_resume_cannot_overwrite_delete_that_commits_after_job_lookup(monkeypatch):
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ConflictError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import delete_document, resume_document
+
+    class FakeQueue:
+        def __init__(self):
+            self.ids: list[str] = []
+
+        async def enqueue(self, job_id: str):
+            self.ids.append(job_id)
+
+        def begin_source_maintenance(self, _source_id: str, _job_id: str):
+            return None
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="resume-delete-cas",
+            sag_source_config_id="resume-delete-cas-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="resume-delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/resume-delete.md",
+            status=DocumentStatus.PAUSED,
+        )
+        session.add(document)
+        await session.flush()
+        process_job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            source_id=source.id,
+            document_id=document.id,
+            status=JobStatus.PAUSED,
+            payload={"process_checkpoint": {"source_id": "engine-resume-delete"}},
+        )
+        session.add(process_job)
+        await session.commit()
+        source_id, document_id, process_job_id = (
+            source.id,
+            document.id,
+            process_job.id,
+        )
+
+        queue = FakeQueue()
+        real_scalar = session.scalar
+        delete_injected = False
+
+        async def scalar_then_delete(statement, *args, **kwargs):
+            nonlocal delete_injected
+            result = await real_scalar(statement, *args, **kwargs)
+            if (
+                not delete_injected
+                and isinstance(result, Job)
+                and result.id == process_job_id
+            ):
+                delete_injected = True
+                await session.commit()
+                async with SessionLocal() as delete_session:
+                    deleting_source = await delete_session.get(Source, source_id)
+                    await delete_document(
+                        delete_session,
+                        deleting_source,
+                        document_id,
+                        job_queue=queue,
+                    )
+            return result
+
+        monkeypatch.setattr(session, "scalar", scalar_then_delete)
+
+        with pytest.raises(ConflictError, match="删除|状态"):
+            await resume_document(session, source, document_id, job_queue=queue)
+
+        await session.refresh(document)
+        await session.refresh(process_job)
+        assert document.status == DocumentStatus.DELETING
+        assert process_job.status == JobStatus.PAUSED
+
+
+@pytest.mark.asyncio
+async def test_pause_rejects_ready_document_while_job_completion_is_committing():
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.core.errors import ConflictError
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import pause_document
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="pause-finish-cas",
+            sag_source_config_id="pause-finish-cas-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="pause-finish.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/pause-finish.md",
+            status=DocumentStatus.READY,
+            progress=100,
+        )
+        session.add(document)
+        await session.flush()
+        session.add(
+            Job(
+                type=JobType.PROCESS_DOCUMENT,
+                source_id=source.id,
+                document_id=document.id,
+                status=JobStatus.RUNNING,
+                progress=0.99,
+            )
+        )
+        await session.commit()
+
+        with pytest.raises(ConflictError, match="结束|状态"):
+            await pause_document(session, source, document.id)
+
+
+@pytest.mark.parametrize("engine_mode", ["complete", "paused", "error"])
+@pytest.mark.asyncio
+async def test_process_exit_cannot_overwrite_concurrent_delete(
+    monkeypatch,
+    engine_mode,
+):
+    from types import SimpleNamespace
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.jobs.control import JobPaused
+    from sag_api.jobs.tasks import process_document
+    from sag_api.services.document_service import delete_document
+
+    class FakeEngine:
+        async def process_document(self, *_args, **_kwargs):
+            if engine_mode == "error":
+                raise RuntimeError("inflight extraction failed")
+            return SimpleNamespace(
+                paused=engine_mode == "paused",
+                chunk_count=1,
+                event_count=1,
+                source_id="engine-exit-delete",
+                token_usage=50,
+            )
+
+    class FakeQueue:
+        async def enqueue(self, _job_id: str):
+            return None
+
+        def begin_source_maintenance(self, _source_id: str, _job_id: str):
+            return None
+
+        def source_maintenance_requested(self, _source_id: str):
+            return False
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name=f"{engine_mode}-delete-cas",
+            sag_source_config_id=f"{engine_mode}-delete-cas-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename=f"{engine_mode}-delete.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path=f"/tmp/{engine_mode}-delete.md",
+            status=DocumentStatus.EXTRACTING,
+        )
+        session.add(document)
+        await session.flush()
+        process_job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            source_id=source.id,
+            document_id=document.id,
+            status=JobStatus.RUNNING,
+            payload={
+                "process_checkpoint": {
+                    "source_id": "engine-exit-delete",
+                    "chunk_ids": ["chunk-1"],
+                    "processed_chunk_ids": [],
+                }
+            },
+        )
+        session.add(process_job)
+        await session.commit()
+        source_id, document_id = source.id, document.id
+
+        real_refresh = session.refresh
+        delete_injected = False
+
+        async def refresh_then_delete(instance, *args, **kwargs):
+            nonlocal delete_injected
+            await real_refresh(instance, *args, **kwargs)
+            if not delete_injected and isinstance(instance, Document):
+                delete_injected = True
+                await session.commit()
+                async with SessionLocal() as delete_session:
+                    deleting_source = await delete_session.get(Source, source_id)
+                    await delete_document(
+                        delete_session,
+                        deleting_source,
+                        document_id,
+                        job_queue=FakeQueue(),
+                    )
+
+        monkeypatch.setattr(session, "refresh", refresh_then_delete)
+
+        with pytest.raises(JobPaused):
+            await process_document(
+                session,
+                process_job,
+                engine_manager=FakeEngine(),
+                job_queue=FakeQueue(),
+            )
+
+        async with SessionLocal() as verification_session:
+            saved_document = await verification_session.get(Document, document_id)
+            assert saved_document.status == DocumentStatus.DELETING
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_supervised_dispatch_after_persisting_queued_state():
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Job, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import resume_document
+
+    class DurableQueue:
+        def __init__(self):
+            self.ids: list[str] = []
+
+        async def enqueue(self, _job_id: str):
+            raise AssertionError("persisted resume must use supervised dispatch")
+
+        async def enqueue_durably(self, job_id: str):
+            self.ids.append(job_id)
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="resume-durable-dispatch",
+            sag_source_config_id="resume-durable-dispatch-config",
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="resume-durable-dispatch.md",
+            content_type="text/markdown",
+            size_bytes=10,
+            storage_path="/tmp/resume-durable-dispatch.md",
+            status=DocumentStatus.PAUSED,
+        )
+        session.add(document)
+        await session.flush()
+        process_job = Job(
+            type=JobType.PROCESS_DOCUMENT,
+            source_id=source.id,
+            document_id=document.id,
+            status=JobStatus.PAUSED,
+        )
+        session.add(process_job)
+        await session.commit()
+
+        queue = DurableQueue()
+        resumed = await resume_document(
+            session,
+            source,
+            document.id,
+            job_queue=queue,
+        )
+
+        assert resumed.status == JobStatus.QUEUED
+        assert queue.ids == [process_job.id]

--- a/apps/api/tests/test_insights.py
+++ b/apps/api/tests/test_insights.py
@@ -248,10 +248,13 @@ async def test_entity_read_path():
                     f"/api/v1/sources/{sid}/documents/{document_id}",
                     headers=H,
                 )
-                if document_response.status_code == 404:
+                async with sf() as s:
+                    article_deleted = await s.get(Article, "d1") is None
+                if document_response.status_code == 404 and article_deleted:
                     break
                 await asyncio.sleep(0.05)
             assert document_response.status_code == 404
+            assert article_deleted
             source_after_delete = (await c.get(f"/api/v1/sources/{sid}", headers=H)).json()
             assert source_after_delete["document_count"] == 0
             assert source_after_delete["chunk_count"] == 0

--- a/apps/api/tests/test_retrieval_relevance.py
+++ b/apps/api/tests/test_retrieval_relevance.py
@@ -243,3 +243,102 @@ async def test_event_recall_excludes_events_from_logically_deleted_document():
         )
 
     assert scores == {("event-config", "visible-event"): 0.9}
+
+
+@pytest.mark.asyncio
+async def test_delete_failed_source_is_filtered_before_vector_top_k():
+    """A large hidden document must not starve a healthy peer from retrieval."""
+    from uuid import uuid4
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus
+    from sag_api.sag import SearchOutcome
+    from sag_api.services.retrieval_service import retrieve_relevant_sections
+
+    await init_db()
+    config_id = f"prefilter-{uuid4().hex}"
+    async with SessionLocal() as session:
+        source = Source(name="prefilter", sag_source_config_id=config_id)
+        session.add(source)
+        await session.flush()
+        session.add_all(
+            [
+                Document(
+                    source_id=source.id,
+                    filename="hidden.pdf",
+                    content_type="application/pdf",
+                    size_bytes=10,
+                    storage_path="/tmp/prefilter-hidden.pdf",
+                    status=DocumentStatus.DELETE_FAILED,
+                    sag_source_id="engine-hidden-large",
+                ),
+                Document(
+                    source_id=source.id,
+                    filename="visible.pdf",
+                    content_type="application/pdf",
+                    size_bytes=10,
+                    storage_path="/tmp/prefilter-visible.pdf",
+                    status=DocumentStatus.READY,
+                    sag_source_id="engine-visible-peer",
+                ),
+            ]
+        )
+        await session.commit()
+
+        class VisibilityAwareFakeEngine:
+            supports_document_source_exclusions = True
+
+            async def search_many(
+                self,
+                _targets,
+                query,
+                *,
+                strategy=None,
+                top_k=None,
+                exclude_source_ids_by_config=None,
+            ):
+                del strategy
+                rows = [
+                    RetrievedSection(
+                        chunk_id=f"hidden-{index}",
+                        heading="目标主题",
+                        content="目标主题来自删除失败的大文档。",
+                        score=0.99 - index * 0.001,
+                        source_id="engine-hidden-large",
+                        source_config_id=config_id,
+                    )
+                    for index in range(25)
+                ]
+                rows.append(
+                    RetrievedSection(
+                        chunk_id="visible-26",
+                        heading="目标主题",
+                        content="目标主题来自仍然可用的健康文档。",
+                        score=0.8,
+                        source_id="engine-visible-peer",
+                        source_config_id=config_id,
+                    )
+                )
+                excluded = set(
+                    (exclude_source_ids_by_config or {}).get(config_id, ())
+                )
+                rows = [row for row in rows if row.source_id not in excluded]
+                return SearchOutcome(
+                    query=query,
+                    sections=rows[: int(top_k or 8)],
+                    stats={},
+                )
+
+            async def grep_chunks(self, *_args, **_kwargs):
+                return []
+
+        outcome = await retrieve_relevant_sections(
+            VisibilityAwareFakeEngine(),
+            [source],
+            "目标主题",
+            strategy="multi_es_fast",
+            top_k=8,
+        )
+
+    assert [section.chunk_id for section in outcome.sections] == ["visible-26"]

--- a/apps/api/tests/test_search_strategy.py
+++ b/apps/api/tests/test_search_strategy.py
@@ -585,3 +585,251 @@ async def _register_eval(client: httpx.AsyncClient) -> dict[str, str]:
     )
     assert response.status_code == 201, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_vector_search_excludes_hidden_document_sources_before_top_k(
+    monkeypatch,
+):
+    from zleap.sag.core.storage import client as storage_client
+    from zleap.sag.modules.load.processor import DocumentProcessor
+
+    from sag_api.core.config import settings
+    from sag_api.sag.engine_manager import EngineManager
+
+    class VectorClient:
+        def __init__(self):
+            self.filter_query = None
+
+        async def vector_search(
+            self,
+            *,
+            index,
+            field,
+            vector,
+            size,
+            filter_query,
+            **_kwargs,
+        ):
+            assert index == "source_chunks"
+            assert field == "content_vector"
+            assert vector == [0.1, 0.2]
+            assert size == 8
+            self.filter_query = filter_query
+            return [
+                {
+                    "chunk_id": "visible-chunk",
+                    "source_id": "visible-document",
+                    "source_config_id": "source-1",
+                    "heading": "健康文档",
+                    "content": "删除失败的文档不能占满候选。",
+                    "rank": 0,
+                    "_score": 0.9,
+                }
+            ]
+
+    manager = EngineManager(settings)
+    vector_client = VectorClient()
+
+    async def runtime_ready(_sources):
+        return None
+
+    async def generate_embedding(_processor, _query):
+        return [0.1, 0.2]
+
+    monkeypatch.setattr(manager, "_ensure_read_runtime", runtime_ready)
+    monkeypatch.setattr(DocumentProcessor, "generate_embedding", generate_embedding)
+    monkeypatch.setattr(storage_client, "get_es_client", lambda: vector_client)
+
+    outcome = await manager.search_many(
+        [("source-1", None), ("source-2", None)],
+        "目标主题",
+        strategy="vector",
+        top_k=8,
+        exclude_source_ids_by_config={
+            "source-1": ("hidden-a", "hidden-b"),
+            "source-2": ("hidden-c",),
+        },
+    )
+
+    assert [section.chunk_id for section in outcome.sections] == ["visible-chunk"]
+    assert vector_client.filter_query == {
+        "bool": {
+            "filter": [{"terms": {"source_config_id": ["source-1", "source-2"]}}],
+            "must_not": [
+                {
+                    "bool": {
+                        "filter": [
+                            {"term": {"source_config_id": "source-1"}},
+                            {"terms": {"source_id": ["hidden-a", "hidden-b"]}},
+                        ]
+                    }
+                },
+                {
+                    "bool": {
+                        "filter": [
+                            {"term": {"source_config_id": "source-2"}},
+                            {"terms": {"source_id": ["hidden-c"]}},
+                        ]
+                    }
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_grep_excludes_hidden_document_source_before_limit():
+    from zleap.sag.db import get_session_factory
+    from zleap.sag.db.models import SourceChunk
+
+    from sag_api.core.config import settings
+    from sag_api.sag.engine_manager import EngineManager
+
+    source_config_id = f"grep-prefilter-{uuid.uuid4().hex}"
+    manager = EngineManager(settings)
+    try:
+        await manager.provision(source_config_id)
+        async with get_session_factory()() as session:
+            session.add_all(
+                [
+                    SourceChunk(
+                        id=uuid.uuid4().hex,
+                        source_config_id=source_config_id,
+                        source_type="ARTICLE",
+                        source_id="hidden-document",
+                        heading="隐藏文档",
+                        content="唯一关键词",
+                        rank=0,
+                    ),
+                    SourceChunk(
+                        id=uuid.uuid4().hex,
+                        source_config_id=source_config_id,
+                        source_type="ARTICLE",
+                        source_id="visible-document",
+                        heading="健康文档",
+                        content="唯一关键词",
+                        rank=1,
+                    ),
+                ]
+            )
+            await session.commit()
+
+        rows = await manager.grep_chunks(
+            source_config_id,
+            "唯一关键词",
+            limit=1,
+            exclude_source_ids=("hidden-document",),
+        )
+    finally:
+        await manager.aclose_all()
+
+    assert [row["source_id"] for row in rows] == ["visible-document"]
+
+
+@pytest.mark.asyncio
+async def test_multi_search_uses_prefiltered_batch_recall_when_sources_are_hidden(
+    monkeypatch,
+):
+    from sag_api.core.config import settings
+    from sag_api.sag import RetrievedSection, SearchOutcome
+    from sag_api.sag.engine_manager import EngineManager
+
+    manager = EngineManager(settings)
+    batch_calls = 0
+    legacy_calls = 0
+
+    async def batch_recall(
+        _targets,
+        query,
+        *,
+        top_k,
+        requested_sources,
+        exclude_source_ids_by_config,
+    ):
+        nonlocal batch_calls
+        batch_calls += 1
+        assert exclude_source_ids_by_config == {"source-1": ("hidden-document",)}
+        return SearchOutcome(
+            query=query,
+            sections=[
+                RetrievedSection(
+                    chunk_id="visible-chunk",
+                    heading="健康文档",
+                    content="精确模式在删除屏障期间安全降级。",
+                    score=0.9,
+                    source_id="visible-document",
+                    source_config_id="source-1",
+                )
+            ],
+            stats={"chunk_recall": "batch-vector"},
+        )
+
+    async def legacy_search(*_args, **_kwargs):
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return SearchOutcome(query="目标主题", sections=[])
+
+    monkeypatch.setattr(manager, "_search_chunk_vectors", batch_recall)
+    monkeypatch.setattr(manager, "search", legacy_search)
+
+    outcome = await manager.search_many(
+        [("source-1", None)],
+        "目标主题",
+        strategy="multi_es_fast",
+        top_k=8,
+        exclude_source_ids_by_config={"source-1": ("hidden-document",)},
+    )
+
+    assert [section.chunk_id for section in outcome.sections] == ["visible-chunk"]
+    assert batch_calls == 1
+    assert legacy_calls == 0
+    assert outcome.stats["requested_strategy"] == "multi_es_fast"
+    assert outcome.stats["effective_strategy"] == "vector"
+
+
+@pytest.mark.asyncio
+async def test_visibility_prefilter_failure_never_falls_back_to_unfiltered_legacy(
+    monkeypatch,
+):
+    from sag_api.core.config import settings
+    from sag_api.sag import RetrievedSection, SearchOutcome
+    from sag_api.sag.engine_manager import EngineManager
+
+    manager = EngineManager(settings)
+    legacy_calls = 0
+
+    async def broken_prefilter(*_args, **_kwargs):
+        raise RuntimeError("vector backend unavailable")
+
+    async def unfiltered_legacy(*_args, **_kwargs):
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return SearchOutcome(
+            query="目标主题",
+            sections=[
+                RetrievedSection(
+                    chunk_id="hidden-chunk",
+                    heading="隐藏文档",
+                    content="不能回退到未过滤候选。",
+                    score=0.99,
+                    source_id="hidden-document",
+                    source_config_id="source-1",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(manager, "_search_chunk_vectors", broken_prefilter)
+    monkeypatch.setattr(manager, "search", unfiltered_legacy)
+
+    outcome = await manager.search_many(
+        [("source-1", None)],
+        "目标主题",
+        strategy="multi_es_fast",
+        top_k=8,
+        exclude_source_ids_by_config={"source-1": ("hidden-document",)},
+    )
+
+    assert outcome.sections == []
+    assert legacy_calls == 0
+    assert outcome.stats["chunk_recall"] == "batch-vector-prefilter-failed"


### PR DESCRIPTION
## 背景

PR #74 将暂停、恢复、删除等用户意图持久化后，仍有少量并发窗口可能让旧 Worker 覆盖新状态，或让已逻辑删除的文档继续占用检索候选。本 PR 对这些高优边界做收口，不改变现有页面形态和接口成功响应格式。

## 调整内容

- 使用文档状态、任务状态和 Worker 领取标记进行条件更新，保证删除/暂停等较新的用户意图不会被旧任务的完成、失败、让行或重试结果覆盖。
- 暂停、恢复操作同时原子更新 Document 与 PROCESS Job；状态竞争失败时返回明确冲突，不再写入过期状态。
- 删除任务和维护窗口失败改为按错误类型与最大尝试次数进行有限重试；永久错误进入 `DELETE_FAILED`，不再无限停留在“正在删除”。
- 已提交到数据库的上传、恢复、重试、删除和信源同步任务使用受监督派发；即使连续入队失败，也会继续后台重排，避免刷新后长期停在“待处理”。
- “待处理”文档的即时删除增加 Worker 领取栅栏；若任务已在并发窗口中被领取，会自动降级为协作删除，避免删除仍在执行的任务记录和文件。
- 删除中的文档在向量与关键词检索的 Top-K/Limit 之前按文档派生 source id 排除，避免隐藏文档占满候选后导致同信源正常文档无法召回；查询完成后仍保留二次可见性检查以覆盖并发删除。
- 删除请求提交后，文档详情、原文件、预览、解析 Markdown、大纲和按行读取立即遵守逻辑删除屏障。
- 清理重新处理接口中的冗余引擎依赖参数；没有修改 `zleap_sag` 包、数据库结构或前端页面。

## 用户影响

- 暂停、恢复、删除和重试在刷新前后保持一致，不会被旧 Worker 的迟到结果反向覆盖。
- 永久删除错误会明确结束为“删除失败”，临时故障仍在上限内自动重试。
- 删除中的大文档不会挤占正常文档的检索候选。
- 真正尚未启动的文档仍保持即时删除体验；已经开始的任务走安全的协作停止与清理流程。

## 验证

- 后端全量：`322 passed, 1 skipped`
- Ruff：通过
- `git diff --check`：通过
- Docker：API 与 Web 镜像构建成功，两个容器均为 healthy
- API readiness：`{"status":"ready","db":true}`

## Review 重点

- Document/Job 条件更新是否覆盖暂停、恢复、删除与 Worker 终态写入的全部竞争窗口。
- 删除维护窗口的有限重试和同信源任务恢复是否保持原有串行维护语义。
- `multi_es_fast` 存在删除排除条件时切换到 SAG 侧批量向量预过滤的兼容性与失败降级行为。
