### PR TITLE
fix(web): 知识库上传在客户端先行拦截超限文件

### DIFF
--- a/apps/web/components/features/upload-zone.tsx
+++ b/apps/web/components/features/upload-zone.tsx
@@ -55,6 +55,11 @@ export function UploadZone({
         toast.error(t("unsupportedType", { name: file.name }));
         continue;
       }
+      // 客户端先行拦截：超过单文件上限即时提示，避免超大文件白传后被服务端拒绝
+      if (file.size > maxMb * 1024 * 1024) {
+        toast.error(t("fileTooLarge", { name: file.name, maxMb }));
+        continue;
+      }
       let waitingTimer: ReturnType<typeof setTimeout> | undefined;
       try {
         const idx = ok + 1;

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -274,6 +274,7 @@
   },
   "UploadZone": {
     "unsupportedType": "{name}: Unsupported file type",
+    "fileTooLarge": "{name}: exceeds the {maxMb, number} MB file limit",
     "fileFailed": "{name}: {error}",
     "uploadFailed": "Upload failed",
     "uploaded": "{count, plural, one {# file uploaded} other {# files uploaded}}. Background processing has started.",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -274,6 +274,7 @@
   },
   "UploadZone": {
     "unsupportedType": "{name}：不支持的文件类型",
+    "fileTooLarge": "{name}：超过单文件 {maxMb, number}MB 上限",
     "fileFailed": "{name}：{error}",
     "uploadFailed": "上传失败",
     "uploaded": "已完成 {count, number} 个文件上传，已进入后台处理",


### PR DESCRIPTION
## 改动范围
- `apps/web/components/features/upload-zone.tsx`：知识库文档上传在客户端先行按 `maxMb`（服务端 `max_upload_mb` 下发）校验 `file.size`，超限文件即时 toast 提示并跳过上传，避免大文件完整传输后被服务端拒绝。
- `apps/web/messages/zh-CN.json` / `apps/web/messages/en-US.json`：新增 `UploadZone.fileTooLarge` 文案键，中英文各一条。

## 影响功能范围
- 知识库文档上传入口：超过单文件上限的文件在本地即被拦截，不再发起网络请求。
- 兼容性：边界语义与服务端一致（`file.size > maxMb * 1024 * 1024` 才拒绝，与服务端 `len(data) > max_upload_bytes` 对齐）；服务端 422 校验保留兜底。
- 未发现额外影响。

## 测试覆盖情况
- 通过：`tsc --noEmit`，覆盖全量类型检查。
- 通过：`node scripts/check-i18n.cjs`，1254 个消息键跨 2 个语言文件一致。
- 通过：`eslint components/features/upload-zone.tsx`，覆盖改动文件。
- CI：待远程 CI 执行。
