### PR TITLE
feat(desktop): 增加更新状态提示与版本展示

### DIFF
--- a/apps/desktop/src/channels.ts
+++ b/apps/desktop/src/channels.ts
@@ -1,6 +1,8 @@
 export const DESKTOP_CHANNELS = {
   appInfo: "desktop:app-info",
   checkForUpdates: "desktop:check-for-updates",
+  getUpdateState: "desktop:get-update-state",
+  installUpdate: "desktop:install-update",
   updateState: "desktop:update-state",
   diagnosticsInfo: "desktop:diagnostics-info",
 } as const;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -129,6 +129,8 @@ function readLogTail(filePath: string, sizeBytes: number): {
 function registerIpc(): void {
   ipcMain.removeHandler(DESKTOP_CHANNELS.appInfo);
   ipcMain.removeHandler(DESKTOP_CHANNELS.checkForUpdates);
+  ipcMain.removeHandler(DESKTOP_CHANNELS.getUpdateState);
+  ipcMain.removeHandler(DESKTOP_CHANNELS.installUpdate);
   ipcMain.removeHandler(DESKTOP_CHANNELS.diagnosticsInfo);
   ipcMain.handle(DESKTOP_CHANNELS.appInfo, (event) => {
     if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
@@ -137,6 +139,14 @@ function registerIpc(): void {
   ipcMain.handle(DESKTOP_CHANNELS.checkForUpdates, async (event) => {
     if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
     return updater?.check() ?? { supported: false };
+  });
+  ipcMain.handle(DESKTOP_CHANNELS.getUpdateState, (event) => {
+    if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
+    return updater?.getState() ?? { status: "idle" };
+  });
+  ipcMain.handle(DESKTOP_CHANNELS.installUpdate, (event) => {
+    if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");
+    return updater?.install() ?? { started: false };
   });
   ipcMain.handle(DESKTOP_CHANNELS.diagnosticsInfo, (event) => {
     if (!isTrustedSender(event)) throw new Error("Untrusted IPC sender");

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -8,6 +8,8 @@ import type { DesktopDiagnosticsInfo, UpdateState } from "./channels";
 const DESKTOP_CHANNELS = {
   appInfo: "desktop:app-info",
   checkForUpdates: "desktop:check-for-updates",
+  getUpdateState: "desktop:get-update-state",
+  installUpdate: "desktop:install-update",
   diagnosticsInfo: "desktop:diagnostics-info",
   updateState: "desktop:update-state",
 } as const;
@@ -17,6 +19,8 @@ export interface SagDesktopBridge {
   readonly platform: NodeJS.Platform;
   appInfo(): Promise<{ version: string; platform: NodeJS.Platform; arch: string }>;
   checkForUpdates(): Promise<{ supported: boolean }>;
+  getUpdateState(): Promise<UpdateState>;
+  installUpdate(): Promise<{ started: boolean }>;
   getDiagnosticsInfo(): Promise<DesktopDiagnosticsInfo>;
   onUpdateState(listener: (state: UpdateState) => void): () => void;
 }
@@ -26,6 +30,8 @@ const bridge: SagDesktopBridge = Object.freeze({
   platform: process.platform,
   appInfo: () => ipcRenderer.invoke(DESKTOP_CHANNELS.appInfo),
   checkForUpdates: () => ipcRenderer.invoke(DESKTOP_CHANNELS.checkForUpdates),
+  getUpdateState: () => ipcRenderer.invoke(DESKTOP_CHANNELS.getUpdateState),
+  installUpdate: () => ipcRenderer.invoke(DESKTOP_CHANNELS.installUpdate),
   getDiagnosticsInfo: () =>
     ipcRenderer.invoke(DESKTOP_CHANNELS.diagnosticsInfo),
   onUpdateState: (listener: (state: UpdateState) => void) => {

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -10,6 +10,8 @@ import { desktopConfig } from "./config";
 
 export interface UpdaterController {
   check(): Promise<{ supported: boolean }>;
+  getState(): UpdateState;
+  install(): { started: boolean };
   dispose(): void;
 }
 
@@ -18,11 +20,13 @@ export function createUpdaterController(
 ): UpdaterController {
   let delayTimer: NodeJS.Timeout | null = null;
   let intervalTimer: NodeJS.Timeout | null = null;
+  let currentState: UpdateState = { status: "idle" };
   const supported =
     app.isPackaged
     && existsSync(path.join(process.resourcesPath, "app-update.yml"));
 
   const publish = (state: UpdateState) => {
+    currentState = state;
     const window = getWindow();
     if (window && !window.isDestroyed()) {
       window.webContents.send(DESKTOP_CHANNELS.updateState, state);
@@ -90,6 +94,14 @@ export function createUpdaterController(
 
   return {
     check,
+    getState: () => currentState,
+    install: () => {
+      if (!supported || currentState.status !== "downloaded") {
+        return { started: false };
+      }
+      autoUpdater.quitAndInstall(false, true);
+      return { started: true };
+    },
     dispose: () => {
       if (delayTimer) clearTimeout(delayTimer);
       if (intervalTimer) clearInterval(intervalTimer);

--- a/apps/web/components/features/app-sidebar.tsx
+++ b/apps/web/components/features/app-sidebar.tsx
@@ -27,6 +27,7 @@ import { useApp } from "@/components/features/app-shell";
 import { useConversationIndex } from "@/components/features/chat/conversation-provider";
 import { WorkspaceSectionIcon } from "@/components/features/workspace-section-icon";
 import { DesktopUpdateIndicator } from "@/components/features/desktop-update-indicator";
+import { AppVersionBadge } from "@/components/features/app-version-badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,7 +68,10 @@ function Brand() {
               className="size-8 shrink-0 rounded-[9px] shadow-sm ring-1 ring-black/10 dark:ring-white/10"
             />
             <div className="grid flex-1 text-left leading-tight group-data-[collapsible=icon]:hidden">
-              <span className="truncate text-base font-semibold">{PRODUCT_NAME}</span>
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate text-base font-semibold">{PRODUCT_NAME}</span>
+                <AppVersionBadge />
+              </span>
               <span className="truncate text-xs text-muted-foreground">{t("brandTagline")}</span>
             </div>
           </Link>

--- a/apps/web/components/features/app-sidebar.tsx
+++ b/apps/web/components/features/app-sidebar.tsx
@@ -26,6 +26,7 @@ import {
 import { useApp } from "@/components/features/app-shell";
 import { useConversationIndex } from "@/components/features/chat/conversation-provider";
 import { WorkspaceSectionIcon } from "@/components/features/workspace-section-icon";
+import { DesktopUpdateIndicator } from "@/components/features/desktop-update-indicator";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -348,6 +349,7 @@ export function AppSidebar({ contained = false }: { contained?: boolean }) {
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>
+          <DesktopUpdateIndicator />
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild

--- a/apps/web/components/features/app-version-badge.test.tsx
+++ b/apps/web/components/features/app-version-badge.test.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import packageMetadata from "@/package.json";
+import { AppVersionBadge } from "@/components/features/app-version-badge";
+
+describe("AppVersionBadge", () => {
+  it("shows the build version with a v prefix", () => {
+    const html = renderToStaticMarkup(<AppVersionBadge />);
+
+    expect(html).toContain(`v${packageMetadata.version}`);
+  });
+});

--- a/apps/web/components/features/app-version-badge.tsx
+++ b/apps/web/components/features/app-version-badge.tsx
@@ -1,0 +1,14 @@
+import packageMetadata from "@/package.json";
+
+export const APP_VERSION = packageMetadata.version;
+
+export function AppVersionBadge() {
+  return (
+    <span
+      aria-label={`SAG version ${APP_VERSION}`}
+      className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+    >
+      v{APP_VERSION}
+    </span>
+  );
+}

--- a/apps/web/components/features/desktop-update-indicator.test.tsx
+++ b/apps/web/components/features/desktop-update-indicator.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+import messages from "@/messages/zh-CN.json";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  connectDesktopUpdater,
+  DesktopUpdateIndicatorView,
+  type DesktopUpdateBridge,
+  type DesktopUpdateState,
+} from "./desktop-update-indicator";
+
+function render(state: DesktopUpdateState) {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider
+      locale="zh-CN"
+      timeZone="Asia/Shanghai"
+      messages={messages}
+    >
+      <TooltipProvider>
+        <SidebarProvider>
+          <DesktopUpdateIndicatorView state={state} onInstall={vi.fn()} />
+        </SidebarProvider>
+      </TooltipProvider>
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("desktop update indicator", () => {
+  it("restores the main-process snapshot without missing newer live events", async () => {
+    let listener: ((state: DesktopUpdateState) => void) | undefined;
+    let resolveSnapshot: ((state: DesktopUpdateState) => void) | undefined;
+    const bridge: DesktopUpdateBridge = {
+      getUpdateState: () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+      installUpdate: vi.fn(),
+      onUpdateState: (next) => {
+        listener = next;
+        return vi.fn();
+      },
+    };
+    const states: DesktopUpdateState[] = [];
+
+    const disconnect = connectDesktopUpdater(bridge, (state) => states.push(state));
+    listener?.({ status: "downloading", percent: 61 });
+    resolveSnapshot?.({ status: "available", version: "1.7.0" });
+    await Promise.resolve();
+
+    expect(states).toEqual([{ status: "downloading", percent: 61 }]);
+    disconnect();
+  });
+
+  it("renders persistent progress while an update downloads", () => {
+    const html = render({ status: "downloading", percent: 42.4 });
+
+    expect(html).toContain("正在下载更新 42%");
+  });
+
+  it("offers restart installation after the update is downloaded", () => {
+    const html = render({ status: "downloaded", version: "1.7.0" });
+
+    expect(html).toContain("重启以更新 1.7.0");
+    expect(html).toContain("button");
+  });
+
+  it("stays hidden when no actionable update exists", () => {
+    expect(render({ status: "idle" })).not.toContain("<button");
+    expect(render({ status: "not-available" })).not.toContain("<button");
+  });
+});

--- a/apps/web/components/features/desktop-update-indicator.tsx
+++ b/apps/web/components/features/desktop-update-indicator.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { ArrowUpCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+export type DesktopUpdateState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "available"; version: string }
+  | { status: "not-available" }
+  | { status: "downloading"; percent: number }
+  | { status: "downloaded"; version: string }
+  | { status: "error"; message: string };
+
+export interface DesktopUpdateBridge {
+  getUpdateState(): Promise<DesktopUpdateState>;
+  installUpdate(): Promise<{ started: boolean }>;
+  onUpdateState(listener: (state: DesktopUpdateState) => void): () => void;
+}
+
+export function connectDesktopUpdater(
+  bridge: DesktopUpdateBridge,
+  onState: (state: DesktopUpdateState) => void,
+): () => void {
+  let active = true;
+  let receivedLiveState = false;
+  const unsubscribe = bridge.onUpdateState((state) => {
+    if (!active) return;
+    receivedLiveState = true;
+    onState(state);
+  });
+  void bridge.getUpdateState().then((state) => {
+    if (active && !receivedLiveState) onState(state);
+  }).catch(() => {
+    // The live subscription remains active if the initial IPC snapshot fails.
+  });
+  return () => {
+    active = false;
+    unsubscribe();
+  };
+}
+
+export function DesktopUpdateIndicatorView({
+  state,
+  onInstall,
+}: {
+  state: DesktopUpdateState;
+  onInstall: () => void;
+}) {
+  const t = useTranslations("DesktopUpdate");
+  if (
+    state.status !== "available"
+    && state.status !== "downloading"
+    && state.status !== "downloaded"
+  ) {
+    return null;
+  }
+
+  const downloaded = state.status === "downloaded";
+  const label =
+    state.status === "available"
+      ? t("available", { version: state.version })
+      : state.status === "downloading"
+        ? t("downloading", { percent: Math.round(state.percent) })
+        : t("restart", { version: state.version });
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        type="button"
+        tooltip={label}
+        aria-label={label}
+        aria-disabled={!downloaded}
+        onClick={() => {
+          if (downloaded) onInstall();
+        }}
+        className="bg-blue-500/10 text-blue-700 hover:bg-blue-500/15 hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-200"
+      >
+        {state.status === "downloading" ? (
+          <Spinner className="size-4" />
+        ) : (
+          <ArrowUpCircle className="size-4" />
+        )}
+        <span>{label}</span>
+        <span
+          className="ml-auto size-2 rounded-full bg-blue-500 group-data-[collapsible=icon]:hidden"
+          aria-hidden="true"
+        />
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+export function DesktopUpdateIndicator() {
+  const t = useTranslations("DesktopUpdate");
+  const [state, setState] = React.useState<DesktopUpdateState>({ status: "idle" });
+  const bridge =
+    typeof window !== "undefined" && window.sagDesktop?.isDesktop
+      ? window.sagDesktop
+      : null;
+
+  React.useEffect(() => {
+    if (!bridge?.getUpdateState || !bridge.installUpdate) return;
+    return connectDesktopUpdater(bridge, setState);
+  }, [bridge]);
+
+  if (!bridge) return null;
+
+  return (
+    <DesktopUpdateIndicatorView
+      state={state}
+      onInstall={() => {
+        void bridge.installUpdate().then(({ started }) => {
+          if (!started) toast.error(t("installUnavailable"));
+        }).catch(() => toast.error(t("installFailed")));
+      }}
+    />
+  );
+}

--- a/apps/web/lib/desktop-bridge.d.ts
+++ b/apps/web/lib/desktop-bridge.d.ts
@@ -23,19 +23,25 @@ export interface SagDesktopDiagnosticsInfo {
   }>;
 }
 
+export type SagDesktopUpdateState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "available"; version: string }
+  | { status: "not-available" }
+  | { status: "downloading"; percent: number }
+  | { status: "downloaded"; version: string }
+  | { status: "error"; message: string };
+
 export interface SagDesktopBridge {
   readonly isDesktop: true;
   readonly platform: string;
   appInfo(): Promise<{ version: string; platform: string; arch: string }>;
   checkForUpdates(): Promise<{ supported: boolean }>;
+  getUpdateState(): Promise<SagDesktopUpdateState>;
+  installUpdate(): Promise<{ started: boolean }>;
   getDiagnosticsInfo(): Promise<SagDesktopDiagnosticsInfo>;
   onUpdateState(
-    listener: (state: {
-      status: string;
-      version?: string;
-      percent?: number;
-      message?: string;
-    }) => void,
+    listener: (state: SagDesktopUpdateState) => void,
   ): () => void;
 }
 

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -151,6 +151,13 @@
     "more": "More",
     "collapse": "Collapse"
   },
+  "DesktopUpdate": {
+    "available": "Update {version} available",
+    "downloading": "Downloading update {percent, number}%",
+    "restart": "Restart to update to {version}",
+    "installUnavailable": "The update has not finished downloading",
+    "installFailed": "Unable to start the update. Try again later."
+  },
   "ArchivedThreads": {
     "title": "Archived conversations",
     "description": "Recently archived conversations appear first and can be restored or permanently deleted.",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -151,6 +151,13 @@
     "more": "更多",
     "collapse": "收起"
   },
+  "DesktopUpdate": {
+    "available": "发现新版本 {version}",
+    "downloading": "正在下载更新 {percent, number}%",
+    "restart": "重启以更新 {version}",
+    "installUnavailable": "更新尚未下载完成",
+    "installFailed": "无法启动更新，请稍后重试"
+  },
   "ArchivedThreads": {
     "title": "归档会话",
     "description": "最近归档的会话优先显示，可恢复或永久删除。",


### PR DESCRIPTION
## 核心改动

- 在桌面端侧边栏左下角展示新版本、下载进度和更新就绪状态
- 更新下载完成后支持点击重启并安装
- 由 Electron 主进程保存更新状态，页面刷新后仍可恢复
- 在左上角 SAG 品牌区域常驻展示当前构建版本号，随发布版本自动更新
- 更新提示仅桌面端展示；版本号在 Web 与桌面端统一展示

## 验证

- Web 单元测试：494 项通过
- Web lint、i18n、类型检查及生产构建通过
- Desktop TypeScript 构建与 preload 校验通过

## 影响范围

仅涉及桌面自动更新 IPC、侧边栏更新提示及版本展示，不修改知识库、检索及数据存储逻辑。