### PR TITLE
feat(octx): 支持单文档导出与任务诊断日志

### DIFF
--- a/apps/api/sag_api/api/v1/octx.py
+++ b/apps/api/sag_api/api/v1/octx.py
@@ -69,6 +69,7 @@ async def create_document_export(
     source_id: str,
     document_id: str,
     body: OctxExportCreate,
+    transfer_id: str | None = Header(default=None, alias="X-OCTX-Transfer-ID"),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
@@ -80,6 +81,7 @@ async def create_document_export(
             document_id,
             version=body.version,
             job_queue=job_queue,
+            transfer_id=transfer_id,
             requested_by_user_id=user.id,
         )
     return OctxTransferOut.from_transfer(transfer)

--- a/apps/api/sag_api/api/v1/octx.py
+++ b/apps/api/sag_api/api/v1/octx.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sag_api.core.db import SessionLocal, get_session
 from sag_api.core.deps import get_current_user, get_job_queue
-from sag_api.core.errors import ConflictError, NotFoundError
+from sag_api.core.errors import ConflictError, ForbiddenError, NotFoundError
 from sag_api.db.models import OctxRelease, OctxSourceBinding, OctxTransfer, User
 from sag_api.db.models.octx import transition_transfer
 from sag_api.enums import OctxTransferStatus
@@ -18,7 +18,9 @@ from sag_api.schemas.octx import (
     OctxTransferOut,
 )
 from sag_api.services.octx_conflict_service import ImportDecision
+from sag_api.services.octx_diagnostics_service import build_octx_diagnostic_snapshot
 from sag_api.services.octx_transfer_service import (
+    create_document_export_transfer,
     create_export_transfer,
     create_import_transfer,
     default_octx_storage,
@@ -43,7 +45,7 @@ async def _transfer(session: AsyncSession, transfer_id: str) -> OctxTransfer:
 async def create_import(
     file: UploadFile = File(...),
     transfer_id: str | None = Header(default=None, alias="X-OCTX-Transfer-ID"),
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> OctxTransferOut:
@@ -53,7 +55,33 @@ async def create_import(
         storage=default_octx_storage(),
         job_queue=job_queue,
         transfer_id=transfer_id,
+        requested_by_user_id=user.id,
     )
+    return OctxTransferOut.from_transfer(transfer)
+
+
+@router.post(
+    "/sources/{source_id}/documents/{document_id}/octx-exports",
+    response_model=OctxTransferOut,
+    status_code=202,
+)
+async def create_document_export(
+    source_id: str,
+    document_id: str,
+    body: OctxExportCreate,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+    job_queue: JobQueue = Depends(get_job_queue),
+) -> OctxTransferOut:
+    async with export_request_admission(SessionLocal, source_id):
+        transfer = await create_document_export_transfer(
+            session,
+            source_id,
+            document_id,
+            version=body.version,
+            job_queue=job_queue,
+            requested_by_user_id=user.id,
+        )
     return OctxTransferOut.from_transfer(transfer)
 
 
@@ -64,6 +92,19 @@ async def get_transfer(
     session: AsyncSession = Depends(get_session),
 ) -> OctxTransferOut:
     return OctxTransferOut.from_transfer(await _transfer(session, transfer_id))
+
+
+@router.get("/octx/transfers/{transfer_id}/diagnostics")
+async def get_transfer_diagnostics(
+    transfer_id: str,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    transfer = await _transfer(session, transfer_id)
+    owner_id = str((transfer.checkpoint or {}).get("requested_by_user_id") or "")
+    if not owner_id or owner_id != user.id:
+        raise ForbiddenError("OCTX diagnostic bundle is not available for this user")
+    return await build_octx_diagnostic_snapshot(session, transfer_id)
 
 
 @router.post(
@@ -107,7 +148,10 @@ async def download_artifact(
     return FileResponse(
         path,
         media_type="application/vnd.octx+zip",
-        filename=f"{transfer.asset_id or transfer.id}-{transfer.package_version or 'release'}.octx",
+        filename=(
+            f"{str((transfer.checkpoint or {}).get('asset_name') or transfer.asset_id or transfer.id)}"
+            f"-{transfer.package_version or 'release'}.octx"
+        ),
         headers={"ETag": f'"{digest}"', "Digest": digest},
     )
 
@@ -120,13 +164,17 @@ async def download_artifact(
 async def create_export(
     source_id: str,
     body: OctxExportCreate,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> OctxTransferOut:
     async with export_request_admission(SessionLocal, source_id):
         transfer = await create_export_transfer(
-            session, source_id, version=body.version, job_queue=job_queue
+            session,
+            source_id,
+            version=body.version,
+            job_queue=job_queue,
+            requested_by_user_id=user.id,
         )
     return OctxTransferOut.from_transfer(transfer)
 

--- a/apps/api/sag_api/db/models/__init__.py
+++ b/apps/api/sag_api/db/models/__init__.py
@@ -5,6 +5,7 @@ from sag_api.db.models.document import Document
 from sag_api.db.models.job import Job
 from sag_api.db.models.octx import (
     OctxAsset,
+    OctxDocumentBinding,
     OctxInstallation,
     OctxOperationLease,
     OctxRelease,
@@ -29,6 +30,7 @@ __all__ = [
     "Job",
     "Message",
     "OctxAsset",
+    "OctxDocumentBinding",
     "OctxInstallation",
     "OctxOperationLease",
     "OctxRelease",

--- a/apps/api/sag_api/db/models/octx.py
+++ b/apps/api/sag_api/db/models/octx.py
@@ -81,6 +81,25 @@ class OctxSourceBinding(TimestampMixin, Base):
     workspace_key: Mapped[str | None] = mapped_column(String(1024), nullable=True)
 
 
+class OctxDocumentBinding(TimestampMixin, Base):
+    """Stable producer identity for an independently exported document."""
+
+    __tablename__ = "octx_document_bindings"
+
+    document_id: Mapped[str] = mapped_column(
+        ForeignKey("documents.id", ondelete="CASCADE"), primary_key=True
+    )
+    asset_id: Mapped[str] = mapped_column(
+        ForeignKey("octx_assets.id", ondelete="RESTRICT"), index=True
+    )
+    active_release_id: Mapped[str] = mapped_column(
+        ForeignKey("octx_releases.id", ondelete="RESTRICT")
+    )
+    content_revision: Mapped[int] = mapped_column(BigInteger, default=0)
+    released_revision: Mapped[int] = mapped_column(BigInteger, default=0)
+    workspace_key: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+
+
 class OctxInstallation(IDMixin, TimestampMixin, Base):
     __tablename__ = "octx_installations"
     __table_args__ = (

--- a/apps/api/sag_api/desktop.py
+++ b/apps/api/sag_api/desktop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import multiprocessing
 import os
 
 import uvicorn
@@ -19,6 +20,10 @@ def _port() -> int:
 
 
 def main() -> None:
+    # PyInstaller children re-enter this executable. Dispatch multiprocessing
+    # bootstrap arguments before Uvicorn starts, otherwise an OCTX worker would
+    # launch a second API server and collide with the desktop sidecar port.
+    multiprocessing.freeze_support()
     uvicorn.run(
         "sag_api.main:app",
         host=os.getenv("SAG_DESKTOP_HOST", "127.0.0.1"),

--- a/apps/api/sag_api/jobs/octx_tasks.py
+++ b/apps/api/sag_api/jobs/octx_tasks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sag_api.core.config import settings
@@ -9,6 +11,7 @@ from sag_api.db.models import Job, OctxTransfer
 from sag_api.db.models.octx import transition_transfer
 from sag_api.enums import OctxTransferStatus
 from sag_api.octx.runner import OctxRunner
+from sag_api.services.octx_diagnostics_service import append_octx_trace
 from sag_api.services.octx_gc_service import gc_expired_transfers, gc_installation
 from sag_api.services.octx_transfer_service import (
     default_octx_storage,
@@ -18,6 +21,8 @@ from sag_api.services.octx_transfer_service import (
 )
 from sag_api.services.source_operation_service import acquire_transfer_operation_lease
 
+log = logging.getLogger(__name__)
+
 
 async def _record_transfer_error(
     session: AsyncSession,
@@ -25,6 +30,7 @@ async def _record_transfer_error(
     error: Exception,
     *,
     retry_status: OctxTransferStatus,
+    job_id: str | None = None,
 ) -> None:
     await session.rollback()
     transfer = await session.get(OctxTransfer, transfer_id)
@@ -46,17 +52,31 @@ async def _record_transfer_error(
         "retryable": retryable,
     }
     details = getattr(error, "details", None)
+    layer = getattr(error, "layer", None)
+    stage = getattr(error, "stage", None)
     if isinstance(details, dict):
-        layer = getattr(error, "layer", None)
-        stage = getattr(error, "stage", None)
-        error_payload.update(
-            {
-                "layer": str(getattr(layer, "value", layer)),
-                "stage": str(getattr(stage, "value", stage)),
-                "details": details,
-            }
-        )
+        error_payload["layer"] = str(getattr(layer, "value", layer))
+        error_payload["stage"] = str(getattr(stage, "value", stage))
+        error_payload["details"] = details
     transfer.error = error_payload
+    progress_detail = dict((transfer.checkpoint or {}).get("progress_detail") or {})
+    trace_stage = str(
+        (str(getattr(stage, "value", stage)) if stage is not None else "")
+        or progress_detail.get("kind")
+        or progress_detail.get("phase")
+        or "octx_task"
+    )
+    append_octx_trace(
+        transfer,
+        stage=trace_stage,
+        state="retrying" if retryable else "failed",
+        details={
+            "job_id": job_id,
+            "source_id": transfer.target_source_id,
+            "code": error_payload["code"],
+            "error_type": error.__class__.__name__,
+        },
+    )
     await session.commit()
 
 
@@ -81,6 +101,15 @@ async def preflight_octx(session: AsyncSession, job: Job, *, engine_manager=None
             transfer.id,
             error,
             retry_status=OctxTransferStatus.VALIDATING,
+            job_id=job.id,
+        )
+        log.exception(
+            "OCTX preflight failed transfer=%s job=%s source=%s stage=%s code=%s",
+            transfer.id,
+            job.id,
+            transfer.target_source_id,
+            getattr(getattr(error, "stage", None), "value", "preflight"),
+            getattr(error, "code", "internal_error"),
         )
         raise
     job.progress = 1.0
@@ -97,6 +126,13 @@ async def export_octx(session: AsyncSession, job: Job, *, engine_manager=None, j
     if not transfer.target_source_id:
         raise RuntimeError("OCTX export has no source")
     try:
+        append_octx_trace(
+            transfer,
+            stage="queued",
+            state="started",
+            details={"job_id": job.id, "source_id": transfer.target_source_id},
+        )
+        await session.commit()
         async with acquire_transfer_operation_lease(
             SessionLocal,
             [f"source:{transfer.target_source_id}"],
@@ -117,6 +153,15 @@ async def export_octx(session: AsyncSession, job: Job, *, engine_manager=None, j
             transfer_id,
             error,
             retry_status=OctxTransferStatus.QUEUED,
+            job_id=job.id,
+        )
+        log.exception(
+            "OCTX export failed transfer=%s job=%s source=%s stage=%s code=%s",
+            transfer_id,
+            job.id,
+            transfer.target_source_id,
+            getattr(getattr(error, "stage", None), "value", "export"),
+            getattr(error, "code", "internal_error"),
         )
         raise
     job.progress = 1.0
@@ -134,6 +179,13 @@ async def import_octx(session: AsyncSession, job: Job, *, engine_manager=None, j
     if transfer.target_source_id:
         resources.append(f"source:{transfer.target_source_id}")
     try:
+        append_octx_trace(
+            transfer,
+            stage="queued",
+            state="started",
+            details={"job_id": job.id, "source_id": transfer.target_source_id},
+        )
+        await session.commit()
         async with acquire_transfer_operation_lease(
             SessionLocal,
             resources,
@@ -153,6 +205,15 @@ async def import_octx(session: AsyncSession, job: Job, *, engine_manager=None, j
             transfer_id,
             error,
             retry_status=OctxTransferStatus.QUEUED,
+            job_id=job.id,
+        )
+        log.exception(
+            "OCTX import failed transfer=%s job=%s source=%s stage=%s code=%s",
+            transfer_id,
+            job.id,
+            transfer.target_source_id,
+            getattr(getattr(error, "stage", None), "value", "import"),
+            getattr(error, "code", "internal_error"),
         )
         raise
     job.progress = 1.0

--- a/apps/api/sag_api/octx/runner.py
+++ b/apps/api/sag_api/octx/runner.py
@@ -17,6 +17,59 @@ from sag_api.octx.storage import StoredUpload
 logger = logging.getLogger(__name__)
 
 
+class OctxWorkerExitedError(RuntimeError):
+    """The isolated OCTX process exited before returning a result."""
+
+    error_type = "OctxWorkerExited"
+
+    def __init__(self, message: str, *, exitcode: int | None = None) -> None:
+        super().__init__(message)
+        self.exitcode = exitcode
+        self.report = None
+
+
+class OctxWorkerResourceLimitError(OctxWorkerExitedError):
+    """The isolated OCTX process exhausted its bounded memory budget."""
+
+    error_type = "OctxWorkerMemoryLimit"
+
+
+def _worker_exit_error(
+    operation: str,
+    *,
+    exitcode: int | None,
+    memory_mb: int,
+) -> OctxWorkerExitedError:
+    # On POSIX, multiprocessing reports signal exits as negative numbers.
+    # SIGKILL is the usual OS/cgroup OOM termination; macOS malloc failures may
+    # abort with SIGABRT. The Windows status is STATUS_NO_MEMORY as signed int.
+    if exitcode in {-9, -6, -1073741801}:
+        return OctxWorkerResourceLimitError(
+            f"OCTX {operation} worker exceeded the {memory_mb} MB memory safety limit (exit_code={exitcode})",
+            exitcode=exitcode,
+        )
+    return OctxWorkerExitedError(
+        f"OCTX {operation} worker exited unexpectedly (exit_code={exitcode})",
+        exitcode=exitcode,
+    )
+
+
+def _worker_reported_error(
+    operation: str,
+    message: dict[str, Any],
+    *,
+    memory_mb: int,
+) -> RuntimeError:
+    if message.get("error_type") == "MemoryError":
+        return OctxWorkerResourceLimitError(
+            f"OCTX {operation} worker exceeded the {memory_mb} MB memory safety limit",
+        )
+    error = RuntimeError(f"{message['error_type']}: {message['message']}")
+    error.error_type = message["error_type"]
+    error.report = message.get("report")
+    return error
+
+
 def _summarize_report_issues(report: dict[str, Any], limit: int = 30) -> list[dict[str, Any]]:
     if not isinstance(report, dict):
         return []
@@ -120,6 +173,7 @@ class BuiltPackage:
 
 
 def _run_process(operation: str, payload: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    memory_mb = int(payload.get("memory_mb") or 0)
     context = multiprocessing.get_context("spawn")
     parent, child = context.Pipe(duplex=False)
     process = context.Process(target=worker_entry, args=(child, operation, payload))
@@ -133,15 +187,23 @@ def _run_process(operation: str, payload: dict[str, Any], *, timeout_seconds: in
                 process.kill()
                 process.join(2)
             raise TimeoutError(f"OCTX {operation} exceeded {timeout_seconds}s")
-        message = parent.recv()
+        try:
+            message = parent.recv()
+        except EOFError as error:
+            process.join(2)
+            if process.is_alive():
+                process.terminate()
+                process.join(2)
+            raise _worker_exit_error(
+                operation,
+                exitcode=process.exitcode,
+                memory_mb=memory_mb,
+            ) from error
     finally:
         parent.close()
         process.join(2)
     if not message["ok"]:
-        error = RuntimeError(f"{message['error_type']}: {message['message']}")
-        error.error_type = message["error_type"]
-        error.report = message.get("report")
-        raise error
+        raise _worker_reported_error(operation, message, memory_mb=memory_mb)
     return message["result"]
 
 
@@ -184,7 +246,7 @@ class OctxRunner:
                 payload,
                 timeout_seconds=self.settings.octx_worker_timeout_seconds,
             )
-        except TimeoutError as error:
+        except (TimeoutError, OctxWorkerResourceLimitError) as error:
             raise ApiError(
                 str(error),
                 code=ErrorCode.OCTX_RESOURCE_LIMIT,

--- a/apps/api/sag_api/octx/semver.py
+++ b/apps/api/sag_api/octx/semver.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import total_ordering
+
+_SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+@total_ordering
+@dataclass(frozen=True, slots=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            self.prerelease,
+        ) == (
+            other.major,
+            other.minor,
+            other.patch,
+            other.prerelease,
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if core != other_core:
+            return core < other_core
+        if not self.prerelease:
+            return False
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            left_numeric = left.isdigit()
+            right_numeric = right.isdigit()
+            if left_numeric and right_numeric:
+                return int(left) < int(right)
+            if left_numeric != right_numeric:
+                return left_numeric
+            return left < right
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def parse_semver(value: str) -> SemVer:
+    match = _SEMVER_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError("invalid SemVer")
+    prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+    return SemVer(
+        major=int(match.group(1)),
+        minor=int(match.group(2)),
+        patch=int(match.group(3)),
+        prerelease=prerelease,
+    )
+
+
+def validate_semver(value: str) -> str:
+    parse_semver(value)
+    return value
+
+
+def bump_semver_patch(value: str) -> str:
+    parsed = parse_semver(value)
+    return f"{parsed.major}.{parsed.minor}.{parsed.patch + 1}"

--- a/apps/api/sag_api/octx/storage.py
+++ b/apps/api/sag_api/octx/storage.py
@@ -67,6 +67,9 @@ class OctxStorage:
     def workspace_dir(self, source_id: str) -> Path:
         return self.root / "workspaces" / self._component(source_id)
 
+    def document_workspace_dir(self, document_id: str) -> Path:
+        return self.root / "document-workspaces" / self._component(document_id)
+
     def resolve_key(self, key: str) -> Path:
         logical = PurePosixPath(key)
         if logical.is_absolute() or not logical.parts or any(

--- a/apps/api/sag_api/sag/octx_snapshot.py
+++ b/apps/api/sag_api/sag/octx_snapshot.py
@@ -399,8 +399,6 @@ async def export_snapshot(
                             extra_data=_octx_extra(selected_parent.extra_data),
                         )
                         record["level"] = int(event.level)
-                    elif event.parent_id:
-                        record["level"] = 0
                     _write_jsonl(event_output, record)
                     for role in ("event.title", "event.content"):
                         vector_manifest.add(

--- a/apps/api/sag_api/sag/octx_snapshot.py
+++ b/apps/api/sag_api/sag/octx_snapshot.py
@@ -10,8 +10,9 @@ from decimal import Decimal
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from sqlalchemy import exists, func, select
+from sqlalchemy import and_, exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import aliased
 
 from sag_api.octx.errors import OctxSourceReextractRequiredError
 from sag_api.sag.octx_ids import ProducerIdMap
@@ -361,13 +362,23 @@ async def export_snapshot(
                 (data / "events.jsonl").open("x", encoding="utf-8") as event_output,
                 (relations / "chunk-events.jsonl").open("x", encoding="utf-8") as relation_output,
             ):
-                event_rows = await session.stream_scalars(
-                    select(SourceEvent)
+                parent_event = aliased(SourceEvent)
+                event_rows = await session.stream(
+                    select(SourceEvent, parent_event)
+                    .outerjoin(
+                        parent_event,
+                        and_(
+                            parent_event.id == SourceEvent.parent_id,
+                            parent_event.source_config_id == source_config_id,
+                            parent_event.article_id.in_(selected_ids),
+                            parent_event.not_deleted(),
+                        ),
+                    )
                     .where(*selected_event_filter)
                     .order_by(SourceEvent.id)
                     .execution_options(yield_per=500)
                 )
-                async for event in event_rows:
+                async for event, selected_parent in event_rows:
                     event_id = ids.exchange_id("event", event.id, extra_data=_octx_extra(event.extra_data))
                     record = {
                         "id": event_id,
@@ -381,9 +392,15 @@ async def export_snapshot(
                         "end_time": event.end_time,
                     }
                     record.update({key: value for key, value in optional.items() if value})
-                    if event.parent_id:
-                        record["parent_id"] = ids.exchange_id("event", event.parent_id)
+                    if selected_parent is not None:
+                        record["parent_id"] = ids.exchange_id(
+                            "event",
+                            selected_parent.id,
+                            extra_data=_octx_extra(selected_parent.extra_data),
+                        )
                         record["level"] = int(event.level)
+                    elif event.parent_id:
+                        record["level"] = 0
                     _write_jsonl(event_output, record)
                     for role in ("event.title", "event.content"):
                         vector_manifest.add(

--- a/apps/api/sag_api/schemas/octx.py
+++ b/apps/api/sag_api/schemas/octx.py
@@ -46,6 +46,9 @@ class OctxTransferOut(BaseModel):
     record_counts: dict = Field(default_factory=dict)
     capabilities: dict = Field(default_factory=dict)
     progress_detail: dict = Field(default_factory=dict)
+    export_scope: str = "source"
+    document_id: str | None = None
+    document_name: str | None = None
     validation_report: dict | None = None
     warnings: list = Field(default_factory=list)
     error: dict | None = None
@@ -80,6 +83,9 @@ class OctxTransferOut(BaseModel):
             record_counts=dict(checkpoint.get("record_counts") or {}),
             capabilities=dict(checkpoint.get("capabilities") or {}),
             progress_detail=dict(checkpoint.get("progress_detail") or {}),
+            export_scope=str(checkpoint.get("export_scope") or "source"),
+            document_id=checkpoint.get("document_id"),
+            document_name=checkpoint.get("document_name"),
             validation_report=transfer.validation_report,
             warnings=list(transfer.warnings or []),
             error=transfer.error,

--- a/apps/api/sag_api/services/octx_diagnostics_service.py
+++ b/apps/api/sag_api/services/octx_diagnostics_service.py
@@ -138,7 +138,7 @@ async def build_octx_diagnostic_snapshot(
     jobs_result = await session.execute(
         select(Job)
         .where(
-            Job.type.in_((JobType.OCTX_IMPORT, JobType.OCTX_EXPORT)),
+            Job.type.in_((JobType.OCTX_PREFLIGHT, JobType.OCTX_IMPORT, JobType.OCTX_EXPORT)),
             Job.payload["transfer_id"].as_string() == transfer_id,
         )
         .order_by(Job.created_at.desc())

--- a/apps/api/sag_api/services/octx_diagnostics_service.py
+++ b/apps/api/sag_api/services/octx_diagnostics_service.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import platform
+import re
+import shutil
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sag_api.core.config import settings
+from sag_api.db.models import Job, OctxTransfer
+from sag_api.enums import JobType
+
+_TRACE_LIMIT = 100
+_STRING_LIMIT = 2000
+_LIST_LIMIT = 100
+_DEPTH_LIMIT = 6
+_OMITTED_KEYS = {
+    "artifact_path",
+    "body",
+    "content",
+    "raw_text",
+    "storage_path",
+    "vector",
+    "vectors",
+}
+_SECRET_FRAGMENTS = (
+    "api_key",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+_POSIX_HOME_PATH = re.compile(r"/(Users|home)/[^\s\"']+")
+_WINDOWS_HOME_PATH = re.compile(r"[A-Za-z]:\\Users\\[^\s\"']+")
+
+
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def sanitize_octx_diagnostic(value: Any, *, _depth: int = 0) -> Any:
+    """Bound diagnostic data and remove content, credentials, and local paths."""
+    if _depth >= _DEPTH_LIMIT:
+        return "[truncated]"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    if isinstance(value, str):
+        cleaned = _POSIX_HOME_PATH.sub("[local_path]", value)
+        cleaned = _WINDOWS_HOME_PATH.sub("[local_path]", cleaned)
+        return cleaned[:_STRING_LIMIT]
+    if isinstance(value, dict):
+        cleaned: dict[str, Any] = {}
+        for raw_key, item in list(value.items())[:_LIST_LIMIT]:
+            key = str(raw_key)
+            lowered = key.lower()
+            if lowered in _OMITTED_KEYS:
+                continue
+            if any(fragment in lowered for fragment in _SECRET_FRAGMENTS):
+                cleaned[key] = "[redacted]"
+                continue
+            cleaned[key] = sanitize_octx_diagnostic(item, _depth=_depth + 1)
+        return cleaned
+    if isinstance(value, (list, tuple, set)):
+        return [
+            sanitize_octx_diagnostic(item, _depth=_depth + 1)
+            for item in list(value)[:_LIST_LIMIT]
+        ]
+    return sanitize_octx_diagnostic(str(value), _depth=_depth + 1)
+
+
+def append_octx_trace(
+    transfer: OctxTransfer,
+    *,
+    stage: str,
+    state: str,
+    details: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> None:
+    checkpoint = dict(transfer.checkpoint or {})
+    trace = list(checkpoint.get("diagnostic_trace") or [])
+    entry: dict[str, Any] = {
+        "at": (now or datetime.now(UTC)).isoformat(),
+        "stage": stage,
+        "state": state,
+    }
+    if details:
+        entry["details"] = sanitize_octx_diagnostic(details)
+    trace.append(entry)
+    checkpoint["diagnostic_trace"] = trace[-_TRACE_LIMIT:]
+    transfer.checkpoint = checkpoint
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _storage_health() -> dict[str, Any]:
+    configured = Path(settings.data_dir) / "octx"
+    probe = configured
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    result: dict[str, Any] = {
+        "configured": True,
+        "exists": configured.exists(),
+        "writable": os.access(probe, os.W_OK),
+    }
+    try:
+        usage = shutil.disk_usage(probe)
+    except OSError as error:
+        result["disk_check_error"] = error.__class__.__name__
+    else:
+        result["free_bytes"] = usage.free
+        result["total_bytes"] = usage.total
+    return result
+
+
+async def build_octx_diagnostic_snapshot(
+    session: AsyncSession,
+    transfer_id: str,
+) -> dict[str, Any]:
+    transfer = await session.get(OctxTransfer, transfer_id)
+    if transfer is None:
+        raise LookupError(f"OCTX transfer not found: {transfer_id}")
+
+    jobs_result = await session.execute(
+        select(Job)
+        .where(
+            Job.type.in_((JobType.OCTX_IMPORT, JobType.OCTX_EXPORT)),
+            Job.payload["transfer_id"].as_string() == transfer_id,
+        )
+        .order_by(Job.created_at.desc())
+        .limit(20)
+    )
+    jobs = list(jobs_result.scalars())
+    database_backend = make_url(settings.database_url).get_backend_name()
+    checkpoint = dict(transfer.checkpoint or {})
+    snapshot = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "transfer": {
+            "id": transfer.id,
+            "direction": _enum_value(transfer.direction),
+            "status": _enum_value(transfer.status),
+            "scope": str(checkpoint.get("export_scope") or "source"),
+            "document_id": checkpoint.get("document_id"),
+            "progress": transfer.progress,
+            "source_id": transfer.target_source_id,
+            "asset_id": transfer.asset_id,
+            "release_id": transfer.release_id,
+            "package_version": transfer.package_version,
+            "package_digest": transfer.package_digest,
+            "error": transfer.error,
+            "warnings": transfer.warnings,
+            "validation_report": transfer.validation_report,
+            "checkpoint": transfer.checkpoint,
+            "created_at": transfer.created_at,
+            "updated_at": transfer.updated_at,
+        },
+        "jobs": [
+            {
+                "id": job.id,
+                "type": _enum_value(job.type),
+                "status": _enum_value(job.status),
+                "progress": job.progress,
+                "attempts": job.attempts,
+                "error": job.error,
+                "started_at": job.started_at,
+                "finished_at": job.finished_at,
+            }
+            for job in jobs
+        ],
+        "environment": {
+            "sag_version": _package_version("sag-api"),
+            "octx_version": _package_version("octx"),
+            "python": platform.python_version(),
+            "platform": sys.platform,
+            "os_release": platform.release(),
+            "architecture": platform.machine(),
+            "database_backend": database_backend,
+            "vector_provider": settings.sag_vector_provider,
+            "relational_provider": settings.sag_relational_provider or "sqlite",
+            "embedding_model": settings.embedding_model,
+            "embedding_dimensions": settings.embedding_dimensions,
+            "job_concurrency": settings.job_concurrency,
+            "octx_worker_memory_mb": settings.octx_worker_memory_mb,
+            "octx_worker_timeout_seconds": settings.octx_worker_timeout_seconds,
+            "octx_arrow_vector_reuse_enabled": settings.octx_arrow_vector_reuse_enabled,
+            "octx_limits": {
+                "max_upload_mb": settings.octx_max_upload_mb,
+                "max_entries": settings.octx_max_entries,
+                "max_file_mb": settings.octx_max_file_mb,
+                "max_uncompressed_mb": settings.octx_max_uncompressed_mb,
+                "max_jsonl_records": settings.octx_max_jsonl_records,
+            },
+            "storage": _storage_health(),
+        },
+    }
+    return sanitize_octx_diagnostic(snapshot)

--- a/apps/api/sag_api/services/octx_transfer_service.py
+++ b/apps/api/sag_api/services/octx_transfer_service.py
@@ -59,6 +59,7 @@ from sag_api.octx.decision_token import (
     verify_export_decision_token,
 )
 from sag_api.octx.runner import BuildPackageRequest, OctxRunner
+from sag_api.octx.semver import bump_semver_patch, parse_semver, validate_semver
 from sag_api.octx.storage import FileSignature, OctxStorage, StoredUpload
 from sag_api.sag.octx_importer import (
     build_structured_plan,
@@ -1305,8 +1306,43 @@ async def create_document_export_transfer(
     *,
     version: str | None,
     job_queue: JobQueue,
+    transfer_id: str | None = None,
     requested_by_user_id: str | None = None,
 ) -> OctxTransfer:
+    try:
+        requested_version = validate_semver(version) if version is not None else None
+    except ValueError as error:
+        raise ValidationError("OCTX export version must be SemVer") from error
+
+    normalized_transfer_id: str | None = None
+    if transfer_id is not None:
+        try:
+            normalized_transfer_id = uuid.UUID(hex=transfer_id).hex
+        except ValueError as error:
+            raise ValidationError("invalid OCTX transfer id") from error
+        existing = await session.get(OctxTransfer, normalized_transfer_id)
+        if existing is not None:
+            checkpoint = dict(existing.checkpoint or {})
+            existing_owner = str(checkpoint.get("requested_by_user_id") or "")
+            same_request = (
+                existing.direction is OctxTransferDirection.EXPORT
+                and existing.target_source_id == source_id
+                and str(checkpoint.get("export_scope") or "source") == "document"
+                and str(checkpoint.get("document_id") or "") == document_id
+                and (
+                    requested_version is None
+                    or requested_version == checkpoint.get("selected_version")
+                )
+                and (
+                    not requested_by_user_id
+                    or not existing_owner
+                    or requested_by_user_id == existing_owner
+                )
+            )
+            if not same_request:
+                raise ConflictError("OCTX transfer id already belongs to another operation")
+            return existing
+
     active = await session.scalar(
         select(OctxTransfer)
         .where(
@@ -1331,11 +1367,7 @@ async def create_document_export_transfer(
             and str(checkpoint.get("document_id") or "") == document_id
         ):
             active_version = str(checkpoint.get("selected_version") or "")
-            if version is not None:
-                try:
-                    requested_version = str(Version(version))
-                except InvalidVersion as error:
-                    raise ValidationError("OCTX export version must be SemVer") from error
+            if requested_version is not None:
                 if active_version and requested_version != active_version:
                     raise ConflictError(f"OCTX export {active_version} is already active for this source")
             return active
@@ -1358,17 +1390,15 @@ async def create_document_export_transfer(
 
     binding = await session.get(OctxDocumentBinding, document.id)
     active_release = await session.get(OctxRelease, binding.active_release_id) if binding else None
-    if version is not None:
-        try:
-            selected_version = str(Version(version))
-        except InvalidVersion as error:
-            raise ValidationError("OCTX export version must be SemVer") from error
+    if requested_version is not None:
+        selected_version = requested_version
     elif active_release is None:
         selected_version = "1.0.0"
     else:
-        current = Version(active_release.version)
-        selected_version = f"{current.major}.{current.minor}.{current.micro + 1}"
-    if active_release is not None and Version(selected_version) <= Version(active_release.version):
+        selected_version = bump_semver_patch(active_release.version)
+    if active_release is not None and parse_semver(selected_version) <= parse_semver(
+        active_release.version
+    ):
         raise ConflictError("OCTX export version must be greater than the active release")
 
     ready = [
@@ -1396,6 +1426,7 @@ async def create_document_export_transfer(
     if requested_by_user_id:
         checkpoint["requested_by_user_id"] = requested_by_user_id
     transfer = OctxTransfer(
+        id=normalized_transfer_id or new_id(),
         direction=OctxTransferDirection.EXPORT,
         status=OctxTransferStatus.QUEUED,
         progress=0.0,

--- a/apps/api/sag_api/services/octx_transfer_service.py
+++ b/apps/api/sag_api/services/octx_transfer_service.py
@@ -27,6 +27,7 @@ from sag_api.db.models import (
     Document,
     Job,
     OctxAsset,
+    OctxDocumentBinding,
     OctxInstallation,
     OctxRelease,
     OctxSourceBinding,
@@ -73,6 +74,7 @@ from sag_api.services.octx_conflict_service import (
     confirm_import_decision,
     resolve_import_conflict,
 )
+from sag_api.services.octx_diagnostics_service import append_octx_trace
 
 if TYPE_CHECKING:
     from sag_api.jobs import JobQueue
@@ -178,6 +180,7 @@ async def create_import_transfer(
     storage: OctxStorage,
     job_queue: JobQueue,
     transfer_id: str | None = None,
+    requested_by_user_id: str | None = None,
 ) -> OctxTransfer:
     filename = str(upload.filename or "")
     if not filename.casefold().endswith(".octx"):
@@ -191,6 +194,11 @@ async def create_import_transfer(
         if existing is not None:
             if existing.direction is not OctxTransferDirection.IMPORT:
                 raise ConflictError("OCTX transfer id already belongs to another operation")
+            existing_owner = str(
+                (existing.checkpoint or {}).get("requested_by_user_id") or ""
+            )
+            if requested_by_user_id and existing_owner and existing_owner != requested_by_user_id:
+                raise ConflictError("OCTX transfer id already belongs to another user")
             return existing
     else:
         normalized_transfer_id = new_id()
@@ -199,6 +207,11 @@ async def create_import_transfer(
         direction=OctxTransferDirection.IMPORT,
         status=OctxTransferStatus.UPLOADED,
         progress=0.0,
+        checkpoint=(
+            {"requested_by_user_id": requested_by_user_id}
+            if requested_by_user_id
+            else {}
+        ),
         expires_at=datetime.now(UTC) + timedelta(hours=settings.octx_transfer_ttl_hours),
     )
     stored = await storage.stream_upload(upload, transfer.id)
@@ -207,6 +220,12 @@ async def create_import_transfer(
     transfer.staging_key = stored.key
     transition_transfer(transfer, OctxTransferStatus.VALIDATING)
     transfer.progress = 0.02
+    append_octx_trace(
+        transfer,
+        stage="upload",
+        state="completed",
+        details={"size_bytes": stored.signature.size},
+    )
     session.add(transfer)
     job = await _create_job(session, transfer, JobType.OCTX_PREFLIGHT)
     await session.commit()
@@ -1113,6 +1132,7 @@ async def create_export_transfer(
     *,
     version: str | None,
     job_queue: JobQueue,
+    requested_by_user_id: str | None = None,
 ) -> OctxTransfer:
     active = await session.scalar(
         select(OctxTransfer)
@@ -1132,6 +1152,9 @@ async def create_export_transfer(
         .limit(1)
     )
     if active is not None:
+        active_scope = str((active.checkpoint or {}).get("export_scope") or "source")
+        if active_scope != "source":
+            raise ConflictError("another OCTX export is already active for this source")
         active_version = str((active.checkpoint or {}).get("selected_version") or "")
         if version is not None:
             try:
@@ -1187,7 +1210,16 @@ async def create_export_transfer(
             package_version=active_release.version,
             package_digest=active_release.package_digest,
             artifact_key=active_release.artifact_key,
-            checkpoint={"asset_name": active_asset.name, "reused_original": True},
+            checkpoint={
+                "asset_name": active_asset.name,
+                "reused_original": True,
+                "export_scope": "source",
+                **(
+                    {"requested_by_user_id": requested_by_user_id}
+                    if requested_by_user_id
+                    else {}
+                ),
+            },
         )
         session.add(transfer)
         await session.commit()
@@ -1215,6 +1247,9 @@ async def create_export_transfer(
         selected_version=selected_version,
         asset_name=source.name,
     )
+    if requested_by_user_id:
+        checkpoint["requested_by_user_id"] = requested_by_user_id
+    checkpoint["export_scope"] = "source"
     transfer = OctxTransfer(
         direction=OctxTransferDirection.EXPORT,
         status=(OctxTransferStatus.DECISION_REQUIRED if excluded else OctxTransferStatus.QUEUED),
@@ -1260,6 +1295,112 @@ async def create_export_transfer(
     await session.refresh(transfer)
     if job is not None:
         await job_queue.enqueue(job.id)
+    return transfer
+
+
+async def create_document_export_transfer(
+    session: AsyncSession,
+    source_id: str,
+    document_id: str,
+    *,
+    version: str | None,
+    job_queue: JobQueue,
+    requested_by_user_id: str | None = None,
+) -> OctxTransfer:
+    active = await session.scalar(
+        select(OctxTransfer)
+        .where(
+            OctxTransfer.direction == OctxTransferDirection.EXPORT,
+            OctxTransfer.target_source_id == source_id,
+            OctxTransfer.status.not_in(
+                [
+                    OctxTransferStatus.READY,
+                    OctxTransferStatus.FAILED,
+                    OctxTransferStatus.CANCELLED,
+                    OctxTransferStatus.EXPIRED,
+                ]
+            ),
+        )
+        .order_by(OctxTransfer.created_at.desc(), OctxTransfer.id.desc())
+        .limit(1)
+    )
+    if active is not None:
+        checkpoint = dict(active.checkpoint or {})
+        if (
+            str(checkpoint.get("export_scope") or "source") == "document"
+            and str(checkpoint.get("document_id") or "") == document_id
+        ):
+            return active
+        raise ConflictError("another OCTX export is already active for this source")
+
+    source = await session.get(Source, source_id)
+    if source is None:
+        raise NotFoundError("source not found")
+    document = await session.get(Document, document_id)
+    if document is None or document.source_id != source_id or not document.is_active:
+        raise NotFoundError("document not found")
+    if document.status is not DocumentStatus.READY or not document.sag_source_id:
+        raise ConflictError(
+            "only READY documents can be exported as OCTX",
+            code=ErrorCode.OCTX_SOURCE_NOT_EXPORTABLE,
+            layer=ErrorLayer.API,
+            stage=ErrorStage.OCTX_EXPORT,
+            retryable=document.status not in {DocumentStatus.FAILED},
+        )
+
+    binding = await session.get(OctxDocumentBinding, document.id)
+    active_release = await session.get(OctxRelease, binding.active_release_id) if binding else None
+    if version is not None:
+        try:
+            selected_version = str(Version(version))
+        except InvalidVersion as error:
+            raise ValidationError("OCTX export version must be SemVer") from error
+    elif active_release is None:
+        selected_version = "1.0.0"
+    else:
+        current = Version(active_release.version)
+        selected_version = f"{current.major}.{current.minor}.{current.micro + 1}"
+    if active_release is not None and Version(selected_version) <= Version(active_release.version):
+        raise ConflictError("OCTX export version must be greater than the active release")
+
+    ready = [
+        {
+            "id": document.id,
+            "article_id": str(document.sag_source_id),
+            "status": document.status.value,
+        }
+    ]
+    content_revision = binding.content_revision if binding is not None else 0
+    checkpoint = _export_checkpoint(
+        ready=ready,
+        excluded=[],
+        source_revision=content_revision,
+        selected_version=selected_version,
+        asset_name=document.filename,
+    )
+    checkpoint.update(
+        {
+            "export_scope": "document",
+            "document_id": document.id,
+            "document_name": document.filename,
+        }
+    )
+    if requested_by_user_id:
+        checkpoint["requested_by_user_id"] = requested_by_user_id
+    transfer = OctxTransfer(
+        direction=OctxTransferDirection.EXPORT,
+        status=OctxTransferStatus.QUEUED,
+        progress=0.0,
+        target_source_id=source_id,
+        checkpoint=checkpoint,
+        expires_at=datetime.now(UTC) + timedelta(hours=settings.octx_transfer_ttl_hours),
+    )
+    session.add(transfer)
+    await session.flush()
+    job = await _create_job(session, transfer, JobType.OCTX_EXPORT, source_id=source_id)
+    await session.commit()
+    await session.refresh(transfer)
+    await job_queue.enqueue(job.id)
     return transfer
 
 
@@ -1337,6 +1478,9 @@ async def submit_export_decision(
             selected_version=str(previous.get("selected_version") or "1.0.0"),
             asset_name=source.name,
         )
+        checkpoint["export_scope"] = str(previous.get("export_scope") or "source")
+        if previous.get("requested_by_user_id"):
+            checkpoint["requested_by_user_id"] = previous["requested_by_user_id"]
         if not ready:
             checkpoint["allowed_actions"] = []
             checkpoint["decision_stale"] = True
@@ -1439,10 +1583,26 @@ async def execute_export(
             "total": len(selected_documents),
         },
     }
+    append_octx_trace(
+        transfer,
+        stage="selection_frozen",
+        state="completed",
+        details={
+            "document_count": len(selected_documents),
+            "excluded_count": len((transfer.checkpoint or {}).get("excluded_documents") or []),
+        },
+    )
     await session.commit()
     await _ensure_transfer_active(session, transfer, stage="before_snapshot")
     attempt_dir, workspace = _prepare_export_attempt(storage, transfer.id, attempt=attempt)
-    persistent_workspace = storage.workspace_dir(source.id)
+    export_scope = str((transfer.checkpoint or {}).get("export_scope") or "source")
+    export_document_id = str((transfer.checkpoint or {}).get("document_id") or "")
+    if export_scope == "document":
+        if not export_document_id or len(selected_documents) != 1 or selected_documents[0].id != export_document_id:
+            raise ConflictError("OCTX document export selection is invalid")
+        persistent_workspace = storage.document_workspace_dir(export_document_id)
+    else:
+        persistent_workspace = storage.workspace_dir(source.id)
     producer_ids = persistent_workspace / "producer-ids.json"
     if sag_session_factory is None:
         sag_session_factory = await engine_manager.get_sag_session_factory(
@@ -1488,6 +1648,15 @@ async def execute_export(
             **dict(transfer.checkpoint or {}),
             "progress_detail": dict(detail),
         }
+        trace = list((transfer.checkpoint or {}).get("diagnostic_trace") or [])
+        trace_stage = "snapshot_vectors" if detail.get("phase") == "vectors" else "snapshot_structured"
+        if not trace or trace[-1].get("stage") != trace_stage:
+            append_octx_trace(
+                transfer,
+                stage=trace_stage,
+                state="started",
+                details={"kind": detail.get("kind"), "total": detail.get("total")},
+            )
         await session.commit()
 
     async with engine_manager.maintenance(source.sag_source_config_id, source=source):
@@ -1516,6 +1685,12 @@ async def execute_export(
         "vector_roles": sorted(stats.vector_roles),
         "progress_detail": {"phase": "packaging", "kind": "validate_package"},
     }
+    append_octx_trace(
+        transfer,
+        stage="package_validation",
+        state="started",
+        details={"vector_role_count": len(stats.vector_roles)},
+    )
     await session.commit()
     output = attempt_dir / "release.octx"
     try:
@@ -1523,7 +1698,7 @@ async def execute_export(
             BuildPackageRequest(
                 workspace=workspace,
                 output=output,
-                name=source.name,
+                name=str((transfer.checkpoint or {}).get("asset_name") or source.name),
                 version=str((transfer.checkpoint or {}).get("selected_version") or "1.0.0"),
                 capabilities={
                     "sag-structured": "0.1",
@@ -1545,6 +1720,7 @@ async def execute_export(
         **dict(transfer.checkpoint or {}),
         "progress_detail": {"phase": "publishing", "kind": "artifact"},
     }
+    append_octx_trace(transfer, stage="artifact_publish", state="started")
     await session.commit()
     await _ensure_transfer_active(session, transfer, stage="before_publish")
     artifact_key = storage.publish_release(built.output, built.asset_id, built.version, built.package_digest)
@@ -1564,7 +1740,7 @@ async def execute_export(
     if asset is None:
         asset = OctxAsset(
             id=built.asset_id,
-            name=source.name[:200],
+            name=str((transfer.checkpoint or {}).get("asset_name") or source.name)[:200],
             ownership=OctxAssetOwnership.LOCAL,
             producer_source_id=source.id,
         )
@@ -1582,7 +1758,10 @@ async def execute_export(
             version=built.version,
             package_digest=built.package_digest,
             manifest={
-                "asset": {"id": built.asset_id, "name": source.name},
+                "asset": {
+                    "id": built.asset_id,
+                    "name": str((transfer.checkpoint or {}).get("asset_name") or source.name),
+                },
                 "release": {
                     "version": built.version,
                     "package_digest": built.package_digest,
@@ -1594,28 +1773,52 @@ async def execute_export(
         )
         session.add(release)
         await session.flush()
-    binding = await session.get(OctxSourceBinding, source.id)
-    if binding is None:
-        binding = OctxSourceBinding(
-            source_id=source.id,
-            asset_id=asset.id,
-            active_release_id=release.id,
-            content_revision=1,
-            released_revision=1,
-            workspace_key=f"workspaces/{source.id}",
-        )
-        session.add(binding)
+    if export_scope == "document":
+        document_binding = await session.get(OctxDocumentBinding, export_document_id)
+        if document_binding is None:
+            document_binding = OctxDocumentBinding(
+                document_id=export_document_id,
+                asset_id=asset.id,
+                active_release_id=release.id,
+                content_revision=1,
+                released_revision=1,
+                workspace_key=f"document-workspaces/{export_document_id}",
+            )
+            session.add(document_binding)
+        else:
+            document_binding.asset_id = asset.id
+            document_binding.active_release_id = release.id
+            document_binding.released_revision = document_binding.content_revision
+            document_binding.workspace_key = f"document-workspaces/{export_document_id}"
     else:
-        binding.asset_id = asset.id
-        binding.active_release_id = release.id
-        binding.released_revision = binding.content_revision
-        binding.workspace_key = f"workspaces/{source.id}"
+        binding = await session.get(OctxSourceBinding, source.id)
+        if binding is None:
+            binding = OctxSourceBinding(
+                source_id=source.id,
+                asset_id=asset.id,
+                active_release_id=release.id,
+                content_revision=1,
+                released_revision=1,
+                workspace_key=f"workspaces/{source.id}",
+            )
+            session.add(binding)
+        else:
+            binding.asset_id = asset.id
+            binding.active_release_id = release.id
+            binding.released_revision = binding.content_revision
+            binding.workspace_key = f"workspaces/{source.id}"
     transfer.asset_id = asset.id
     transfer.release_id = release.id
     transfer.package_version = release.version
     transfer.package_digest = release.package_digest
     transfer.artifact_key = release.artifact_key
     transfer.validation_report = dict(built.report)
+    append_octx_trace(
+        transfer,
+        stage="ready",
+        state="completed",
+        details={"package_digest": release.package_digest},
+    )
     await _commit_export_ready(session, transfer)
     return transfer
 

--- a/apps/api/sag_api/services/octx_transfer_service.py
+++ b/apps/api/sag_api/services/octx_transfer_service.py
@@ -1330,6 +1330,14 @@ async def create_document_export_transfer(
             str(checkpoint.get("export_scope") or "source") == "document"
             and str(checkpoint.get("document_id") or "") == document_id
         ):
+            active_version = str(checkpoint.get("selected_version") or "")
+            if version is not None:
+                try:
+                    requested_version = str(Version(version))
+                except InvalidVersion as error:
+                    raise ValidationError("OCTX export version must be SemVer") from error
+                if active_version and requested_version != active_version:
+                    raise ConflictError(f"OCTX export {active_version} is already active for this source")
             return active
         raise ConflictError("another OCTX export is already active for this source")
 
@@ -1542,24 +1550,22 @@ async def execute_export(
     source = await session.get(Source, transfer.target_source_id)
     if source is None:
         raise NotFoundError("source not found")
-    documents = (
+    checkpoint = dict(transfer.checkpoint or {})
+    selected_document_ids = tuple(checkpoint.get("selected_document_ids") or ())
+    selected_article_ids = tuple(checkpoint.get("selected_article_ids") or ())
+    selected_documents = (
         (
             await session.execute(
-                select(Document)
-                .where(
+                select(Document).where(
                     Document.source_id == source.id,
                     Document.is_active.is_(True),
+                    Document.id.in_(selected_document_ids),
                 )
-                .order_by(Document.created_at, Document.id)
             )
         )
         .scalars()
         .all()
     )
-    checkpoint = dict(transfer.checkpoint or {})
-    selected_document_ids = tuple(checkpoint.get("selected_document_ids") or ())
-    selected_article_ids = tuple(checkpoint.get("selected_article_ids") or ())
-    selected_documents = [document for document in documents if document.id in selected_document_ids]
     selected_documents.sort(key=lambda document: selected_document_ids.index(document.id))
     if (
         not selected_document_ids

--- a/apps/api/tests/test_octx_diagnostics.py
+++ b/apps/api/tests/test_octx_diagnostics.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+@pytest_asyncio.fixture
+async def diagnostic_sessions(tmp_path):
+    from sag_api.db import models  # noqa: F401
+    from sag_api.db.base import Base
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'meta.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+def test_octx_trace_is_bounded_and_sanitized():
+    from sag_api.db.models import OctxTransfer
+    from sag_api.enums import OctxTransferDirection, OctxTransferStatus
+    from sag_api.services.octx_diagnostics_service import append_octx_trace
+
+    transfer = OctxTransfer(
+        direction=OctxTransferDirection.EXPORT,
+        status=OctxTransferStatus.QUEUED,
+        checkpoint={},
+    )
+
+    for index in range(105):
+        append_octx_trace(
+            transfer,
+            stage="snapshot_structured",
+            state="running",
+            details={
+                "index": index,
+                "content": "private document body",
+                "storage_path": "/Users/private/source.pdf",
+                "api_token": "top-secret-token",
+                "safe": "x" * 3000,
+            },
+        )
+
+    trace = transfer.checkpoint["diagnostic_trace"]
+    serialized = json.dumps(trace)
+    assert len(trace) == 100
+    assert trace[0]["details"]["index"] == 5
+    assert trace[-1]["details"]["index"] == 104
+    assert "private document body" not in serialized
+    assert "/Users/private/source.pdf" not in serialized
+    assert "top-secret-token" not in serialized
+    assert len(trace[-1]["details"]["safe"]) <= 2000
+
+
+@pytest.mark.asyncio
+async def test_octx_diagnostic_snapshot_correlates_job_and_environment(
+    diagnostic_sessions,
+):
+    from sag_api.db.models import Job, OctxTransfer
+    from sag_api.enums import (
+        JobStatus,
+        JobType,
+        OctxTransferDirection,
+        OctxTransferStatus,
+    )
+    from sag_api.services.octx_diagnostics_service import (
+        build_octx_diagnostic_snapshot,
+    )
+
+    async with diagnostic_sessions() as session:
+        transfer = OctxTransfer(
+            direction=OctxTransferDirection.EXPORT,
+            status=OctxTransferStatus.FAILED,
+            checkpoint={"progress_detail": {"stage": "package_validation"}},
+            error={
+                "code": "octx_validation_failed",
+                "message": "package validation failed",
+                "details": {"api_key": "must-not-leak"},
+            },
+        )
+        session.add(transfer)
+        await session.flush()
+        job = Job(
+            type=JobType.OCTX_EXPORT,
+            status=JobStatus.FAILED,
+            payload={"transfer_id": transfer.id},
+            error="Traceback at /Users/private/SAG/octx.py: validation failed",
+            attempts=2,
+        )
+        session.add(job)
+        await session.commit()
+
+        snapshot = await build_octx_diagnostic_snapshot(session, transfer.id)
+
+    serialized = json.dumps(snapshot)
+    assert snapshot["transfer"]["id"] == transfer.id
+    assert snapshot["transfer"]["direction"] == "export"
+    assert snapshot["transfer"]["status"] == "failed"
+    assert snapshot["jobs"][0]["id"] == job.id
+    assert snapshot["jobs"][0]["attempts"] == 2
+    assert snapshot["environment"]["python"]
+    assert snapshot["environment"]["platform"]
+    assert snapshot["environment"]["octx_version"]
+    assert "database_backend" in snapshot["environment"]
+    assert "storage" in snapshot["environment"]
+    assert "must-not-leak" not in serialized
+    assert "/Users/" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_document_export_binding_is_independent_from_source_binding(
+    diagnostic_sessions,
+):
+    from sag_api.db.models import (
+        Document,
+        OctxAsset,
+        OctxDocumentBinding,
+        OctxRelease,
+        Source,
+    )
+    from sag_api.enums import (
+        DocumentStatus,
+        OctxAssetOwnership,
+        OctxReleaseOrigin,
+        SourceStatus,
+        SourceType,
+    )
+
+    async with diagnostic_sessions() as session:
+        source = Source(
+            name="source",
+            source_type=SourceType.DOCUMENT,
+            sag_source_config_id="source-config",
+            status=SourceStatus.ACTIVE,
+        )
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="one.pdf",
+            storage_path="one.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-1",
+        )
+        session.add(document)
+        await session.flush()
+        asset = OctxAsset(
+            id="0198f12d-80c0-7000-8000-000000000001",
+            name="one.pdf",
+            ownership=OctxAssetOwnership.LOCAL,
+            producer_source_id=source.id,
+        )
+        session.add(asset)
+        await session.flush()
+        release = OctxRelease(
+            asset_id=asset.id,
+            version="1.0.0",
+            package_digest="sha256:" + "a" * 64,
+            manifest={},
+            artifact_key="releases/one.octx",
+            created_by=OctxReleaseOrigin.EXPORT,
+        )
+        session.add(release)
+        await session.flush()
+        session.add(
+            OctxDocumentBinding(
+                document_id=document.id,
+                asset_id=asset.id,
+                active_release_id=release.id,
+                content_revision=1,
+                released_revision=1,
+                workspace_key=f"document-workspaces/{document.id}",
+            )
+        )
+        await session.commit()
+
+        binding = await session.get(OctxDocumentBinding, document.id)
+        assert binding is not None
+        assert binding.asset_id == asset.id
+        assert binding.active_release_id == release.id
+
+
+@pytest.mark.asyncio
+async def test_octx_diagnostics_require_the_transfer_creator(diagnostic_sessions):
+    from types import SimpleNamespace
+
+    from sag_api.api.v1.octx import get_transfer_diagnostics
+    from sag_api.core.errors import ForbiddenError
+    from sag_api.db.models import OctxTransfer
+    from sag_api.enums import OctxTransferDirection, OctxTransferStatus
+
+    async with diagnostic_sessions() as session:
+        transfer = OctxTransfer(
+            direction=OctxTransferDirection.EXPORT,
+            status=OctxTransferStatus.FAILED,
+            checkpoint={"requested_by_user_id": "user-1"},
+        )
+        session.add(transfer)
+        await session.commit()
+
+        snapshot = await get_transfer_diagnostics(
+            transfer.id,
+            SimpleNamespace(id="user-1"),
+            session,
+        )
+        assert snapshot["transfer"]["id"] == transfer.id
+
+        with pytest.raises(ForbiddenError):
+            await get_transfer_diagnostics(
+                transfer.id,
+                SimpleNamespace(id="user-2"),
+                session,
+            )

--- a/apps/api/tests/test_octx_diagnostics.py
+++ b/apps/api/tests/test_octx_diagnostics.py
@@ -114,6 +114,36 @@ async def test_octx_diagnostic_snapshot_correlates_job_and_environment(
 
 
 @pytest.mark.asyncio
+async def test_octx_diagnostic_snapshot_includes_preflight_job(diagnostic_sessions):
+    from sag_api.db.models import Job, OctxTransfer
+    from sag_api.enums import JobStatus, JobType, OctxTransferDirection, OctxTransferStatus
+    from sag_api.services.octx_diagnostics_service import build_octx_diagnostic_snapshot
+
+    async with diagnostic_sessions() as session:
+        transfer = OctxTransfer(
+            direction=OctxTransferDirection.IMPORT,
+            status=OctxTransferStatus.FAILED,
+            checkpoint={},
+        )
+        session.add(transfer)
+        await session.flush()
+        preflight = Job(
+            type=JobType.OCTX_PREFLIGHT,
+            status=JobStatus.FAILED,
+            payload={"transfer_id": transfer.id},
+            error="invalid manifest",
+            attempts=1,
+        )
+        session.add(preflight)
+        await session.commit()
+
+        snapshot = await build_octx_diagnostic_snapshot(session, transfer.id)
+
+    assert [job["id"] for job in snapshot["jobs"]] == [preflight.id]
+    assert snapshot["jobs"][0]["type"] == "octx_preflight"
+
+
+@pytest.mark.asyncio
 async def test_document_export_binding_is_independent_from_source_binding(
     diagnostic_sessions,
 ):

--- a/apps/api/tests/test_octx_runtime.py
+++ b/apps/api/tests/test_octx_runtime.py
@@ -8,6 +8,91 @@ import pytest
 from starlette.datastructures import UploadFile
 
 
+def test_desktop_main_prepares_frozen_multiprocessing_before_uvicorn(monkeypatch):
+    """A frozen child must dispatch to multiprocessing instead of starting a second API."""
+    from sag_api import desktop
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        desktop.multiprocessing,
+        "freeze_support",
+        lambda: calls.append("freeze_support"),
+    )
+    monkeypatch.setattr(
+        desktop.uvicorn,
+        "run",
+        lambda *_args, **_kwargs: calls.append("uvicorn"),
+    )
+
+    desktop.main()
+
+    assert calls == ["freeze_support", "uvicorn"]
+
+
+def test_worker_pipe_eof_reports_non_empty_exit_diagnostics():
+    """A crashed worker must not degrade into an empty EOFError in the UI."""
+    from sag_api.octx.runner import _worker_exit_error
+
+    error = _worker_exit_error("build", exitcode=7, memory_mb=2048)
+
+    assert error.error_type == "OctxWorkerExited"
+    assert error.exitcode == 7
+    assert str(error) == "OCTX build worker exited unexpectedly (exit_code=7)"
+
+
+@pytest.mark.parametrize("exitcode", (-9, -6))
+def test_worker_oom_like_exit_is_classified_as_resource_limit(exitcode):
+    """A SIGKILL/SIGABRT child exit must fail only the task as a resource limit."""
+    from sag_api.octx.runner import OctxWorkerResourceLimitError, _worker_exit_error
+
+    error = _worker_exit_error("build", exitcode=exitcode, memory_mb=2048)
+
+    assert isinstance(error, OctxWorkerResourceLimitError)
+    assert error.error_type == "OctxWorkerMemoryLimit"
+    assert error.exitcode == exitcode
+    assert "2048 MB" in str(error)
+
+
+def test_worker_reported_memory_error_is_classified_as_resource_limit():
+    """A caught Python MemoryError must use the same bounded-task failure path."""
+    from sag_api.octx.runner import OctxWorkerResourceLimitError, _worker_reported_error
+
+    error = _worker_reported_error(
+        "build",
+        {"error_type": "MemoryError", "message": "", "report": None},
+        memory_mb=2048,
+    )
+
+    assert isinstance(error, OctxWorkerResourceLimitError)
+    assert error.error_type == "OctxWorkerMemoryLimit"
+    assert "2048 MB" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_runner_maps_worker_memory_limit_to_non_retryable_resource_error(monkeypatch):
+    """Worker OOM must fail only the task with a stable user-facing error code."""
+    from sag_api.core.config import Settings
+    from sag_api.core.errors import ApiError
+    from sag_api.octx import runner as runner_module
+    from sag_api.octx.runner import OctxRunner, OctxWorkerResourceLimitError
+
+    async def raise_memory_limit(*_args, **_kwargs):
+        raise OctxWorkerResourceLimitError("bounded worker OOM", exitcode=-9)
+
+    monkeypatch.setattr(runner_module.asyncio, "to_thread", raise_memory_limit)
+
+    with pytest.raises(ApiError) as caught:
+        await OctxRunner(Settings(_env_file=None))._execute("build", {})
+
+    assert caught.value.to_envelope()["error"] == {
+        "code": "octx_resource_limit",
+        "message": "bounded worker OOM",
+        "layer": "api",
+        "stage": "octx_publish",
+        "retryable": False,
+    }
+
+
 def test_octx_runtime_modules_are_present():
     """Missing an adapter module would push unsafe file handling into API handlers."""
     for name in ("limits", "storage", "errors", "runner"):

--- a/apps/api/tests/test_octx_snapshot.py
+++ b/apps/api/tests/test_octx_snapshot.py
@@ -340,6 +340,7 @@ async def test_export_snapshot_preserves_selected_parent_event_identity(tmp_path
 @pytest.mark.asyncio
 async def test_document_snapshot_detaches_parent_outside_selected_article(tmp_path):
     """A child whose parent is outside the selected documents becomes a root Event."""
+    from octx import create_octx
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from zleap.sag.db.base import Base
     from zleap.sag.db.models import (
@@ -479,9 +480,17 @@ async def test_document_snapshot_detaches_parent_outside_selected_article(tmp_pa
     assert len(event_records) == 1
     child_record = event_records[0]
     assert "parent_id" not in child_record
-    assert child_record["level"] == 0
+    assert "level" not in child_record
     event_ids = {record["id"] for record in event_records}
     assert {record["parent_id"] for record in event_records if record.get("parent_id")} <= event_ids
+
+    result = create_octx(
+        tmp_path / "cross-document-parent-workspace",
+        output=tmp_path / "cross-document-parent.octx",
+        name="Cross document parent",
+        capabilities={"sag-structured": "0.1"},
+    )
+    assert result.report.valid is True
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_octx_snapshot.py
+++ b/apps/api/tests/test_octx_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from decimal import Decimal
 from types import SimpleNamespace
@@ -182,6 +183,305 @@ async def test_export_snapshot_creates_fully_validated_structured_workspace(tmp_
         assert exported_events[0]["title"] == original_event_title
         assert exported_events[0]["content"] == "Exported event"
         assert len(list(package.iter_entities())) == 1
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_preserves_selected_parent_event_identity(tmp_path):
+    """A selected child must retain its selected parent's stored OCTX identity."""
+    from octx import create_octx
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from zleap.sag.db.base import Base
+    from zleap.sag.db.models import (
+        Article,
+        ArticleParseStatus,
+        Entity,
+        EntityType,
+        EventEntity,
+        SourceChunk,
+        SourceConfig,
+        SourceEvent,
+    )
+
+    from sag_api.sag.octx_importer import build_structured_plan
+    from sag_api.sag.octx_snapshot import export_snapshot
+
+    source_config_id = "parent-identity-source"
+    article_id = str(uuid.uuid4())
+    chunk_id = str(uuid.uuid4())
+    entity_id = str(uuid.uuid4())
+    entity_type_id = str(uuid.uuid4())
+    first_id, second_id = sorted(
+        str(uuid.uuid5(uuid.NAMESPACE_URL, name)) for name in ("selected-child", "selected-parent")
+    )
+    child_event_id = first_id
+    parent_event_id = second_id
+    child_record_id = "018f5f7e-89ab-7def-8123-0123456789c1"
+    parent_record_id = "018f5f7e-89ab-7def-8123-0123456789c2"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'parent-identity.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    async with sessions() as session:
+        session.add(SourceConfig(id=source_config_id, name="Parent identity", target_config={}))
+        session.add(
+            Article(
+                id=article_id,
+                source_config_id=source_config_id,
+                title="Selected document",
+                content="Selected document content.",
+                status="COMPLETED",
+                parse_status=ArticleParseStatus.COMPLETED,
+            )
+        )
+        session.add(
+            SourceChunk(
+                id=chunk_id,
+                source_config_id=source_config_id,
+                source_type="ARTICLE",
+                source_id=article_id,
+                article_id=article_id,
+                content="Selected document content.",
+                rank=0,
+                chunk_length=26,
+            )
+        )
+        session.add(
+            EntityType(
+                id=entity_type_id,
+                scope="source",
+                source_config_id=source_config_id,
+                type="topic",
+                name="Topic",
+                weight=Decimal("1.00"),
+                similarity_threshold=Decimal("0.800"),
+            )
+        )
+        session.add(
+            Entity(
+                id=entity_id,
+                source_config_id=source_config_id,
+                entity_type_id=entity_type_id,
+                type="topic",
+                name="Parent identity",
+                normalized_name="parent identity",
+            )
+        )
+        session.add_all(
+            [
+                SourceEvent(
+                    id=parent_event_id,
+                    source_config_id=source_config_id,
+                    source_type="ARTICLE",
+                    source_id=article_id,
+                    article_id=article_id,
+                    title="Parent event",
+                    summary="Parent event",
+                    content="Parent event content.",
+                    rank=0,
+                    level=0,
+                    chunk_id=chunk_id,
+                    extra_data={"octx": {"record_id": parent_record_id}},
+                ),
+                SourceEvent(
+                    id=child_event_id,
+                    source_config_id=source_config_id,
+                    source_type="ARTICLE",
+                    source_id=article_id,
+                    article_id=article_id,
+                    parent_id=parent_event_id,
+                    title="Child event",
+                    summary="Child event",
+                    content="Child event content.",
+                    rank=1,
+                    level=1,
+                    chunk_id=chunk_id,
+                    extra_data={"octx": {"record_id": child_record_id}},
+                ),
+            ]
+        )
+        await session.flush()
+        session.add_all(
+            [
+                EventEntity(id=str(uuid.uuid4()), event_id=parent_event_id, entity_id=entity_id, weight=Decimal("1")),
+                EventEntity(id=str(uuid.uuid4()), event_id=child_event_id, entity_id=entity_id, weight=Decimal("1")),
+            ]
+        )
+        await session.commit()
+
+    try:
+        await export_snapshot(
+            SimpleNamespace(id="source-local", name="Parent identity", sag_source_config_id=source_config_id),
+            [SimpleNamespace(sag_source_id=article_id, filename="selected.md", is_active=True)],
+            tmp_path / "parent-identity-workspace",
+            selected_article_ids=[article_id],
+            producer_state_path=tmp_path / "parent-identity-producer-ids.json",
+            session_factory=sessions,
+        )
+    finally:
+        await engine.dispose()
+
+    event_records = [
+        json.loads(line)
+        for line in (tmp_path / "parent-identity-workspace/data/events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    child_record = next(record for record in event_records if record["id"] == child_record_id)
+    assert child_record["parent_id"] == parent_record_id
+    assert parent_record_id in {record["id"] for record in event_records}
+
+    package_path = create_octx(
+        tmp_path / "parent-identity-workspace",
+        output=tmp_path / "parent-identity.octx",
+        name="Parent identity",
+        capabilities={"sag-structured": "0.1"},
+    ).output
+    build_structured_plan(package_path, tmp_path / "parent-identity-plan.sqlite3", str(uuid.uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_document_snapshot_detaches_parent_outside_selected_article(tmp_path):
+    """A child whose parent is outside the selected documents becomes a root Event."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from zleap.sag.db.base import Base
+    from zleap.sag.db.models import (
+        Article,
+        ArticleParseStatus,
+        Entity,
+        EntityType,
+        EventEntity,
+        SourceChunk,
+        SourceConfig,
+        SourceEvent,
+    )
+
+    from sag_api.sag.octx_snapshot import export_snapshot
+
+    source_config_id = "cross-document-parent-source"
+    parent_article_id = str(uuid.uuid4())
+    child_article_id = str(uuid.uuid4())
+    parent_chunk_id = str(uuid.uuid4())
+    child_chunk_id = str(uuid.uuid4())
+    parent_event_id = str(uuid.uuid4())
+    child_event_id = str(uuid.uuid4())
+    entity_id = str(uuid.uuid4())
+    entity_type_id = str(uuid.uuid4())
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'cross-document-parent.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    async with sessions() as session:
+        session.add(SourceConfig(id=source_config_id, name="Cross document parent", target_config={}))
+        for article_id, title in ((parent_article_id, "Parent document"), (child_article_id, "Child document")):
+            session.add(
+                Article(
+                    id=article_id,
+                    source_config_id=source_config_id,
+                    title=title,
+                    content=f"{title} content.",
+                    status="COMPLETED",
+                    parse_status=ArticleParseStatus.COMPLETED,
+                )
+            )
+        for chunk_id, article_id, content in (
+            (parent_chunk_id, parent_article_id, "Parent document content."),
+            (child_chunk_id, child_article_id, "Child document content."),
+        ):
+            session.add(
+                SourceChunk(
+                    id=chunk_id,
+                    source_config_id=source_config_id,
+                    source_type="ARTICLE",
+                    source_id=article_id,
+                    article_id=article_id,
+                    content=content,
+                    rank=0,
+                    chunk_length=len(content),
+                )
+            )
+        session.add(
+            EntityType(
+                id=entity_type_id,
+                scope="source",
+                source_config_id=source_config_id,
+                type="topic",
+                name="Topic",
+                weight=Decimal("1.00"),
+                similarity_threshold=Decimal("0.800"),
+            )
+        )
+        session.add(
+            Entity(
+                id=entity_id,
+                source_config_id=source_config_id,
+                entity_type_id=entity_type_id,
+                type="topic",
+                name="Cross document parent",
+                normalized_name="cross document parent",
+            )
+        )
+        session.add_all(
+            [
+                SourceEvent(
+                    id=parent_event_id,
+                    source_config_id=source_config_id,
+                    source_type="ARTICLE",
+                    source_id=parent_article_id,
+                    article_id=parent_article_id,
+                    title="Parent event",
+                    summary="Parent event",
+                    content="Parent event content.",
+                    rank=0,
+                    level=0,
+                    chunk_id=parent_chunk_id,
+                ),
+                SourceEvent(
+                    id=child_event_id,
+                    source_config_id=source_config_id,
+                    source_type="ARTICLE",
+                    source_id=child_article_id,
+                    article_id=child_article_id,
+                    parent_id=parent_event_id,
+                    title="Child event",
+                    summary="Child event",
+                    content="Child event content.",
+                    rank=0,
+                    level=1,
+                    chunk_id=child_chunk_id,
+                ),
+            ]
+        )
+        await session.flush()
+        session.add_all(
+            [
+                EventEntity(id=str(uuid.uuid4()), event_id=parent_event_id, entity_id=entity_id, weight=Decimal("1")),
+                EventEntity(id=str(uuid.uuid4()), event_id=child_event_id, entity_id=entity_id, weight=Decimal("1")),
+            ]
+        )
+        await session.commit()
+
+    try:
+        await export_snapshot(
+            SimpleNamespace(id="source-local", name="Cross document parent", sag_source_config_id=source_config_id),
+            [SimpleNamespace(sag_source_id=child_article_id, filename="child.md", is_active=True)],
+            tmp_path / "cross-document-parent-workspace",
+            selected_article_ids=[child_article_id],
+            producer_state_path=tmp_path / "cross-document-parent-producer-ids.json",
+            session_factory=sessions,
+        )
+    finally:
+        await engine.dispose()
+
+    event_records = [
+        json.loads(line)
+        for line in (tmp_path / "cross-document-parent-workspace/data/events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert len(event_records) == 1
+    child_record = event_records[0]
+    assert "parent_id" not in child_record
+    assert child_record["level"] == 0
+    event_ids = {record["id"] for record in event_records}
+    assert {record["parent_id"] for record in event_records if record.get("parent_id")} <= event_ids
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_octx_transfer_service.py
+++ b/apps/api/tests/test_octx_transfer_service.py
@@ -1873,6 +1873,109 @@ async def test_document_export_freezes_one_ready_document_and_serializes_source(
 
 
 @pytest.mark.asyncio
+async def test_document_export_client_transfer_id_reuses_completed_request(
+    transfer_sessions,
+):
+    """A lost response must not create a second release after the first export finishes."""
+    from sqlalchemy import func, select
+
+    from sag_api.db.models import Document, Job, OctxTransfer, Source
+    from sag_api.enums import DocumentStatus, OctxTransferStatus
+    from sag_api.services.octx_transfer_service import create_document_export_transfer
+
+    class Queue:
+        def __init__(self):
+            self.ids: list[str] = []
+
+        async def enqueue(self, job_id: str) -> None:
+            self.ids.append(job_id)
+
+    queue = Queue()
+    transfer_id = "b" * 32
+    async with transfer_sessions() as session:
+        source = Source(name="Documents", sag_source_config_id="idempotent-document-export")
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="one.pdf",
+            storage_path="/tmp/one.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-one",
+            is_active=True,
+        )
+        session.add(document)
+        await session.commit()
+
+        first = await create_document_export_transfer(
+            session,
+            source.id,
+            document.id,
+            version="1.0.0",
+            job_queue=queue,
+            transfer_id=transfer_id,
+            requested_by_user_id="user-1",
+        )
+        first.status = OctxTransferStatus.READY
+        await session.commit()
+
+        repeated = await create_document_export_transfer(
+            session,
+            source.id,
+            document.id,
+            version="1.0.0",
+            job_queue=queue,
+            transfer_id=transfer_id,
+            requested_by_user_id="user-1",
+        )
+
+        assert repeated.id == first.id == transfer_id
+        assert len(queue.ids) == 1
+        assert await session.scalar(select(func.count()).select_from(OctxTransfer)) == 1
+        assert await session.scalar(select(func.count()).select_from(Job)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", ["1.0.0-alpha.1", "1.0.0-foo"])
+async def test_document_export_preserves_octx_semver_prerelease(
+    transfer_sessions,
+    version,
+):
+    from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus
+    from sag_api.services.octx_transfer_service import create_document_export_transfer
+
+    class Queue:
+        async def enqueue(self, _job_id: str) -> None:
+            return None
+
+    async with transfer_sessions() as session:
+        source = Source(name="Documents", sag_source_config_id="semver-document-export")
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="one.pdf",
+            storage_path="/tmp/one.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-one",
+            is_active=True,
+        )
+        session.add(document)
+        await session.commit()
+
+        transfer = await create_document_export_transfer(
+            session,
+            source.id,
+            document.id,
+            version=version,
+            job_queue=Queue(),
+        )
+
+        assert transfer.checkpoint["selected_version"] == version
+
+
+@pytest.mark.asyncio
 async def test_document_export_rejects_non_ready_document(transfer_sessions):
     from sag_api.core.errors import ConflictError
     from sag_api.db.models import Document, Source

--- a/apps/api/tests/test_octx_transfer_service.py
+++ b/apps/api/tests/test_octx_transfer_service.py
@@ -446,10 +446,12 @@ async def test_structured_import_activates_source_only_after_shadow_is_ready(tra
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("trusted_vectors", [True, False])
+@pytest.mark.parametrize("export_scope", ["source", "document"])
 async def test_export_transfer_builds_immutable_fully_validated_release(
     transfer_sessions,
     tmp_path,
     trusted_vectors,
+    export_scope,
 ):
     from contextlib import asynccontextmanager
     from types import SimpleNamespace
@@ -469,7 +471,13 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
     )
 
     from sag_api.core.config import Settings
-    from sag_api.db.models import Document, OctxRelease, OctxSourceBinding, Source
+    from sag_api.db.models import (
+        Document,
+        OctxDocumentBinding,
+        OctxRelease,
+        OctxSourceBinding,
+        Source,
+    )
     from sag_api.enums import DocumentStatus, OctxTransferStatus
     from sag_api.octx.runner import OctxRunner
     from sag_api.octx.storage import OctxStorage
@@ -481,6 +489,7 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
     from sag_api.sag.octx_vector_protocol import embedding_identity
     from sag_api.sag.octx_vector_rebuilder import rebuild_vectors
     from sag_api.services.octx_transfer_service import (
+        create_document_export_transfer,
         create_export_transfer,
         execute_export,
     )
@@ -598,18 +607,31 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
             source = Source(name="Export", sag_source_config_id="src_export")
             session.add(source)
             await session.flush()
-            session.add(
-                Document(
-                    source_id=source.id,
-                    filename="export.md",
-                    storage_path=str(tmp_path / "export.md"),
-                    status=DocumentStatus.READY,
-                    sag_source_id=article_id,
-                    is_active=True,
-                )
+            document = Document(
+                source_id=source.id,
+                filename="export.md",
+                storage_path=str(tmp_path / "export.md"),
+                status=DocumentStatus.READY,
+                sag_source_id=article_id,
+                is_active=True,
             )
+            session.add(document)
             await session.commit()
-            transfer = await create_export_transfer(session, source.id, version=None, job_queue=queue)
+            if export_scope == "document":
+                transfer = await create_document_export_transfer(
+                    session,
+                    source.id,
+                    document.id,
+                    version=None,
+                    job_queue=queue,
+                )
+            else:
+                transfer = await create_export_transfer(
+                    session,
+                    source.id,
+                    version=None,
+                    job_queue=queue,
+                )
 
             class Embedding:
                 model = "test/embedding"
@@ -635,9 +657,14 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
                 attempt=1,
             )
             assert transfer.status is OctxTransferStatus.READY
-            binding = await session.get(OctxSourceBinding, source.id)
             release = await session.get(OctxRelease, transfer.release_id)
-            assert binding.active_release_id == release.id
+            if export_scope == "document":
+                binding = await session.get(OctxDocumentBinding, document.id)
+                assert binding.active_release_id == release.id
+                assert await session.get(OctxSourceBinding, source.id) is None
+            else:
+                binding = await session.get(OctxSourceBinding, source.id)
+                assert binding.active_release_id == release.id
             artifact = storage.resolve_key(release.artifact_key)
             with open_octx(artifact) as package:
                 assert package.manifest["capabilities"]["sag-structured"]["version"] == "0.1"
@@ -646,6 +673,32 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
                 assert len(list(package.iter_documents())) == 1
             validation = validate_octx(artifact)
             assert validation.valid and validation.fully_validated
+
+            if export_scope == "document":
+                first_asset_id = transfer.asset_id
+                repeated_transfer = await create_document_export_transfer(
+                    session,
+                    source.id,
+                    document.id,
+                    version=None,
+                    job_queue=queue,
+                )
+                await execute_export(
+                    session,
+                    repeated_transfer,
+                    storage=storage,
+                    runner=OctxRunner(
+                        Settings(_env_file=None, octx_worker_timeout_seconds=30)
+                    ),
+                    engine_manager=EngineManager(),
+                    sag_session_factory=sag_sessions,
+                    embedding_client=Embedding(),
+                    vector_store=VectorStore(),
+                    attempt=1,
+                )
+                assert repeated_transfer.asset_id == first_asset_id
+                assert repeated_transfer.package_version == "1.0.1"
+                assert await session.get(OctxSourceBinding, source.id) is None
 
             roundtrip_plan = tmp_path / "roundtrip.sqlite3"
             roundtrip_namespace = str(__import__("uuid").uuid4())
@@ -1698,6 +1751,125 @@ async def test_repeated_export_request_reuses_active_transfer(
         assert len(queue.ids) == 1
         assert await session.scalar(select(func.count(OctxTransfer.id))) == 1
         assert await session.scalar(select(func.count(Job.id))) == 1
+
+
+@pytest.mark.asyncio
+async def test_document_export_freezes_one_ready_document_and_serializes_source(
+    transfer_sessions,
+):
+    from sag_api.core.errors import ConflictError
+    from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus, OctxTransferStatus
+    from sag_api.services.octx_transfer_service import (
+        create_document_export_transfer,
+        create_export_transfer,
+    )
+
+    class Queue:
+        def __init__(self):
+            self.ids: list[str] = []
+
+        async def enqueue(self, job_id: str) -> None:
+            self.ids.append(job_id)
+
+    queue = Queue()
+    async with transfer_sessions() as session:
+        source = Source(name="Documents", sag_source_config_id="document-export")
+        session.add(source)
+        await session.flush()
+        first = Document(
+            source_id=source.id,
+            filename="first.pdf",
+            storage_path="/tmp/first.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-first",
+            is_active=True,
+        )
+        second = Document(
+            source_id=source.id,
+            filename="second.pdf",
+            storage_path="/tmp/second.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-second",
+            is_active=True,
+        )
+        session.add_all([first, second])
+        await session.commit()
+
+        transfer = await create_document_export_transfer(
+            session,
+            source.id,
+            first.id,
+            version=None,
+            job_queue=queue,
+        )
+        repeated = await create_document_export_transfer(
+            session,
+            source.id,
+            first.id,
+            version=None,
+            job_queue=queue,
+        )
+
+        assert transfer.status is OctxTransferStatus.QUEUED
+        assert repeated.id == transfer.id
+        assert transfer.checkpoint["export_scope"] == "document"
+        assert transfer.checkpoint["document_id"] == first.id
+        assert transfer.checkpoint["selected_document_ids"] == [first.id]
+        assert transfer.checkpoint["selected_article_ids"] == ["article-first"]
+        assert transfer.checkpoint["asset_name"] == "first.pdf"
+        assert len(queue.ids) == 1
+
+        with pytest.raises(ConflictError):
+            await create_document_export_transfer(
+                session,
+                source.id,
+                second.id,
+                version=None,
+                job_queue=queue,
+            )
+        with pytest.raises(ConflictError):
+            await create_export_transfer(
+                session,
+                source.id,
+                version=None,
+                job_queue=queue,
+            )
+
+
+@pytest.mark.asyncio
+async def test_document_export_rejects_non_ready_document(transfer_sessions):
+    from sag_api.core.errors import ConflictError
+    from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus
+    from sag_api.services.octx_transfer_service import create_document_export_transfer
+
+    class Queue:
+        async def enqueue(self, _job_id: str) -> None:
+            raise AssertionError("non-ready document must not be queued")
+
+    async with transfer_sessions() as session:
+        source = Source(name="Documents", sag_source_config_id="not-ready-export")
+        session.add(source)
+        await session.flush()
+        document = Document(
+            source_id=source.id,
+            filename="extracting.pdf",
+            storage_path="/tmp/extracting.pdf",
+            status=DocumentStatus.EXTRACTING,
+            is_active=True,
+        )
+        session.add(document)
+        await session.commit()
+
+        with pytest.raises(ConflictError):
+            await create_document_export_transfer(
+                session,
+                source.id,
+                document.id,
+                version=None,
+                job_queue=Queue(),
+            )
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_octx_transfer_service.py
+++ b/apps/api/tests/test_octx_transfer_service.py
@@ -616,6 +616,17 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
                 is_active=True,
             )
             session.add(document)
+            if export_scope == "document":
+                session.add(
+                    Document(
+                        source_id=source.id,
+                        filename="unselected.md",
+                        storage_path=str(tmp_path / "unselected.md"),
+                        status=DocumentStatus.READY,
+                        sag_source_id=str(__import__("uuid").uuid4()),
+                        is_active=True,
+                    )
+                )
             await session.commit()
             if export_scope == "document":
                 transfer = await create_document_export_transfer(
@@ -645,17 +656,32 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
                 async def fetch_vector_fields(self, index, ids, fields):
                     return {record_id: {field: [0.1, 0.2] for field in fields} for record_id in ids}
 
-            await execute_export(
-                session,
-                transfer,
-                storage=storage,
-                runner=OctxRunner(Settings(_env_file=None, octx_worker_timeout_seconds=30)),
-                engine_manager=EngineManager(),
-                sag_session_factory=sag_sessions,
-                embedding_client=Embedding(),
-                vector_store=VectorStore(),
-                attempt=1,
-            )
+            document_queries: list[str] = []
+
+            def capture_document_query(orm_execute_state):
+                if orm_execute_state.is_select and "FROM documents" in str(orm_execute_state.statement):
+                    document_queries.append(str(orm_execute_state.statement))
+
+            event.listen(session.sync_session, "do_orm_execute", capture_document_query)
+            try:
+                await execute_export(
+                    session,
+                    transfer,
+                    storage=storage,
+                    runner=OctxRunner(
+                        Settings(_env_file=None, octx_worker_timeout_seconds=30)
+                    ),
+                    engine_manager=EngineManager(),
+                    sag_session_factory=sag_sessions,
+                    embedding_client=Embedding(),
+                    vector_store=VectorStore(),
+                    attempt=1,
+                )
+            finally:
+                event.remove(session.sync_session, "do_orm_execute", capture_document_query)
+            if export_scope == "document":
+                assert len(document_queries) == 1
+                assert "documents.id IN" in document_queries[0]
             assert transfer.status is OctxTransferStatus.READY
             release = await session.get(OctxRelease, transfer.release_id)
             if export_scope == "document":
@@ -1800,14 +1826,14 @@ async def test_document_export_freezes_one_ready_document_and_serializes_source(
             session,
             source.id,
             first.id,
-            version=None,
+            version="1.2.3",
             job_queue=queue,
         )
         repeated = await create_document_export_transfer(
             session,
             source.id,
             first.id,
-            version=None,
+            version="1.2.3",
             job_queue=queue,
         )
 
@@ -1819,6 +1845,15 @@ async def test_document_export_freezes_one_ready_document_and_serializes_source(
         assert transfer.checkpoint["selected_article_ids"] == ["article-first"]
         assert transfer.checkpoint["asset_name"] == "first.pdf"
         assert len(queue.ids) == 1
+
+        with pytest.raises(ConflictError, match="OCTX export 1.2.3 is already active for this source"):
+            await create_document_export_transfer(
+                session,
+                source.id,
+                first.id,
+                version="1.2.4",
+                job_queue=queue,
+            )
 
         with pytest.raises(ConflictError):
             await create_document_export_transfer(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "node ./scripts/clean.mjs",
     "typecheck": "tsc --noEmit",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && node ./scripts/verify-preload.mjs",
     "dev": "npm run build && node ./scripts/dev.mjs",
     "build:web": "node ./scripts/build-web.mjs",
     "build:backend": "node ./scripts/build-backend.mjs",

--- a/apps/desktop/scripts/verify-preload.mjs
+++ b/apps/desktop/scripts/verify-preload.mjs
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const preloadPath = path.join(desktopRoot, "dist", "preload.js");
+const source = await readFile(preloadPath, "utf8");
+
+if (/require\(["']\.[./]/.test(source)) {
+  throw new Error(
+    "Sandboxed Electron preload must be self-contained; relative require() was found",
+  );
+}

--- a/apps/desktop/src/channels.ts
+++ b/apps/desktop/src/channels.ts
@@ -18,6 +18,9 @@ export interface DesktopDiagnosticsInfo {
   version: string;
   platform: string;
   arch: string;
+  osRelease: string;
+  osVersion: string;
+  packaged: boolean;
   electron: string;
   chrome: string;
   node: string;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
+import { release as osRelease, version as osVersion } from "node:os";
 import path from "node:path";
 
 import {
@@ -167,6 +168,9 @@ function registerIpc(): void {
       version: app.getVersion(),
       platform: process.platform,
       arch: process.arch,
+      osRelease: osRelease(),
+      osVersion: osVersion(),
+      packaged: app.isPackaged,
       electron: process.versions.electron ?? "unknown",
       chrome: process.versions.chrome ?? "unknown",
       node: process.versions.node ?? "unknown",

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,10 +1,16 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-import {
-  DESKTOP_CHANNELS,
-  type DesktopDiagnosticsInfo,
-  type UpdateState,
-} from "./channels";
+import type { DesktopDiagnosticsInfo, UpdateState } from "./channels";
+
+// A sandboxed Electron preload only supports a limited require() surface and
+// cannot load local CommonJS modules. Keep these stable IPC names self-contained
+// so the bridge is available in packaged builds.
+const DESKTOP_CHANNELS = {
+  appInfo: "desktop:app-info",
+  checkForUpdates: "desktop:check-for-updates",
+  diagnosticsInfo: "desktop:diagnostics-info",
+  updateState: "desktop:update-state",
+} as const;
 
 export interface SagDesktopBridge {
   readonly isDesktop: true;

--- a/apps/web/app/(app)/knowledge/[id]/page.tsx
+++ b/apps/web/app/(app)/knowledge/[id]/page.tsx
@@ -320,6 +320,7 @@ export default function SourceDetailPage() {
           ) : (
             <DocumentList
               sourceId={id}
+              sourceName={source.name}
               documents={documents}
               activities={documentActivities}
               onAction={mutateDocument}

--- a/apps/web/components/features/document-list.tsx
+++ b/apps/web/components/features/document-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { FileText, Pause, Play, RefreshCw, Trash2 } from "lucide-react";
+import { Download, FileText, Pause, Play, RefreshCw, Trash2 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -20,9 +20,11 @@ import { useDetailPanel } from "@/components/features/detail-panel";
 import { useApp } from "@/components/features/app-shell";
 import { DocumentActivityBadge } from "@/components/features/status-badge";
 import { Button } from "@/components/ui/button";
+import { useOctxExports } from "@/components/features/octx-export-provider";
 
 export function DocumentList({
   sourceId,
+  sourceName,
   documents,
   activities,
   onAction,
@@ -30,6 +32,7 @@ export function DocumentList({
   onOpenDocument,
 }: {
   sourceId: string;
+  sourceName: string;
   documents: Doc[];
   activities: Record<string, DocumentActivity>;
   onAction: (document: Doc, action: DocumentAction) => Promise<boolean>;
@@ -40,6 +43,8 @@ export function DocumentList({
   const locale = useLocale();
   const { open } = useDetailPanel();
   const { timezone } = useApp();
+  const { startDocumentExport, isSourceExporting } = useOctxExports();
+  const exportRunning = isSourceExporting(sourceId);
 
   async function perform(document: Doc, action: DocumentAction) {
     try {
@@ -87,6 +92,25 @@ export function DocumentList({
     const buttonClass = compact ? "size-7" : undefined;
     return (
       <div className="flex shrink-0 items-center gap-0.5">
+        {document.status === "ready" && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className={buttonClass}
+            title={t("exportOctx")}
+            disabled={activity.busy || exportRunning}
+            onClick={() =>
+              void startDocumentExport(
+                sourceId,
+                sourceName,
+                document.id,
+                document.filename,
+              )
+            }
+          >
+            <Download className="size-4" />
+          </Button>
+        )}
         {document.status === "extracting" && (
           <Button
             variant="ghost"

--- a/apps/web/components/features/knowledge-source-workspace.tsx
+++ b/apps/web/components/features/knowledge-source-workspace.tsx
@@ -235,6 +235,7 @@ export function KnowledgeSourceWorkspace({
             ) : (
               <DocumentList
                 sourceId={sourceId}
+                sourceName={source.name}
                 documents={documents}
                 activities={documentActivities}
                 onAction={mutateDocument}

--- a/apps/web/components/features/octx-export-provider.test.ts
+++ b/apps/web/components/features/octx-export-provider.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { projectDesktopDiagnostics } from "./octx-export-provider";
+
+describe("projectDesktopDiagnostics", () => {
+  it("omits raw desktop log data from OCTX diagnostics downloads", () => {
+    const diagnostics = projectDesktopDiagnostics({
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      osRelease: "24.0.0",
+      osVersion: "macOS",
+      packaged: true,
+      electron: "37.0.0",
+      chrome: "138.0.0",
+      node: "22.0.0",
+      logFiles: [
+        {
+          name: "document-content.log",
+          path: "/Users/alice/SAG/logs/main.log",
+          sizeBytes: 512,
+          truncated: true,
+          content:
+            "Authorization: Basic YWxpY2U6c2VjcmV0\nCookie: sag_token=secret\npostgresql://alice:secret@db.example/sag\nDocument content payload\nfree-form secret",
+        },
+      ],
+    });
+
+    expect(diagnostics).toEqual({
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      os_release: "24.0.0",
+      os_version: "macOS",
+      packaged: true,
+      electron: "37.0.0",
+      chrome: "138.0.0",
+      node: "22.0.0",
+      log_file_count: 1,
+      has_truncated_logs: true,
+    });
+
+    const serialized = JSON.stringify(diagnostics);
+    for (const unsafeValue of [
+      "Authorization: Basic",
+      "Cookie:",
+      "postgresql://",
+      "Document content payload",
+      "free-form secret",
+      "document-content.log",
+      "/Users/alice",
+    ]) {
+      expect(serialized).not.toContain(unsafeValue);
+    }
+  });
+});

--- a/apps/web/components/features/octx-export-provider.tsx
+++ b/apps/web/components/features/octx-export-provider.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { OctxExportTaskManager } from "@/lib/octx-export-manager";
 import { exportDismissDelay } from "@/lib/octx-export-dismissal";
+import { getDiagnosticsStore, sanitize } from "@/lib/diagnostics";
 import {
   isActiveExportForSource,
   OCTX_EXPORT_TASKS_STORAGE_KEY,
@@ -18,10 +19,17 @@ const POLL_INTERVAL_MS = 1500;
 interface OctxExportsContextValue {
   tasks: PersistedOctxExportTask[];
   startExport: (sourceId: string, sourceName: string) => Promise<void>;
+  startDocumentExport: (
+    sourceId: string,
+    sourceName: string,
+    documentId: string,
+    documentName: string,
+  ) => Promise<void>;
   confirmReadyOnly: (transferId: string, decisionToken: string) => Promise<void>;
   cancelDecision: (transferId: string, decisionToken: string) => Promise<void>;
   cancelTransfer: (transferId: string) => Promise<void>;
   downloadAgain: (transferId: string) => Promise<void>;
+  downloadDiagnostics: (transferId: string) => Promise<void>;
   dismissTransfer: (transferId: string) => void;
   isSourceExporting: (sourceId: string) => boolean;
 }
@@ -47,6 +55,22 @@ function artifactFilename(task: PersistedOctxExportTask): string {
   return `${stem}-${version}.octx`;
 }
 
+function downloadJson(value: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(value, null, 2)], { type: "application/json" });
+  triggerDownload(blob, filename);
+}
+
+function redactLocalHomePaths(content: string): string {
+  return content
+    .replace(/\/(?:Users|home)\/[^\s"']+/g, "[LOCAL_PATH]")
+    .replace(/[A-Za-z]:\\Users\\[^\s"']+/g, "[LOCAL_PATH]")
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(
+      /(api[_-]?key|token|password|secret|credential)(\s*[:=]\s*)[^\s,;]+/gi,
+      "$1$2[REDACTED]",
+    );
+}
+
 export function OctxExportProvider({ children }: { children: React.ReactNode }) {
   const t = useTranslations("SourceCard");
   const [tasks, setTasks] = React.useState<PersistedOctxExportTask[]>([]);
@@ -58,6 +82,7 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
       save: (value) => window.localStorage.setItem(OCTX_EXPORT_TASKS_STORAGE_KEY, value),
       getTransfer: api.getOctxTransfer,
       startExport: api.startOctxExport,
+      startDocumentExport: api.startOctxDocumentExport,
       decideExport: (transferId, decisionToken) =>
         api.decideOctxExport(transferId, {
           action: "export_ready_only",
@@ -74,6 +99,7 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
         triggerDownload(blob, artifactFilename(task));
         toast.success(t("exportReady"));
       },
+      recordEvent: (type, data) => getDiagnosticsStore().record(type, data),
       now: () => new Date().toISOString(),
     });
     managerRef.current = manager;
@@ -123,6 +149,29 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
     [reportError],
   );
 
+  const startDocumentExport = React.useCallback(
+    async (
+      sourceId: string,
+      sourceName: string,
+      documentId: string,
+      documentName: string,
+    ) => {
+      if (isActiveExportForSource(tasks, sourceId)) return;
+      try {
+        await managerRef.current?.startDocument(
+          sourceId,
+          sourceName,
+          documentId,
+          documentName,
+        );
+        toast.message(t("exportStarted"));
+      } catch (error) {
+        reportError(error);
+      }
+    },
+    [reportError, t, tasks],
+  );
+
   const cancelTransfer = React.useCallback(
     async (transferId: string) => {
       try {
@@ -160,6 +209,66 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
     managerRef.current?.dismiss(transferId);
   }, []);
 
+  const downloadDiagnostics = React.useCallback(
+    async (transferId: string) => {
+      try {
+        const server = await api.getOctxTransferDiagnostics(transferId);
+        let desktop: Record<string, unknown> | null = null;
+        if (window.sagDesktop?.getDiagnosticsInfo) {
+          try {
+            const info = await window.sagDesktop.getDiagnosticsInfo();
+            desktop = {
+              version: info.version,
+              platform: info.platform,
+              arch: info.arch,
+              os_release: info.osRelease,
+              os_version: info.osVersion,
+              packaged: info.packaged,
+              electron: info.electron,
+              chrome: info.chrome,
+              node: info.node,
+              log_files: info.logFiles.map((file) => ({
+                name: file.name,
+                size_bytes: file.sizeBytes,
+                truncated: file.truncated,
+                content: redactLocalHomePaths(file.content),
+              })),
+            };
+          } catch (desktopError) {
+            desktop = {
+              collection_error:
+                desktopError instanceof Error
+                  ? desktopError.message
+                  : String(desktopError),
+            };
+          }
+        }
+        const frontend = getDiagnosticsStore().export({
+          app: window.sagDesktop?.isDesktop ? "desktop" : "web",
+          desktop_version: typeof desktop?.version === "string" ? desktop.version : undefined,
+          user_agent: navigator.userAgent,
+          language: navigator.language,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+        downloadJson(
+          sanitize({
+            schema_version: 1,
+            exported_at: new Date().toISOString(),
+            transfer_id: transferId,
+            server,
+            frontend,
+            desktop,
+          }),
+          `sag-octx-diagnostics-${transferId}.json`,
+        );
+        toast.success(t("exportDiagnosticsReady"));
+      } catch (error) {
+        reportError(error);
+      }
+    },
+    [reportError, t],
+  );
+
   React.useEffect(() => {
     const timers = tasks.flatMap((task) => {
       const delay = exportDismissDelay(task);
@@ -173,10 +282,12 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
     () => ({
       tasks,
       startExport,
+      startDocumentExport,
       confirmReadyOnly,
       cancelDecision,
       cancelTransfer,
       downloadAgain,
+      downloadDiagnostics,
       dismissTransfer,
       isSourceExporting: (sourceId) => isActiveExportForSource(tasks, sourceId),
     }),
@@ -186,6 +297,8 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
       confirmReadyOnly,
       dismissTransfer,
       downloadAgain,
+      downloadDiagnostics,
+      startDocumentExport,
       startExport,
       tasks,
     ],

--- a/apps/web/components/features/octx-export-provider.tsx
+++ b/apps/web/components/features/octx-export-provider.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { api, ApiError } from "@/lib/api";
+import type { SagDesktopDiagnosticsInfo } from "@/lib/desktop-bridge";
 import { OctxExportTaskManager } from "@/lib/octx-export-manager";
 import { exportDismissDelay } from "@/lib/octx-export-dismissal";
 import { getDiagnosticsStore, sanitize } from "@/lib/diagnostics";
@@ -60,15 +61,22 @@ function downloadJson(value: unknown, filename: string) {
   triggerDownload(blob, filename);
 }
 
-function redactLocalHomePaths(content: string): string {
-  return content
-    .replace(/\/(?:Users|home)\/[^\s"']+/g, "[LOCAL_PATH]")
-    .replace(/[A-Za-z]:\\Users\\[^\s"']+/g, "[LOCAL_PATH]")
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
-    .replace(
-      /(api[_-]?key|token|password|secret|credential)(\s*[:=]\s*)[^\s,;]+/gi,
-      "$1$2[REDACTED]",
-    );
+export function projectDesktopDiagnostics(
+  info: SagDesktopDiagnosticsInfo,
+): Record<string, string | number | boolean> {
+  return {
+    version: info.version,
+    platform: info.platform,
+    arch: info.arch,
+    os_release: info.osRelease,
+    os_version: info.osVersion,
+    packaged: info.packaged,
+    electron: info.electron,
+    chrome: info.chrome,
+    node: info.node,
+    log_file_count: info.logFiles.length,
+    has_truncated_logs: info.logFiles.some((file) => file.truncated),
+  };
 }
 
 export function OctxExportProvider({ children }: { children: React.ReactNode }) {
@@ -217,29 +225,10 @@ export function OctxExportProvider({ children }: { children: React.ReactNode }) 
         if (window.sagDesktop?.getDiagnosticsInfo) {
           try {
             const info = await window.sagDesktop.getDiagnosticsInfo();
+            desktop = projectDesktopDiagnostics(info);
+          } catch {
             desktop = {
-              version: info.version,
-              platform: info.platform,
-              arch: info.arch,
-              os_release: info.osRelease,
-              os_version: info.osVersion,
-              packaged: info.packaged,
-              electron: info.electron,
-              chrome: info.chrome,
-              node: info.node,
-              log_files: info.logFiles.map((file) => ({
-                name: file.name,
-                size_bytes: file.sizeBytes,
-                truncated: file.truncated,
-                content: redactLocalHomePaths(file.content),
-              })),
-            };
-          } catch (desktopError) {
-            desktop = {
-              collection_error:
-                desktopError instanceof Error
-                  ? desktopError.message
-                  : String(desktopError),
+              collection_error: "desktop_diagnostics_unavailable",
             };
           }
         }

--- a/apps/web/components/features/octx-export-task-center.test.tsx
+++ b/apps/web/components/features/octx-export-task-center.test.tsx
@@ -60,6 +60,7 @@ describe("OCTX export task center", () => {
           ]}
           onCancel={vi.fn()}
           onDownload={vi.fn()}
+          onDiagnostics={vi.fn()}
           onDismiss={vi.fn()}
         />
       </NextIntlClientProvider>,
@@ -87,6 +88,7 @@ describe("OCTX export task center", () => {
           ]}
           onCancel={vi.fn()}
           onDownload={vi.fn()}
+          onDiagnostics={vi.fn()}
           onDismiss={vi.fn()}
         />
       </NextIntlClientProvider>,
@@ -116,6 +118,7 @@ describe("OCTX export task center", () => {
           ]}
           onCancel={vi.fn()}
           onDownload={vi.fn()}
+          onDiagnostics={vi.fn()}
           onDismiss={vi.fn()}
         />
       </NextIntlClientProvider>,
@@ -126,6 +129,7 @@ describe("OCTX export task center", () => {
     expect(html).toContain("2 个事项");
     expect(html).toContain('href="/knowledge/source-1"');
     expect(html).toContain("前往文档列表");
+    expect(html).toContain("导出诊断日志");
   });
 
   it("offers dismissal for terminal tasks without replacing active cancellation", () => {
@@ -140,6 +144,7 @@ describe("OCTX export task center", () => {
           ]}
           onCancel={vi.fn()}
           onDownload={vi.fn()}
+          onDiagnostics={vi.fn()}
           onDismiss={vi.fn()}
         />
       </NextIntlClientProvider>,

--- a/apps/web/components/features/octx-export-task-center.tsx
+++ b/apps/web/components/features/octx-export-task-center.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Download, FileWarning, X } from "lucide-react";
+import { Download, FileJson, FileWarning, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import {
@@ -34,11 +34,13 @@ export function OctxExportTaskList({
   tasks,
   onCancel,
   onDownload,
+  onDiagnostics,
   onDismiss,
 }: {
   tasks: PersistedOctxExportTask[];
   onCancel: (transferId: string) => void;
   onDownload: (transferId: string) => void;
+  onDiagnostics: (transferId: string) => void;
   onDismiss: (transferId: string) => void;
 }) {
   const t = useTranslations("SourceCard");
@@ -76,6 +78,11 @@ export function OctxExportTaskList({
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium">{task.sourceName}</p>
+                  {transfer.export_scope === "document" && (
+                    <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                      {t("documentExportBadge")} · {transfer.document_name ?? task.filenameHint}
+                    </p>
+                  )}
                   <p className="mt-0.5 text-xs text-muted-foreground">
                     {progressLabel}
                   </p>
@@ -103,6 +110,18 @@ export function OctxExportTaskList({
                     >
                       <Download className="size-3.5" />
                       {t("exportDownloadAgain")}
+                    </Button>
+                  )}
+                  {(transfer.status === "failed" || task.downloadError) && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => onDiagnostics(task.transferId)}
+                    >
+                      <FileJson className="size-3.5" />
+                      {t("exportDiagnostics")}
                     </Button>
                   )}
                   {isTerminalExportStatus(transfer.status) && (
@@ -153,6 +172,11 @@ export function OctxExportTaskList({
                   {transfer.error?.message ?? t("exportFailed")}
                 </p>
               )}
+              {task.downloadError && (
+                <p className="mt-2 break-words text-xs text-destructive">
+                  {t("exportDownloadFailed")}: {task.downloadError}
+                </p>
+              )}
             </div>
           );
         })}
@@ -162,12 +186,13 @@ export function OctxExportTaskList({
 }
 
 export function OctxExportTaskCenter() {
-  const { tasks, cancelTransfer, dismissTransfer, downloadAgain } = useOctxExports();
+  const { tasks, cancelTransfer, dismissTransfer, downloadAgain, downloadDiagnostics } = useOctxExports();
   return (
     <OctxExportTaskList
       tasks={tasks}
       onCancel={(transferId) => void cancelTransfer(transferId)}
       onDownload={(transferId) => void downloadAgain(transferId)}
+      onDiagnostics={(transferId) => void downloadDiagnostics(transferId)}
       onDismiss={dismissTransfer}
     />
   );

--- a/apps/web/lib/api-octx.test.ts
+++ b/apps/web/lib/api-octx.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "./api";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("OCTX document export API", () => {
+  it("reuses one transfer id when retrying a lost create response", async () => {
+    vi.useFakeTimers();
+    const body = {
+      id: "b".repeat(32),
+      direction: "export",
+      status: "queued",
+      progress: 0,
+      created_at: "2026-08-14T00:00:00Z",
+      updated_at: "2026-08-14T00:00:00Z",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(body), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("crypto", { randomUUID: () => "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" });
+
+    const pending = api.startOctxDocumentExport("source-1", "document-1");
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const first = fetchMock.mock.calls[0][1] as RequestInit;
+    const second = fetchMock.mock.calls[1][1] as RequestInit;
+    expect((first.headers as Record<string, string>)["X-OCTX-Transfer-ID"]).toBe(
+      "bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb",
+    );
+    expect((second.headers as Record<string, string>)["X-OCTX-Transfer-ID"]).toBe(
+      (first.headers as Record<string, string>)["X-OCTX-Transfer-ID"],
+    );
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -589,6 +589,39 @@ async function startOctxExport(
   }
 }
 
+async function startOctxDocumentExport(
+  sourceId: string,
+  documentId: string,
+  version?: string,
+): Promise<OctxTransfer> {
+  const submit = () =>
+    request<OctxTransfer>(
+      `/api/v1/sources/${sourceId}/documents/${documentId}/octx-exports`,
+      {
+        method: "POST",
+        body: JSON.stringify(version ? { version } : {}),
+      },
+    );
+  try {
+    return await submit();
+  } catch (error) {
+    if (!isRetryableOctxExportStartError(error)) throw error;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  try {
+    return await submit();
+  } catch (error) {
+    if (!isRetryableOctxExportStartError(error)) throw error;
+    throw new ApiError(
+      error.status,
+      "octx_export_start_busy",
+      clientErrorMessage("octxExportStartBusy"),
+      error.requestId,
+      { layer: error.layer, stage: error.stage, retryable: true },
+    );
+  }
+}
+
 export const api = {
   // auth / system
   register: (b: { email: string; password: string; name?: string }) =>
@@ -1024,8 +1057,11 @@ export const api = {
 
   // OCTX 数据包导入/导出
   startOctxExport,
+  startOctxDocumentExport,
   getOctxTransfer: (transferId: string) =>
     request<OctxTransfer>(`/api/v1/octx/transfers/${transferId}`),
+  getOctxTransferDiagnostics: (transferId: string) =>
+    request<Record<string, unknown>>(`/api/v1/octx/transfers/${transferId}/diagnostics`),
   cancelOctxTransfer: (transferId: string) =>
     request<OctxTransfer>(`/api/v1/octx/transfers/${transferId}`, {
       method: "DELETE",

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -594,12 +594,14 @@ async function startOctxDocumentExport(
   documentId: string,
   version?: string,
 ): Promise<OctxTransfer> {
+  const transferId = crypto.randomUUID().replaceAll("-", "");
   const submit = () =>
     request<OctxTransfer>(
       `/api/v1/sources/${sourceId}/documents/${documentId}/octx-exports`,
       {
         method: "POST",
         body: JSON.stringify(version ? { version } : {}),
+        headers: { "X-OCTX-Transfer-ID": transferId },
       },
     );
   try {

--- a/apps/web/lib/desktop-bridge.d.ts
+++ b/apps/web/lib/desktop-bridge.d.ts
@@ -8,6 +8,9 @@ export interface SagDesktopDiagnosticsInfo {
   version: string;
   platform: string;
   arch: string;
+  osRelease: string;
+  osVersion: string;
+  packaged: boolean;
   electron: string;
   chrome: string;
   node: string;

--- a/apps/web/lib/diagnostics.ts
+++ b/apps/web/lib/diagnostics.ts
@@ -15,6 +15,7 @@ export type DiagEventType =
   | "knowledge.upload"
   | "knowledge.create"
   | "knowledge.process"
+  | "octx.export"
   | "qa.ask"
   | "qa.event"
   | "qa.complete"

--- a/apps/web/lib/octx-export-manager.test.ts
+++ b/apps/web/lib/octx-export-manager.test.ts
@@ -123,6 +123,34 @@ describe("OCTX export task manager", () => {
     expect(download).not.toHaveBeenCalled();
   });
 
+  it("records the real automatic download failure for support diagnostics", async () => {
+    const recordEvent = vi.fn();
+    const manager = new OctxExportTaskManager({
+      load: () => null,
+      save: vi.fn(),
+      getTransfer: vi.fn(),
+      startExport: vi.fn().mockResolvedValue(transfer("transfer-1", "ready", 1)),
+      decideExport: vi.fn(),
+      cancelDecision: vi.fn(),
+      cancelTransfer: vi.fn(),
+      download: vi.fn().mockRejectedValue(new Error("desktop download bridge failed")),
+      recordEvent,
+      now: () => "2026-08-11T02:00:00Z",
+    });
+
+    await manager.start("source-1", "产品手册");
+
+    expect(manager.snapshot()[0]).toMatchObject({
+      autoDownloaded: false,
+      downloadError: "desktop download bridge failed",
+    });
+    expect(recordEvent).toHaveBeenCalledWith("octx.export", expect.objectContaining({
+      transfer_id: "transfer-1",
+      action: "download_failed",
+      error_type: "Error",
+    }));
+  });
+
   it("keeps the last server state when a refresh request temporarily fails", async () => {
     const previous = task(transfer("transfer-1", "packaging", 0.6));
     const manager = new OctxExportTaskManager({

--- a/apps/web/lib/octx-export-manager.ts
+++ b/apps/web/lib/octx-export-manager.ts
@@ -13,10 +13,12 @@ export interface OctxExportManagerDependencies {
   save: (value: string) => void;
   getTransfer: (transferId: string) => Promise<OctxTransfer>;
   startExport: (sourceId: string) => Promise<OctxTransfer>;
+  startDocumentExport?: (sourceId: string, documentId: string) => Promise<OctxTransfer>;
   decideExport: (transferId: string, decisionToken: string) => Promise<OctxTransfer>;
   cancelDecision: (transferId: string, decisionToken: string) => Promise<OctxTransfer>;
   cancelTransfer: (transferId: string) => Promise<OctxTransfer>;
   download: (task: PersistedOctxExportTask) => Promise<void>;
+  recordEvent?: (type: "octx.export", data: Record<string, unknown>) => void;
   now: () => string;
 }
 
@@ -54,6 +56,13 @@ export class OctxExportTaskManager {
     filenameHint?: string,
   ): Promise<PersistedOctxExportTask> {
     const transfer = await this.dependencies.startExport(sourceId);
+    this.dependencies.recordEvent?.("octx.export", {
+      action: "created",
+      transfer_id: transfer.id,
+      source_id: sourceId,
+      scope: "source",
+      status: transfer.status,
+    });
     const metadata: NewOctxExportTask = {
       transferId: transfer.id,
       sourceId,
@@ -62,6 +71,36 @@ export class OctxExportTaskManager {
       createdAt: this.dependencies.now(),
     };
     return this.reconcile(metadata, transfer);
+  }
+
+  async startDocument(
+    sourceId: string,
+    sourceName: string,
+    documentId: string,
+    documentName: string,
+  ): Promise<PersistedOctxExportTask> {
+    if (!this.dependencies.startDocumentExport) {
+      throw new Error("Document OCTX export is unavailable");
+    }
+    const transfer = await this.dependencies.startDocumentExport(sourceId, documentId);
+    this.dependencies.recordEvent?.("octx.export", {
+      action: "created",
+      transfer_id: transfer.id,
+      source_id: sourceId,
+      document_id: documentId,
+      scope: "document",
+      status: transfer.status,
+    });
+    return this.reconcile(
+      {
+        transferId: transfer.id,
+        sourceId,
+        sourceName,
+        filenameHint: documentName,
+        createdAt: this.dependencies.now(),
+      },
+      transfer,
+    );
   }
 
   async refresh(): Promise<void> {
@@ -110,8 +149,13 @@ export class OctxExportTaskManager {
   async downloadAgain(transferId: string): Promise<void> {
     const task = this.tasks.find((item) => item.transferId === transferId);
     if (!task || task.transfer.status !== "ready") return;
-    await this.dependencies.download(task);
-    this.markDownloaded(transferId);
+    try {
+      await this.dependencies.download(task);
+      this.markDownloaded(transferId);
+    } catch (error) {
+      this.markDownloadFailed(task, error);
+      throw error;
+    }
   }
 
   dismiss(transferId: string): void {
@@ -141,14 +185,34 @@ export class OctxExportTaskManager {
     try {
       await this.dependencies.download(task);
       this.markDownloaded(task.transferId);
-    } catch {
-      // Keep autoDownloaded=false so the visible task offers a manual retry.
+    } catch (error) {
+      this.markDownloadFailed(task, error);
     }
+  }
+
+  private markDownloadFailed(task: PersistedOctxExportTask, error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    this.tasks = this.tasks.map((item) =>
+      item.transferId === task.transferId
+        ? { ...item, autoDownloaded: false, downloadError: message.slice(0, 1000) }
+        : item,
+    );
+    this.dependencies.recordEvent?.("octx.export", {
+      action: "download_failed",
+      transfer_id: task.transferId,
+      source_id: task.sourceId,
+      scope: task.transfer.export_scope ?? "source",
+      error_type: error instanceof Error ? error.name : typeof error,
+      error_message: message,
+    });
+    this.persistAndEmit();
   }
 
   private markDownloaded(transferId: string): void {
     this.tasks = this.tasks.map((task) =>
-      task.transferId === transferId ? { ...task, autoDownloaded: true } : task,
+      task.transferId === transferId
+        ? { ...task, autoDownloaded: true, downloadError: undefined }
+        : task,
     );
     this.persistAndEmit();
   }

--- a/apps/web/lib/octx-export-tasks.ts
+++ b/apps/web/lib/octx-export-tasks.ts
@@ -17,6 +17,7 @@ export interface PersistedOctxExportTask {
   sourceId: string;
   sourceName: string;
   filenameHint?: string;
+  downloadError?: string;
   autoDownloaded: boolean;
   createdAt: string;
   transfer: OctxTransfer;
@@ -53,6 +54,7 @@ function isTask(value: unknown): value is PersistedOctxExportTask {
     typeof task.sourceId === "string" &&
     typeof task.sourceName === "string" &&
     (task.filenameHint === undefined || typeof task.filenameHint === "string") &&
+    (task.downloadError === undefined || typeof task.downloadError === "string") &&
     typeof task.autoDownloaded === "boolean" &&
     typeof task.createdAt === "string" &&
     isTransfer(task.transfer) &&
@@ -86,6 +88,7 @@ export function mergeExportTransfer(
     sourceId: existing?.sourceId ?? metadata.sourceId,
     sourceName: existing?.sourceName ?? metadata.sourceName,
     filenameHint: existing?.filenameHint ?? metadata.filenameHint,
+    downloadError: existing?.downloadError,
     autoDownloaded: existing?.autoDownloaded ?? false,
     createdAt: existing?.createdAt ?? metadata.createdAt,
     transfer,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -783,6 +783,9 @@ export interface OctxTransfer {
     completed?: number;
     total?: number;
   };
+  export_scope?: "source" | "document";
+  document_id?: string | null;
+  document_name?: string | null;
   validation_report: Record<string, unknown> | null;
   warnings: unknown[];
   error: OctxTransferError | null;

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -235,6 +235,10 @@
     "exportCancel": "Cancel",
     "exportDismiss": "Dismiss",
     "exportDownloadAgain": "Download again",
+    "exportDiagnostics": "Export diagnostics",
+    "exportDiagnosticsReady": "Diagnostics exported. Send the file to support for analysis.",
+    "exportDownloadFailed": "Package download failed",
+    "documentExportBadge": "Single-document export",
     "exportReextractRequired": "Re-extract these documents before exporting again",
     "exportMissingEvents": "{count, plural, one {# event} other {# events}}",
     "exportGoToDocuments": "Go to documents",
@@ -307,6 +311,7 @@
     "pause": "Stop extraction",
     "resume": "Resume extraction",
     "reprocess": "Reprocess",
+    "exportOctx": "Export this document as .octx",
     "delete": "Delete"
   },
   "Knowledge": {

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -235,6 +235,10 @@
     "exportCancel": "取消",
     "exportDismiss": "关闭",
     "exportDownloadAgain": "重新下载",
+    "exportDiagnostics": "导出诊断日志",
+    "exportDiagnosticsReady": "诊断日志已导出，请发送给研发排查",
+    "exportDownloadFailed": "数据包下载失败",
+    "documentExportBadge": "单文档导出",
     "exportReextractRequired": "请重新提取以下文档后再导出",
     "exportMissingEvents": "{count, number} 个事项",
     "exportGoToDocuments": "前往文档列表",
@@ -307,6 +311,7 @@
     "pause": "停止抽取",
     "resume": "继续抽取",
     "reprocess": "重新处理",
+    "exportOctx": "导出此文档为 .octx",
     "delete": "删除"
   },
   "Knowledge": {


### PR DESCRIPTION
## 核心改动

- 支持将 READY 文档独立导出为 OCTX；使用独立 Asset/Release，重复导出保持 Asset 稳定并自动递增版本，导入后默认创建独立信源。
- 单文档与整库导出在同一信源内串行，相同请求复用已有任务，避免重复打包和快照竞争。
- 完善 OCTX 故障诊断：记录任务阶段、关联 ID、结构化错误与桌面运行环境；自动下载失败时可从任务中心导出诊断文件。
- 隔离桌面端 OCTX Worker，并识别内存不足等异常退出，避免导出任务拖垮主服务。
- 单文档裁剪跨文档父事项时按根事项导出，确保生成的 OCTX 包通过 0.1.4 完整校验。

## 影响范围

- 保留现有整库 OCTX 导入导出行为；新增的文档绑定不修改原信源的 OCTX 版本绑定。
- 变更集中在 OCTX 导出任务、诊断链路和桌面端 Worker，不涉及知识库检索与问答逻辑。
- 诊断接口校验任务创建者；诊断包不包含正文、向量、密钥及 Electron/Python 原始日志内容。

## 验证

- 后端全量测试：468 passed，1 skipped
- OCTX 专项测试：117 passed
- Web 单元测试、lint、typecheck 与生产构建通过
- Desktop typecheck、build、macOS ARM64 DMG/ZIP 打包通过
- 单文档 OCTX 构建、完整校验、往返导入与版本递增验证通过
