### PR TITLE
fix(api): MinerU 服务商与官方 URL 冲突时协议跟随 URL 主机

### DIFF
--- a/apps/api/sag_api/services/settings_service.py
+++ b/apps/api/sag_api/services/settings_service.py
@@ -129,6 +129,14 @@ def _normalize_overrides(overrides: dict) -> dict:
         == "https://api.302ai.cn"
     ):
         normalized["mineru_base_url"] = _OFFICIAL_MINERU_BASE_URL
+    elif (
+        normalized["mineru_provider"] == "302"
+        and (urlparse(str(normalized.get("mineru_base_url") or "")).hostname or "").lower()
+        == "mineru.net"
+    ):
+        # 用户在设置页只粘贴了官方 URL、未切换服务商下拉框时，协议必须跟随
+        # URL 主机走官方分支，否则会把官方 v4 请求误发到 302 适配器。
+        normalized["mineru_provider"] = "official"
     strategy = normalized.get("search_strategy")
     if strategy == "atomic":
         normalized["search_strategy"] = normalize_search_strategy(strategy)

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -126,6 +126,54 @@ def test_official_provider_repairs_stale_302_mineru_base_url(stale_base_url):
     assert normalized["mineru_base_url"] == "https://mineru.net/api/v4"
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected_provider", "expected_base_url"),
+    [
+        # 显式 302 + 官方 URL：provider 跟随 URL 主机切换为官方
+        (
+            {"mineru_provider": "302", "mineru_base_url": "https://mineru.net/api/v4"},
+            "official",
+            "https://mineru.net/api/v4",
+        ),
+        (
+            {
+                "mineru_provider": "302",
+                "mineru_base_url": "https://mineru.net/api/v4/file-urls/batch",
+            },
+            "official",
+            "https://mineru.net/api/v4/file-urls/batch",
+        ),
+        # 显式 302 + 302 URL：保持 302 不动
+        (
+            {"mineru_provider": "302", "mineru_base_url": "https://api.302ai.cn"},
+            "302",
+            "https://api.302ai.cn",
+        ),
+        # 未设 provider 时按 URL 主机推断（既有行为）
+        (
+            {"mineru_base_url": "https://mineru.net/api/v4"},
+            "official",
+            "https://mineru.net/api/v4",
+        ),
+        # 官方 + 旧 302 地址（含尾斜杠）仍修复为官方默认地址（既有行为）
+        (
+            {"mineru_provider": "official", "mineru_base_url": "https://api.302ai.cn/"},
+            "official",
+            "https://mineru.net/api/v4",
+        ),
+    ],
+)
+def test_mineru_provider_follows_base_url_host(
+    raw, expected_provider, expected_base_url
+):
+    from sag_api.services.settings_service import _normalize_overrides
+
+    normalized = _normalize_overrides(raw)
+
+    assert normalized["mineru_provider"] == expected_provider
+    assert normalized["mineru_base_url"] == expected_base_url
+
+
 def test_default_model_output_limit_is_20000(monkeypatch):
     monkeypatch.delenv("SAG_LLM_MAX_TOKENS", raising=False)
     assert Settings(_env_file=None).llm_max_tokens == 20_000


### PR DESCRIPTION
## 问题

设置页只粘贴官方 URL（https://mineru.net/api/v4/file-urls/batch）而服务商下拉框仍是默认 302 时，后端会把官方 v4 请求误发到 302 适配器（POST …/302/upload-file），官方解析始终无法启用。对应 Issue #107 的复现场景，fnos 包与 main 行为一致。

## 修复

`_normalize_overrides` 增加反向纠正：显式 `mineru_provider=302` 且 Base URL 主机为 mineru.net 时，provider 自动切换为 official，协议跟随 URL 主机走官方分支；302 URL + 302 provider 不受影响，官方 + 旧 302 地址的既有修复保持不变。

## 验证

- 新增 5 组参数化回归测试（含既有行为），全部通过
- 端到端验证：302 + 官方 URL 保存后 → OfficialMinerUClient 接管
- 相关套件：test_settings / test_document_parsing / test_quick_model_setup → 56 passed
- ruff / git diff --check 通过

关联 Issue：#107