### PR TITLE
docs(fnos): 丰富 App Center 介绍图文

### DIFF
--- a/packages/fnos/native/sag/manifest
+++ b/packages/fnos/native/sag/manifest
@@ -1,7 +1,7 @@
 appname=sag
 version=__SAG_VERSION__
 display_name=SAG知识库
-desc=AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识
+desc=<b>最强 AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识</b><br><br><b>导入知识</b> - 添加文档,SAG 自动完成解析、分块、事件与实体抽取<br><img src="https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-import.png" width=480 /><br><br><b>带引用的回答</b> - Agent 基于选定知识源作答,附带可点击的原文引用<br><img src="https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-chat.png" width=480 /><br><br><b>探索模式</b> - 将整个知识库展开为可交互的知识宇宙,穿梭事件与实体<br><img src="https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-explore-mode.gif" width=480 /><br><br><b>事件实体图谱</b> - 将来源切换为图谱视图,查看事件、实体及其关联<br><img src="https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-graph.png" width=480 />
 platform=__SAG_PLATFORM__
 os_min_version=1.2.0302
 source=thirdparty

--- a/scripts/validate-fnos-native-package.mjs
+++ b/scripts/validate-fnos-native-package.mjs
@@ -75,7 +75,7 @@ export async function validateNativeTemplate(root, platform) {
   const requiredManifest = {
     appname: "sag",
     display_name: "SAG知识库",
-    desc: "AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识",
+    desc: "<b>最强 AI 知识库 · 让散落文档汇聚为可检索、可追溯的知识</b><br><br><b>导入知识</b> - 添加文档,SAG 自动完成解析、分块、事件与实体抽取<br><img src=\"https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-import.png\" width=480 /><br><br><b>带引用的回答</b> - Agent 基于选定知识源作答,附带可点击的原文引用<br><img src=\"https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-chat.png\" width=480 /><br><br><b>探索模式</b> - 将整个知识库展开为可交互的知识宇宙,穿梭事件与实体<br><img src=\"https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-explore-mode.gif\" width=480 /><br><br><b>事件实体图谱</b> - 将来源切换为图谱视图,查看事件、实体及其关联<br><img src=\"https://raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/docs/assets/readme/product-graph.png\" width=480 />",
     os_min_version: "1.2.0302",
     source: "thirdparty",
     maintainer: "Zleap AI",


### PR DESCRIPTION
## Summary

- 把 fnOS App Center 的 desc 从一句 tagline 扩成「tagline + 四段功能演示」的图文排版
- 参考 README.md 的四个主要演示步骤:导入知识 / 带引用的回答 / 探索模式 / 事件实体图谱
- 每段一行说明 + 一张主图,图片来自 `docs/assets/readme/` 已有素材,通过 `raw.githubusercontent.com/Zleap-AI/SAG/fnos/develop/…` 引用
- HTML 只用 fnOS 应用中心富文本白名单支持的 `<b>` / `<br>` / `<img>`(HTML width attr,非 CSS style);此前尝试过的 `<video>` 与 `style='…'` 均不生效,已避开
- 同步更新 `scripts/validate-fnos-native-package.mjs` 让合约期望值与 manifest 一致

## Test plan

- [x] `node --test scripts/tests/fnos-native-package.test.mjs` — 20 pass / 2 skip
- [x] 4 张图片 URL `curl -I` 全部返回 HTTP 200
- [x] 本地打出 `sag-1.5.3-fnos.6-x86.fpk`,装到 fnOS 设备后 App Center 的介绍图文渲染正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)