### PR TITLE
feat: 新增 OrcaRouter 模型 Provider（OpenAI 兼容网关）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ SAG_LLM_MAX_TOKENS=20000
 # 若部署方需要固定生成模型配置，设为 true。修改 LLM 配置后需重启服务。
 SAG_LOCK_LLM_CONFIG=false
 # Anthropic / Gemini 原生接入时将 SAG_LLM_PROVIDER 改为对应值，Base URL 留空使用官方端点。
+# OrcaRouter 网关接入（模型名需带命名空间，如 openai/gpt-4o-mini）：
+# SAG_LLM_PROVIDER=orcarouter
+# SAG_LLM_BASE_URL=https://api.orcarouter.ai/v1
+# SAG_LLM_API_KEY=sk-orca-...
+# SAG_LLM_MODEL=openai/gpt-4o-mini
 SAG_EMBEDDING_MODEL=bge-large-en-v1.5
 SAG_EMBEDDING_BASE_URL=https://api.302ai.cn/v1
 SAG_EMBEDDING_API_KEY=

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ The UI and services still start without model credentials. Embeddings are requir
 
 To make the deployment configuration mandatory, set `SAG_LOCK_LLM_CONFIG=true`. SAG then shows the generation fields as locked in Settings and continues to use the `SAG_LLM_*` values. Change Docker Compose or `.env` and restart the API container to update a locked configuration. API keys remain deployment-managed and are never returned by the Settings API.
 
+The Settings → Models form is driven by the backend provider catalog (`openai`, `anthropic`, `gemini`, `orcarouter`). OrcaRouter is an OpenAI-compatible gateway that requires namespaced model ids, e.g.:
+
+```bash
+SAG_LLM_PROVIDER=orcarouter
+SAG_LLM_BASE_URL=https://api.orcarouter.ai/v1
+SAG_LLM_API_KEY=sk-orca-...
+SAG_LLM_MODEL=openai/gpt-4o-mini
+```
+
+OrcaRouter does not share the embedding format, so configure a separate OpenAI-compatible embedding endpoint and key.
+
 ### Import knowledge
 
 Create a source and add Markdown, text, PDF, Office, or other supported documents. SAG normalizes documents to Markdown, then runs chunking, embedding, event extraction, and entity extraction in the background.

--- a/apps/api/sag_api/core/model_providers.py
+++ b/apps/api/sag_api/core/model_providers.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass
 from types import MappingProxyType
 from typing import Literal
 
-ModelProviderId = Literal["openai", "anthropic", "gemini"]
+ModelProviderId = Literal["openai", "anthropic", "gemini", "orcarouter"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +81,25 @@ _PROVIDER_SPECS = (
         temperature_configurable=True,
         can_reuse_embedding_credentials=False,
         api_key_placeholder="AIza…",
+    ),
+    # OrcaRouter is an OpenAI-compatible gateway that requires namespaced model
+    # ids (e.g. "openai/gpt-4o-mini"). LiteLLM strips exactly one transport
+    # prefix before forwarding, so a plain "openai" prefix would reduce the id
+    # to a bare model name that OrcaRouter rejects. hosted_vllm is LiteLLM's
+    # generic OpenAI-compatible passthrough: it strips only its own prefix and
+    # forwards the remaining namespaced id unchanged.
+    ModelProviderSpec(
+        id="orcarouter",
+        display_name="OrcaRouter",
+        protocol="openai_chat_completions",
+        litellm_prefix="hosted_vllm",
+        default_model="openai/gpt-4o-mini",
+        default_base_url="https://api.orcarouter.ai/v1",
+        default_context_window=128_000,
+        default_temperature=0.3,
+        temperature_configurable=True,
+        can_reuse_embedding_credentials=False,
+        api_key_placeholder="sk-orca-…",
     ),
 )
 

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -227,6 +227,7 @@ async def test_model_config_crud_masking_and_test(monkeypatch: pytest.MonkeyPatc
                     "openai",
                     "anthropic",
                     "gemini",
+                    "orcarouter",
                 ]
                 assert providers[0]["default_model"] == body["llm_model"]
                 assert "litellm_prefix" not in providers[0]

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -35,10 +35,34 @@ def test_connector_registry():
 
 def test_model_provider_registry_is_the_public_source_of_truth():
     catalog = model_provider_catalog()
-    assert [provider["id"] for provider in catalog] == ["openai", "anthropic", "gemini"]
+    assert [provider["id"] for provider in catalog] == ["openai", "anthropic", "gemini", "orcarouter"]
     assert all("litellm_prefix" not in provider for provider in catalog)
     assert get_model_provider("openai").route_model("qwen3.6-flash") == "openai/qwen3.6-flash"
     assert get_model_provider("gemini").route_model("gemini/gemini-3.5-flash") == "gemini/gemini-3.5-flash"
+    assert get_model_provider("orcarouter").route_model("openai/gpt-4o-mini") == "hosted_vllm/openai/gpt-4o-mini"
+
+
+def test_orcarouter_provider_keeps_namespaced_model_through_hosted_vllm():
+    provider = get_model_provider("orcarouter")
+    assert provider.default_base_url == "https://api.orcarouter.ai/v1"
+    assert provider.can_reuse_embedding_credentials is False
+    # OrcaRouter requires the namespaced id upstream; hosted_vllm is the
+    # transport prefix LiteLLM strips before forwarding.
+    assert provider.route_model("openai/gpt-4o-mini") == "hosted_vllm/openai/gpt-4o-mini"
+    assert provider.route_model("hosted_vllm/openai/gpt-4o-mini") == "hosted_vllm/openai/gpt-4o-mini"
+
+    configured = Settings(
+        _env_file=None,
+        llm_provider="orcarouter",
+        llm_base_url="https://api.orcarouter.ai/v1",
+        llm_api_key="sk-orca-test",
+        llm_model="openai/gpt-4o-mini",
+    )
+    assert configured.routed_llm_model == "hosted_vllm/openai/gpt-4o-mini"
+    engine = build_engine_config(configured)
+    assert engine.llm.model == "hosted_vllm/openai/gpt-4o-mini"
+    assert engine.llm.base_url == "https://api.orcarouter.ai/v1"
+    assert engine.embedding.api_key == "not-configured"
 
 
 def test_build_engine_config_zero_infra():
@@ -56,6 +80,7 @@ def test_build_engine_config_zero_infra():
         ("openai", "qwen3.6-flash", "openai/qwen3.6-flash"),
         ("anthropic", "claude-sonnet-5", "anthropic/claude-sonnet-5"),
         ("gemini", "gemini-3.5-flash", "gemini/gemini-3.5-flash"),
+        ("orcarouter", "openai/gpt-4o-mini", "hosted_vllm/openai/gpt-4o-mini"),
     ],
 )
 def test_extraction_engine_uses_one_litellm_transport(provider, model, expected_model):
@@ -420,6 +445,7 @@ async def test_deepseek_v4_agent_turn_sends_non_thinking_tool_request(monkeypatc
         ("openai", "qwen3.6-flash", "openai/qwen3.6-flash", 0.3),
         ("anthropic", "claude-sonnet-5", "anthropic/claude-sonnet-5", 1.0),
         ("gemini", "gemini/gemini-3.5-flash", "gemini/gemini-3.5-flash", 0.3),
+        ("orcarouter", "openai/gpt-4o-mini", "hosted_vllm/openai/gpt-4o-mini", 0.3),
     ],
 )
 async def test_generation_providers_use_one_litellm_route(monkeypatch, provider, model, expected, expected_temperature):

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -146,7 +146,7 @@ export interface Binding {
   config: Record<string, unknown>;
 }
 
-export type ModelProviderId = "openai" | "anthropic" | "gemini";
+export type ModelProviderId = "openai" | "anthropic" | "gemini" | "orcarouter";
 
 export interface ModelProviderSpec {
   id: ModelProviderId;

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -597,12 +597,14 @@
     "providerDescription": {
       "openai": "Works with OpenAI and compatible gateways such as 302.AI or private deployments.",
       "anthropic": "Uses the Anthropic Messages protocol with Claude streaming and tool calls.",
-      "gemini": "Uses Gemini GenerateContent with streaming and function calling."
+      "gemini": "Uses Gemini GenerateContent with streaming and function calling.",
+      "orcarouter": "Uses the OrcaRouter gateway for OpenAI-compatible models with namespaced model ids."
     },
     "baseUrlDescription": {
       "openai": "Enter the API root for an OpenAI-compatible Chat Completions endpoint.",
       "anthropic": "Leave blank for Anthropic's official endpoint, or enter a custom proxy URL.",
-      "gemini": "Leave blank for Google Gemini's official endpoint, or enter a custom proxy URL."
+      "gemini": "Leave blank for Google Gemini's official endpoint, or enter a custom proxy URL.",
+      "orcarouter": "OrcaRouter endpoint. Model ids are namespaced, e.g. openai/gpt-4o-mini."
     },
     "officialEndpoint": "Leave blank to use the official endpoint",
     "providerChangedKeyDescription": "The provider changed. Enter its API key; leaving this blank keeps the previously saved key.",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -597,12 +597,14 @@
     "providerDescription": {
       "openai": "支持 OpenAI 官方及 302.AI、私有网关等兼容端点。",
       "anthropic": "使用 Anthropic Messages 协议，支持 Claude 工具调用与流式回答。",
-      "gemini": "使用 Gemini GenerateContent 协议，支持函数调用与流式回答。"
+      "gemini": "使用 Gemini GenerateContent 协议，支持函数调用与流式回答。",
+      "orcarouter": "通过 OrcaRouter 网关接入 OpenAI 兼容模型，模型名需带命名空间前缀。"
     },
     "baseUrlDescription": {
       "openai": "填写兼容 Chat Completions 的 API 根地址。",
       "anthropic": "留空使用 Anthropic 官方端点；私有代理可填自定义地址。",
-      "gemini": "留空使用 Google Gemini 官方端点；私有代理可填自定义地址。"
+      "gemini": "留空使用 Google Gemini 官方端点；私有代理可填自定义地址。",
+      "orcarouter": "OrcaRouter 端点地址；模型名需带命名空间，如 openai/gpt-4o-mini。"
     },
     "officialEndpoint": "留空使用官方端点",
     "providerChangedKeyDescription": "已切换接入方式；请输入新 provider 的 API Key，留空将继续使用原密钥。",


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class model provider in the SAG **Settings → Models** form. OrcaRouter is an OpenAI-compatible AI gateway whose API requires **namespaced model ids** (e.g. `openai/gpt-4o-mini`).

## What this changes

- `apps/api/sag_api/core/model_providers.py` — new `orcarouter` entry in the provider registry (`ModelProviderId` + `ModelProviderSpec`). The spec uses the `hosted_vllm` LiteLLM transport, the generic OpenAI-compatible passthrough, with `default_model="openai/gpt-4o-mini"` and `default_base_url="https://api.orcarouter.ai/v1"`.
- `apps/web/lib/types.ts` — `"orcarouter"` added to the `ModelProviderId` union.
- `apps/web/messages/en-US.json` / `zh-CN.json` — provider + base-URL descriptions for both locales.
- `apps/api/tests/test_units.py`, `apps/api/tests/test_settings.py` — catalog, `route_model` and full `LLMClient`-wiring coverage for the new provider.
- `.env.example` / `README.md` — documented OrcaRouter configuration.

## Why a separate provider rather than the OpenAI-compatible escape hatch

OrcaRouter's namespaced model-id requirement interacts with LiteLLM's prefix handling: LiteLLM strips exactly **one** transport prefix before forwarding, so the existing `openai` provider (prefix `openai/`) would reduce `openai/gpt-4o-mini` to a bare `gpt-4o-mini`, which OrcaRouter rejects. The `hosted_vllm` transport strips only its own prefix and forwards the remaining namespaced id unchanged — verified live against `https://api.orcarouter.ai/v1`.

## How to use it

Select **OrcaRouter** in Settings → Models, or configure via env:

```bash
SAG_LLM_PROVIDER=orcarouter
SAG_LLM_BASE_URL=https://api.orcarouter.ai/v1
SAG_LLM_API_KEY=sk-orca-...
SAG_LLM_MODEL=openai/gpt-4o-mini
```

## Verification

- Unit tests: `test_units.py` 49 passed; model/settings-adjacent set 65 passed (full API suite: 451 passed; 26 pre-existing `octx`-environment failures on Windows, reproduced on pristine `main`).
- Ruff check clean; en/zh i18n key parity confirmed.
- L3 live test through the real SAG boundary (`Settings(llm_provider="orcarouter", ...)` → `LLMClient.complete()` → LiteLLM → OrcaRouter) returned a valid completion.

Security: no secrets, credentials, or private data are introduced, transmitted, or exposed by this change.

I'm an engineer on the OrcaRouter team.