### PR TITLE
test(api): 修复 SQLite 全量测试锁竞争

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -12,6 +12,10 @@ os.environ.setdefault("SAG_DATA_DIR", f"{_TMP}/sag")
 os.environ.setdefault("SAG_UPLOAD_DIR", f"{_TMP}/uploads")
 os.environ.setdefault("SAG_DEBUG", "false")
 os.environ.setdefault("SAG_SAG_LANGUAGE", "zh")
+# The suite intentionally shares one temporary SQLite database. Startup warmup
+# would otherwise provision sources persisted by earlier cases in the background
+# while the current case is writing, introducing cross-test lock contention.
+os.environ["SAG_ENGINE_WARMUP_COUNT"] = "0"
 # 强制离线：即使存在带真实 key 的 .env，也保证测试确定性（不发起 LLM 调用）
 os.environ["SAG_LLM_API_KEY"] = ""
 os.environ["SAG_LLM_BASE_URL"] = ""

--- a/apps/api/tests/test_hardening.py
+++ b/apps/api/tests/test_hardening.py
@@ -6,6 +6,13 @@ import httpx
 import pytest
 
 
+def test_test_runtime_disables_background_engine_warmup():
+    """Shared SQLite tests must not provision sources left by earlier cases."""
+    from sag_api.core.config import settings
+
+    assert settings.engine_warmup_count == 0
+
+
 @pytest.mark.asyncio
 async def test_source_creation_rolls_back_when_engine_provision_fails():
     from sqlalchemy import select


### PR DESCRIPTION
## 问题

API 全量测试共享同一个临时 SQLite 数据库。应用生命周期启动时会后台预热前序用例遗留的信源，并与当前用例创建信源并发写入 SAG 数据库，导致 `database is locked`，后端质量门禁随机失败并阻断桌面端发布。

## 修复

- 测试环境显式关闭启动时的信源引擎预热，隔离跨用例后台写入
- 增加测试约束，防止测试环境意外恢复后台预热
- 生产环境默认预热配置保持不变
- 不跳过、不弱化真实信源创建、上传和异步任务测试

## 验证

- 修复前：本地全套稳定复现 `1 failed, 471 passed, 1 skipped`
- 修复后：API 全套 `473 passed, 1 skipped`
- 失败用例与新增约束测试通过
- Ruff 与 `git diff --check` 通过

## 影响范围

仅修改 2 个测试文件，不涉及生产业务代码、配置默认值或文档。