### PR TITLE
test(universe): 稳定异步重建任务等待

### DIFF
--- a/apps/api/tests/test_universe_engine.py
+++ b/apps/api/tests/test_universe_engine.py
@@ -1,6 +1,7 @@
 """Exercise aggregate overview and keyset expansion against the real graph store."""
 
 import asyncio
+import time
 import uuid
 from datetime import datetime, timedelta
 
@@ -193,14 +194,19 @@ async def test_universe_real_store_statistics_and_keyset_cursor():
 
             rebuilt = await client.post("/api/v1/universe/rebuild", headers=headers)
             assert rebuilt.status_code == 202, rebuilt.text
-            for _ in range(500):
+            deadline = time.monotonic() + 60
+            while True:
                 job_response = await client.get(
                     f"/api/v1/jobs/{rebuilt.json()['id']}", headers=headers
                 )
                 assert job_response.status_code == 200, job_response.text
                 if job_response.json()["status"] in {"succeeded", "failed"}:
                     break
-                await asyncio.sleep(0.01)
+                assert time.monotonic() < deadline, (
+                    f"universe rebuild did not finish within 60 seconds: "
+                    f"{job_response.text}"
+                )
+                await asyncio.sleep(0.05)
             assert job_response.json()["status"] == "succeeded", job_response.text
             rebuilt = await client.get("/api/v1/universe/manifest", headers=headers)
             assert rebuilt.status_code == 200, rebuilt.text


### PR DESCRIPTION
## 问题
Universe 集成测试仅等待约 5 秒，CI 负载较高时任务仍处于 `running`，导致功能正常但测试误报失败。

## 修复
- 改为基于单调时钟的状态轮询，最长等待 60 秒
- 任务 `failed` 时立即进入原有失败断言
- 超时仍明确失败，不跳过、不弱化成功及数据结果校验

## 验证
- 目标真实异步用例连续运行通过
- Ruff 检查通过
- `git diff --check` 通过

## 影响范围
仅修改 `apps/api/tests/test_universe_engine.py`，不涉及业务代码和文档。