### PR TITLE
fix: 文档删除不再报资源占用错误，上传文档直接排队等待删除清理

### DIFF
--- a/apps/api/sag_api/api/v1/documents.py
+++ b/apps/api/sag_api/api/v1/documents.py
@@ -33,10 +33,7 @@ from sag_api.services.document_service import (
     reprocess_document,
     resume_document,
 )
-from sag_api.services.source_operation_service import (
-    source_content_mutation,
-    source_upload_mutation,
-)
+from sag_api.services.source_operation_service import source_document_mutation
 from sag_api.services.source_service import get_source
 
 router = APIRouter(prefix="/sources/{source_id}/documents", tags=["documents"])
@@ -114,7 +111,7 @@ async def upload(
                 len(data),
                 request_id,
             )
-        async with source_upload_mutation(SessionLocal, source_id):
+        async with source_document_mutation(SessionLocal, source_id, "document-upload"):
             source = await get_source(session, source_id)
             document, _job = await create_document_from_upload(
                 session,
@@ -162,7 +159,7 @@ async def ingest(
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> DocumentOut:
     """统一写入接口：外部系统持续推送文本 / 消息进入信源。"""
-    async with source_content_mutation(SessionLocal, source_id, "document-ingest"):
+    async with source_document_mutation(SessionLocal, source_id, "document-ingest"):
         source = await get_source(session, source_id)
         document = await ingest_content(
             session,
@@ -289,7 +286,7 @@ async def reprocess(
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> JobOut:
-    async with source_content_mutation(SessionLocal, source_id, "document-reprocess"):
+    async with source_document_mutation(SessionLocal, source_id, "document-reprocess"):
         source = await get_source(session, source_id)
         job = await reprocess_document(
             session,
@@ -323,7 +320,7 @@ async def resume(
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> JobOut:
-    async with source_content_mutation(SessionLocal, source_id, "document-resume"):
+    async with source_document_mutation(SessionLocal, source_id, "document-resume"):
         source = await get_source(session, source_id)
         job = await resume_document(session, source, document_id, job_queue=job_queue)
     return JobOut.model_validate(job)
@@ -337,7 +334,7 @@ async def delete_(
     session: AsyncSession = Depends(get_session),
     job_queue: JobQueue = Depends(get_job_queue),
 ) -> Ok:
-    async with source_content_mutation(SessionLocal, source_id, "document-delete"):
+    async with source_document_mutation(SessionLocal, source_id, "document-delete"):
         source = await get_source(session, source_id)
         await delete_document(
             session,

--- a/apps/api/sag_api/services/document_service.py
+++ b/apps/api/sag_api/services/document_service.py
@@ -283,39 +283,58 @@ async def _document_derived_source_ids(
     return values
 
 
-async def _refresh_source_counts(session: AsyncSession, source: Source) -> None:
-    document_count, chunk_count, event_count = (
-        await session.execute(
-            select(
-                func.count(Document.id),
-                func.coalesce(
-                    func.sum(
-                        case(
-                            (Document.status == DocumentStatus.READY, Document.chunk_count),
-                            else_=0,
-                        )
-                    ),
-                    0,
+def _source_document_filter(source_id: str):
+    return (
+        Document.source_id == source_id,
+        Document.is_active.is_(True),
+        Document.status.not_in([DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED]),
+    )
+
+
+def _source_sum_clause(source_id: str, column):
+    """仅统计 READY 文档的分块/事件列求和。"""
+    return (
+        select(
+            func.coalesce(
+                func.sum(
+                    case(
+                        (Document.status == DocumentStatus.READY, column),
+                        else_=0,
+                    )
                 ),
-                func.coalesce(
-                    func.sum(
-                        case(
-                            (Document.status == DocumentStatus.READY, Document.event_count),
-                            else_=0,
-                        )
-                    ),
-                    0,
-                ),
-            ).where(
-                Document.source_id == source.id,
-                Document.is_active.is_(True),
-                Document.status.not_in([DocumentStatus.DELETING, DocumentStatus.DELETE_FAILED]),
+                0,
             )
         )
-    ).one()
-    source.document_count = int(document_count)
-    source.chunk_count = int(chunk_count)
-    source.event_count = int(event_count)
+        .where(*_source_document_filter(source_id))
+        .scalar_subquery()
+    )
+
+
+async def _refresh_source_counts(session: AsyncSession, source: Source) -> None:
+    """原子重算信源聚合计数。
+
+    删除任务与文档级变更（上传/删除等）可并发提交；用单条 UPDATE 在数据库
+    层串行化计数写入，避免「先 SELECT 后赋值」在两者交错时丢失计数。
+    """
+    document_count = (
+        select(func.count(Document.id))
+        .where(*_source_document_filter(source.id))
+        .scalar_subquery()
+    )
+    await session.execute(
+        update(Source)
+        .where(Source.id == source.id)
+        .values(
+            document_count=document_count,
+            chunk_count=_source_sum_clause(source.id, Document.chunk_count),
+            event_count=_source_sum_clause(source.id, Document.event_count),
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.refresh(
+        source,
+        attribute_names=["document_count", "chunk_count", "event_count"],
+    )
 
 
 async def _commit_document_job_transition(

--- a/apps/api/sag_api/services/source_operation_service.py
+++ b/apps/api/sag_api/services/source_operation_service.py
@@ -155,32 +155,61 @@ async def acquire_operation_lease(
         await _release_owned(session_factory, acquired, owner)
 
 
+_DOCUMENT_DELETE_OWNER_PREFIX = "document-delete:"
+_DOCUMENT_MUTATION_BUSY_MESSAGE = "知识库正在执行其他数据操作，请稍后重试"
+
+
 @asynccontextmanager
-async def source_content_mutation(
+async def source_document_mutation(
     session_factory: async_sessionmaker,
     source_id: str,
     operation: str,
     *,
     admission_timeout_seconds: float = 1,
 ) -> AsyncIterator[None]:
-    """Serialize every source-content mutation with OCTX import/export jobs."""
+    """Admit one document-level mutation, queueing behind deletion cleanups.
+
+    Document deletion holds the source gate while engine-side records are
+    removed, but its critical section only touches the deleted document's rows
+    and files plus source counts. Every document-level mutation (upload /
+    delete / reprocess / resume / ingest) therefore proceeds immediately when
+    a deletion cleanup is in flight; its own processing is serialized in the
+    background (the maintenance coordinator dispatches maintenance jobs one at
+    a time, and processor admission waits for the cleanup to drain).
+
+    Other exclusive owners (OCTX import/export, source deletion) retain the
+    normal fail-fast behavior so transfer snapshots cannot be mutated
+    underneath them.
+    """
     if not source_id or not operation:
         raise ValueError("source mutation requires source_id and operation")
     owner = f"{operation}:{new_id()}"
+    resource_key = f"source:{source_id}"
     deadline = time.monotonic() + admission_timeout_seconds
+    bypassed = False
     while True:
-        lease = acquire_operation_lease(session_factory, [f"source:{source_id}"], owner=owner)
+        lease = acquire_operation_lease(session_factory, [resource_key], owner=owner)
         try:
             await lease.__aenter__()
             break
-        except ConflictError:
+        except ConflictError as error:
+            active_owner = await _active_lease_owner(session_factory, resource_key)
+            if active_owner is not None and active_owner.startswith(_DOCUMENT_DELETE_OWNER_PREFIX):
+                bypassed = True
+                break
             if time.monotonic() >= deadline:
-                raise
+                raise ConflictError(
+                    _DOCUMENT_MUTATION_BUSY_MESSAGE,
+                    layer=ErrorLayer.STORE,
+                    stage=ErrorStage.OCTX_RESOLVE,
+                    retryable=True,
+                ) from error
             await asyncio.sleep(0.02)
     try:
         yield
     finally:
-        await lease.__aexit__(None, None, None)
+        if not bypassed:
+            await lease.__aexit__(None, None, None)
 
 
 @asynccontextmanager
@@ -210,58 +239,6 @@ async def _active_lease_owner(
                 OctxOperationLease.expires_at > _now(),
             )
         )
-
-
-@asynccontextmanager
-async def source_upload_mutation(
-    session_factory: async_sessionmaker,
-    source_id: str,
-    *,
-    admission_timeout_seconds: float = 1,
-    delete_wait_timeout_seconds: float = 60,
-) -> AsyncIterator[None]:
-    """Admit uploads, waiting only for the preceding document deletion.
-
-    Document deletion can legitimately hold the source gate while engine-side
-    records are removed. A user who immediately corrects a mistaken upload
-    should not see that internal lease conflict. Other exclusive owners (OCTX
-    import/export, source deletion, reprocessing) retain the normal fail-fast
-    behavior so transfer snapshots cannot be mutated underneath them.
-    """
-    if not source_id:
-        raise ValueError("source upload mutation requires source_id")
-    owner = f"document-upload:{new_id()}"
-    resource_key = f"source:{source_id}"
-    started_at = time.monotonic()
-    admission_deadline = started_at + admission_timeout_seconds
-    delete_deadline = started_at + delete_wait_timeout_seconds
-    while True:
-        lease = acquire_operation_lease(session_factory, [resource_key], owner=owner)
-        try:
-            await lease.__aenter__()
-            break
-        except ConflictError as error:
-            active_owner = await _active_lease_owner(session_factory, resource_key)
-            deleting = bool(active_owner and active_owner.startswith("document-delete:"))
-            now = time.monotonic()
-            if deleting and now < delete_deadline:
-                await asyncio.sleep(0.05)
-                continue
-            if now < admission_deadline:
-                await asyncio.sleep(0.02)
-                continue
-            if deleting:
-                raise ConflictError(
-                    "上一份文档仍在清理，请稍后重试",
-                    layer=ErrorLayer.STORE,
-                    stage=ErrorStage.OCTX_RESOLVE,
-                    retryable=True,
-                ) from error
-            raise
-    try:
-        yield
-    finally:
-        await lease.__aexit__(None, None, None)
 
 
 def _processing_resource(source_id: str, job_id: str) -> str:
@@ -310,15 +287,24 @@ async def acquire_source_processing_lease(
     job_id: str,
     *,
     admission_timeout_seconds: float = 1,
+    delete_wait_timeout_seconds: float = 120,
 ) -> AsyncIterator[None]:
-    """Register one shared processor while briefly crossing the source gate."""
+    """Register one shared processor while briefly crossing the source gate.
+
+    A document uploaded right after a deletion is queued as pending while the
+    delete cleanup drains; this admission therefore waits for a document-delete
+    owner instead of consuming a retry attempt. Other exclusive owners keep the
+    normal fail-fast admission so transfers are never blocked for long.
+    """
     owner = f"document:{job_id}"
     processing = acquire_operation_lease(
         session_factory,
         [_processing_resource(source_id, job_id)],
         owner=owner,
     )
-    deadline = time.monotonic() + admission_timeout_seconds
+    started_at = time.monotonic()
+    deadline = started_at + admission_timeout_seconds
+    delete_deadline = started_at + delete_wait_timeout_seconds
     while True:
         try:
             async with acquire_operation_lease(
@@ -329,6 +315,14 @@ async def acquire_source_processing_lease(
                 await processing.__aenter__()
             break
         except ConflictError:
+            active_owner = await _active_lease_owner(session_factory, f"source:{source_id}")
+            deleting = bool(
+                active_owner is not None
+                and active_owner.startswith(_DOCUMENT_DELETE_OWNER_PREFIX)
+            )
+            if deleting and time.monotonic() < delete_deadline:
+                await asyncio.sleep(0.05)
+                continue
             if time.monotonic() >= deadline:
                 raise
             await asyncio.sleep(0.02)

--- a/apps/api/tests/test_octx_conflict_and_lease.py
+++ b/apps/api/tests/test_octx_conflict_and_lease.py
@@ -127,7 +127,7 @@ async def test_ordinary_source_mutation_cannot_enter_during_octx_export(octx_ses
     from sag_api.core.errors import ConflictError
     from sag_api.services.source_operation_service import (
         acquire_operation_lease,
-        source_content_mutation,
+        source_document_mutation,
     )
 
     async with acquire_operation_lease(
@@ -136,75 +136,16 @@ async def test_ordinary_source_mutation_cannot_enter_during_octx_export(octx_ses
         owner="octx-export",
     ):
         with pytest.raises(ConflictError):
-            async with source_content_mutation(octx_sessions, "source-a", "document-delete"):
+            async with source_document_mutation(octx_sessions, "source-a", "document-delete"):
                 pass
 
 
 @pytest.mark.asyncio
-async def test_upload_waits_for_document_delete_lease(octx_sessions):
-    """A quick re-upload should continue after the preceding async delete drains."""
-    import asyncio
-
+async def test_document_mutations_bypass_document_delete_lease(octx_sessions):
+    """Upload and delete requests must not block behind a preceding deletion."""
     from sag_api.services.source_operation_service import (
         acquire_operation_lease,
-        source_upload_mutation,
-    )
-
-    delete_started = asyncio.Event()
-
-    async def delete_document() -> None:
-        async with acquire_operation_lease(
-            octx_sessions,
-            ["source:source-a"],
-            owner="document-delete:job-a",
-        ):
-            delete_started.set()
-            await asyncio.sleep(0.08)
-
-    deletion = asyncio.create_task(delete_document())
-    await delete_started.wait()
-    entered = False
-    async with source_upload_mutation(
-        octx_sessions,
-        "source-a",
-        admission_timeout_seconds=0.01,
-        delete_wait_timeout_seconds=0.5,
-    ):
-        entered = True
-    await deletion
-    assert entered is True
-
-
-@pytest.mark.asyncio
-async def test_upload_does_not_wait_for_octx_export_lease(octx_sessions):
-    """The delete exception must not weaken OCTX import/export isolation."""
-    from sag_api.core.errors import ConflictError
-    from sag_api.services.source_operation_service import (
-        acquire_operation_lease,
-        source_upload_mutation,
-    )
-
-    async with acquire_operation_lease(
-        octx_sessions,
-        ["source:source-a"],
-        owner="octx-export:job-a",
-    ):
-        with pytest.raises(ConflictError, match="OCTX operation resource is busy"):
-            async with source_upload_mutation(
-                octx_sessions,
-                "source-a",
-                admission_timeout_seconds=0.01,
-                delete_wait_timeout_seconds=0.5,
-            ):
-                pass
-
-
-@pytest.mark.asyncio
-async def test_upload_delete_wait_timeout_is_user_facing(octx_sessions):
-    from sag_api.core.errors import ConflictError
-    from sag_api.services.source_operation_service import (
-        acquire_operation_lease,
-        source_upload_mutation,
+        source_document_mutation,
     )
 
     async with acquire_operation_lease(
@@ -212,12 +153,173 @@ async def test_upload_delete_wait_timeout_is_user_facing(octx_sessions):
         ["source:source-a"],
         owner="document-delete:job-a",
     ):
-        with pytest.raises(ConflictError, match="上一份文档仍在清理，请稍后重试"):
-            async with source_upload_mutation(
+        async with source_document_mutation(octx_sessions, "source-a", "document-upload"):
+            async with source_document_mutation(octx_sessions, "source-a", "document-delete"):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_upload_and_delete_flow_works_while_delete_cleanup_runs(octx_sessions, tmp_path):
+    """Upload/delete domain logic must complete and keep counts consistent during a delete cleanup."""
+    from sag_api.db.models import Document, Source
+    from sag_api.enums import DocumentStatus, JobStatus, JobType
+    from sag_api.services.document_service import (
+        create_document_from_upload,
+        delete_document,
+    )
+    from sag_api.services.source_operation_service import (
+        acquire_operation_lease,
+        source_document_mutation,
+    )
+
+    class Queue:
+        def __init__(self):
+            self.enqueued: list[str] = []
+
+        async def enqueue(self, job_id: str) -> None:
+            self.enqueued.append(job_id)
+
+        def begin_source_maintenance(self, _source_id: str, _job_id: str) -> None:
+            return None
+
+    async with octx_sessions() as session:
+        source = Source(
+            id="source-busy-delete",
+            name="Busy delete",
+            sag_source_config_id="src_busy_delete",
+        )
+        session.add(source)
+        await session.flush()
+        ready_document = Document(
+            id="document-to-delete",
+            source_id=source.id,
+            filename="old.pdf",
+            storage_path="old.pdf",
+            status=DocumentStatus.READY,
+            sag_source_id="article-old",
+            chunk_count=2,
+            event_count=1,
+        )
+        session.add(ready_document)
+        await session.commit()
+
+        queue = Queue()
+        async with acquire_operation_lease(
+            octx_sessions,
+            ["source:source-busy-delete"],
+            owner="document-delete:job-a",
+        ):
+            async with source_document_mutation(
+                octx_sessions, source.id, "document-delete"
+            ):
+                delete_job = await delete_document(
+                    session, source, ready_document.id, job_queue=queue
+                )
+            async with source_document_mutation(
+                octx_sessions, source.id, "document-upload"
+            ):
+                uploaded, process_job = await create_document_from_upload(
+                    session,
+                    source,
+                    filename="new.md",
+                    content_type="text/markdown",
+                    data=b"# New",
+                    upload_dir=str(tmp_path / "uploads"),
+                    job_queue=queue,
+                )
+
+    assert delete_job.type == JobType.DELETE_DOCUMENT
+    assert delete_job.status == JobStatus.QUEUED
+    assert uploaded.status == DocumentStatus.PENDING
+    assert process_job.status == JobStatus.QUEUED
+    async with octx_sessions() as session:
+        current_source = await session.get(Source, source.id)
+        assert current_source.document_count == 1  # 旧文档已计入删除路径，仅剩新文档
+        assert current_source.chunk_count == 0
+        assert current_source.event_count == 0
+
+
+@pytest.mark.asyncio
+async def test_document_mutation_does_not_wait_for_octx_export_lease(octx_sessions):
+    """The delete exception must not weaken OCTX import/export isolation."""
+    from sag_api.core.errors import ConflictError
+    from sag_api.services.source_operation_service import (
+        acquire_operation_lease,
+        source_document_mutation,
+    )
+
+    async with acquire_operation_lease(
+        octx_sessions,
+        ["source:source-a"],
+        owner="octx-export:job-a",
+    ):
+        with pytest.raises(ConflictError, match="知识库正在执行其他数据操作"):
+            async with source_document_mutation(
                 octx_sessions,
                 "source-a",
+                "document-upload",
                 admission_timeout_seconds=0.01,
-                delete_wait_timeout_seconds=0.03,
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_processor_admission_waits_for_document_delete(octx_sessions):
+    """A queued upload must start processing only after the delete drains."""
+    import asyncio
+
+    from sag_api.services.source_operation_service import (
+        acquire_operation_lease,
+        acquire_source_processing_lease,
+    )
+
+    delete_acquired = asyncio.Event()
+
+    async def delete_document() -> None:
+        async with acquire_operation_lease(
+            octx_sessions,
+            ["source:source-a"],
+            owner="document-delete:job-a",
+        ):
+            delete_acquired.set()
+            await asyncio.sleep(0.05)
+
+    deletion = asyncio.create_task(delete_document())
+    await delete_acquired.wait()
+    entered = False
+    async with acquire_source_processing_lease(
+        octx_sessions,
+        "source-a",
+        "job-b",
+        admission_timeout_seconds=0.05,
+        delete_wait_timeout_seconds=1,
+    ):
+        entered = True
+    await deletion
+    assert entered is True
+
+
+@pytest.mark.asyncio
+async def test_processor_admission_does_not_wait_for_octx_export(octx_sessions):
+    """Processor admission keeps fail-fast behavior for transfer leases."""
+    from sag_api.core.errors import ConflictError
+    from sag_api.services.source_operation_service import (
+        acquire_operation_lease,
+        acquire_source_processing_lease,
+    )
+
+    async with acquire_operation_lease(
+        octx_sessions,
+        ["source:source-a"],
+        owner="octx-export:job-a",
+    ):
+        with pytest.raises(ConflictError):
+            async with acquire_source_processing_lease(
+                octx_sessions,
+                "source-a",
+                "job-b",
+                admission_timeout_seconds=0.05,
+                delete_wait_timeout_seconds=1,
             ):
                 pass
 

--- a/apps/web/components/features/upload-zone.tsx
+++ b/apps/web/components/features/upload-zone.tsx
@@ -35,7 +35,6 @@ export function UploadZone({
     pct: number;
     idx: number;
     total: number;
-    waiting: boolean;
   } | null>(null);
 
   const extOf = (name: string) => {
@@ -60,21 +59,15 @@ export function UploadZone({
         toast.error(t("fileTooLarge", { name: file.name, maxMb }));
         continue;
       }
-      let waitingTimer: ReturnType<typeof setTimeout> | undefined;
       try {
         const idx = ok + 1;
-        setProgress({ name: file.name, pct: 0, idx, total: files.length, waiting: false });
+        setProgress({ name: file.name, pct: 0, idx, total: files.length });
+        // 删除清理期间的文档会直接排队显示为“待处理”，上传请求本身不再等待。
         const { document: doc } = await api.uploadDocumentWithProgress(
           sourceId,
           file,
           (pct) => setProgress((p) => (p ? { ...p, pct } : p)),
-          () => {
-            waitingTimer = setTimeout(() => {
-              setProgress((p) => (p ? { ...p, waiting: true } : p));
-            }, 500);
-          },
         );
-        if (waitingTimer) clearTimeout(waitingTimer);
         ok += 1;
         getDiagnosticsStore().record("knowledge.upload", {
           source_id: sourceId,
@@ -87,7 +80,6 @@ export function UploadZone({
           event_count: doc.event_count,
         });
       } catch (err) {
-        if (waitingTimer) clearTimeout(waitingTimer);
         toast.error(t("fileFailed", {
           name: file.name,
           error: err instanceof ApiError ? err.message : t("uploadFailed"),
@@ -162,12 +154,6 @@ export function UploadZone({
                 {progress.pct}%
               </span>
             </div>
-            {progress.waiting ? (
-              <div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
-                <Spinner className="size-3" />
-                <span>{t("waitingForCleanup")}</span>
-              </div>
-            ) : null}
           </div>
         ) : (
           <div className="text-xs text-muted-foreground">

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -280,7 +280,6 @@
     "uploaded": "{count, plural, one {# file uploaded} other {# files uploaded}}. Background processing has started.",
     "uploading": "Uploading files…",
     "uploadProgress": "File upload progress",
-    "waitingForCleanup": "File uploaded. Waiting for the previous document deletion to finish…",
     "prompt": "Drop files here or click to choose",
     "support": "Supports Markdown, text, PDF, and more · Up to {maxMb, number} MB per file",
     "concurrencyHint": "Is background parsing and extraction slow for multiple documents? Adjust chunk concurrency.",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -280,7 +280,6 @@
     "uploaded": "已完成 {count, number} 个文件上传，已进入后台处理",
     "uploading": "正在上传文件…",
     "uploadProgress": "文件上传进度",
-    "waitingForCleanup": "文件已上传，正在等待上一份文档删除完成…",
     "prompt": "拖拽文件到此处，或点击选择",
     "support": "支持 Markdown / 文本 / PDF 等 · 单文件 ≤ {maxMb, number}MB",
     "concurrencyHint": "多文档后台解析与抽取较慢？可调整分片并发数。",


### PR DESCRIPTION
## 改动范围
- [apps/api/sag_api/services/source_operation_service.py]：新增 `source_document_mutation`——文档级变更（上传/删除/重处理/续传/ingest）在删除清理持有信源租约时直接放行，不再 1 秒准入超时后报 "OCTX operation resource is busy"；被 OCTX 导入导出等独占持有者阻塞时返回友好中文提示。`acquire_source_processing_lease` 增加对删除清理的等待（默认 120 秒），上传的处理任务在删除完成后自动启动。
- [apps/api/sag_api/api/v1/documents.py]：上传/删除/重处理/续传/ingest 五个端点统一改用 `source_document_mutation`。
- [apps/api/sag_api/services/document_service.py]：`_refresh_source_counts` 改为单条原子 UPDATE + 子查询，避免删除任务与并发上传提交时计数丢失。
- [apps/web/components/features/upload-zone.tsx]：移除上传区的“正在等待上一份文档删除”文案与 500ms 计时逻辑，上传请求立即返回，文档以“待处理”入队。
- [apps/web/messages]：删除中英文 `UploadZone.waitingForCleanup` 文案键。
- [apps/api/tests/test_octx_conflict_and_lease.py]：新增回归测试——删除清理期间上传/删除领域逻辑与计数一致性、文档级变更对删除租约的放行、处理器准入等待删除、对 OCTX 导出租约仍快速失败。

## 影响功能范围
- 用户功能：同一知识库内连续删除文档不再报错；删除后立即上传不再阻塞，新文档直接显示“待处理”，删除完成后自动开始解析。
- 接口行为：文档级写接口在删除清理期间不再返回 409；被 OCTX 导入导出阻塞时的 409 错误文案改为“知识库正在执行其他数据操作，请稍后重试”。
- 兼容性或风险：删除清理与文档级变更并发时依赖原子计数更新保证聚合计数一致；未发现额外影响。

## 测试覆盖情况
- 通过：`uv run --extra dev pytest tests/test_octx_conflict_and_lease.py tests/test_settings.py tests/test_document_parsing.py tests/test_document_cleanup_coordinator.py tests/test_document_job_retry.py tests/test_document_resume.py tests/test_document_priority_queue.py tests/test_api_smoke.py`（164 passed）；后端全量 493 passed；`ruff check` 通过。
- 通过：`npx vitest run`（504 passed）、`npx tsc --noEmit`、`npm run i18n:check`、`eslint` 通过。
- CI：待远程 CI 执行。
