### PR TITLE
chore(fnos): 优化 manifest desc 文案(中文)

### DIFF
--- a/docs/fnos/docker-to-native-evaluation.md
+++ b/docs/fnos/docker-to-native-evaluation.md
@@ -317,7 +317,7 @@ packages/fnos/native/sag/
 appname=sag
 version=1.6.0-fnos.1
 display_name=SAG知识库
-desc=Self-hosted AI knowledge base and research workspace
+desc=自托管 AI 知识库与研究工作台
 platform=x86
 os_min_version=1.2.0401
 source=thirdparty

--- a/docs/fnos/docker-to-native-evaluation.md
+++ b/docs/fnos/docker-to-native-evaluation.md
@@ -317,7 +317,7 @@ packages/fnos/native/sag/
 appname=sag
 version=1.6.0-fnos.1
 display_name=SAG知识库
-desc=自托管 AI 知识库与研究工作台
+desc=让散落文档汇聚为可检索、可追溯的知识
 platform=x86
 os_min_version=1.2.0401
 source=thirdparty

--- a/docs/fnos/docker-to-native-evaluation.md
+++ b/docs/fnos/docker-to-native-evaluation.md
@@ -317,7 +317,7 @@ packages/fnos/native/sag/
 appname=sag
 version=1.6.0-fnos.1
 display_name=SAG知识库
-desc=让散落文档汇聚为可检索、可追溯的知识
+desc=AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识
 platform=x86
 os_min_version=1.2.0401
 source=thirdparty

--- a/docs/fnos/native-multi-user-implementation-plan.md
+++ b/docs/fnos/native-multi-user-implementation-plan.md
@@ -125,7 +125,7 @@ Use this manifest, with `__SAG_VERSION__` and `__SAG_PLATFORM__` intentionally r
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=让散落文档汇聚为可检索、可追溯的知识
+desc=AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/docs/fnos/native-multi-user-implementation-plan.md
+++ b/docs/fnos/native-multi-user-implementation-plan.md
@@ -125,7 +125,7 @@ Use this manifest, with `__SAG_VERSION__` and `__SAG_PLATFORM__` intentionally r
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=Self-hosted AI knowledge base and research workspace
+desc=自托管 AI 知识库与研究工作台
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/docs/fnos/native-multi-user-implementation-plan.md
+++ b/docs/fnos/native-multi-user-implementation-plan.md
@@ -125,7 +125,7 @@ Use this manifest, with `__SAG_VERSION__` and `__SAG_PLATFORM__` intentionally r
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=自托管 AI 知识库与研究工作台
+desc=让散落文档汇聚为可检索、可追溯的知识
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/packages/fnos/native/sag/manifest
+++ b/packages/fnos/native/sag/manifest
@@ -1,7 +1,7 @@
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=让散落文档汇聚为可检索、可追溯的知识
+desc=AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/packages/fnos/native/sag/manifest
+++ b/packages/fnos/native/sag/manifest
@@ -1,7 +1,7 @@
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=自托管 AI 知识库与研究工作台
+desc=让散落文档汇聚为可检索、可追溯的知识
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/packages/fnos/native/sag/manifest
+++ b/packages/fnos/native/sag/manifest
@@ -1,7 +1,7 @@
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=Self-hosted AI knowledge base and research workspace
+desc=自托管 AI 知识库与研究工作台
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -75,7 +75,7 @@ export async function validateNativeTemplate(root, platform) {
   const requiredManifest = {
     appname: "sag",
     display_name: "SAG知识库",
-    desc: "Self-hosted AI knowledge base and research workspace",
+    desc: "自托管 AI 知识库与研究工作台",
     os_min_version: "1.2.0302",
     source: "thirdparty",
     maintainer: "Zleap AI",

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -75,7 +75,7 @@ export async function validateNativeTemplate(root, platform) {
   const requiredManifest = {
     appname: "sag",
     display_name: "SAG知识库",
-    desc: "让散落文档汇聚为可检索、可追溯的知识",
+    desc: "AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识",
     os_min_version: "1.2.0302",
     source: "thirdparty",
     maintainer: "Zleap AI",

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -75,7 +75,7 @@ export async function validateNativeTemplate(root, platform) {
   const requiredManifest = {
     appname: "sag",
     display_name: "SAG知识库",
-    desc: "自托管 AI 知识库与研究工作台",
+    desc: "让散落文档汇聚为可检索、可追溯的知识",
     os_min_version: "1.2.0302",
     source: "thirdparty",
     maintainer: "Zleap AI",


### PR DESCRIPTION
## Summary
- `packages/fnos/native/sag/manifest` 的 `desc` 改为 **AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识**
  - 前半 "AI 知识库" 点品类,与 `display_name=SAG知识库` 互补(不重复带 SAG)
  - 后半承接 README "turns scattered documents and data into knowledge that is searchable, connected, and traceable",突出 SAG 的两个核心卖点:**检索** + **溯源**
  - fnOS App Center 卡片扫读节奏更好
- 同步更新 `scripts/validate-fnos-native-package.mjs` 的 desc 契约
- 同步更新 `docs/fnos/docker-to-native-evaluation.md`、`docs/fnos/native-multi-user-implementation-plan.md` 里的 manifest 示例,避免漂移

## Test plan
- [x] `node --test scripts/tests/fnos-native-package.test.mjs`(20 pass / 2 skip)
- [ ] 复核 fnOS App Center 卡片上 desc 显示效果

🤖 Generated with [Claude Code](https://claude.com/claude-code)