### PR TITLE
fix(api): MinerU SSRF 守卫放行 fake-ip 代理 DNS（198.18.0.0/15）

### DIFF
--- a/apps/api/sag_api/parsing/mineru.py
+++ b/apps/api/sag_api/parsing/mineru.py
@@ -541,6 +541,12 @@ def _is_http_url(value: str) -> bool:
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
+# Clash/mihomo 等代理的 fake-ip 模式会把域名解析到 198.18.0.0/15（基准测试保留段），
+# 由 TUN 网关按 fake-ip 映射表转发到真实公网地址。该段不属于任何真实内网服务，
+# 非 TUN 环境亦不可路由，放行不会引入可访问内网目标的 SSRF 面。
+_FAKE_IP_POOL = ipaddress.ip_network("198.18.0.0/15")
+
+
 async def _assert_public_host(host: str, port: int) -> None:
     """拒绝 loopback、私网、链路本地与保留地址，降低结果下载 SSRF 风险。"""
     if host == "localhost" or host.endswith((".localhost", ".local", ".internal")):
@@ -560,7 +566,7 @@ async def _assert_public_host(host: str, port: int) -> None:
         resolved = [ipaddress.ip_address(address) for address in addresses]
     else:
         resolved = [literal]
-    if any(not address.is_global for address in resolved):
+    if any(not address.is_global and address not in _FAKE_IP_POOL for address in resolved):
         raise UpstreamError("MinerU 结果 URL 指向了本地或内网地址")
 
 

--- a/apps/api/sag_api/sag/chunk_heading_vectors.py
+++ b/apps/api/sag_api/sag/chunk_heading_vectors.py
@@ -5,7 +5,96 @@ from typing import Any
 
 from sqlalchemy import select
 
+from sag_api.core.logging import get_logger
+
 VectorFieldFetcher = Callable[..., Awaitable[dict[str, dict[str, Any]]]]
+
+log = get_logger("sag.vectors")
+
+
+def _chunk_document(
+    chunk: Any,
+    source_config_id: str,
+    *,
+    heading_vector: Any,
+    content_vector: Any,
+) -> dict[str, Any]:
+    return {
+        "id": str(chunk.id),
+        "chunk_id": str(chunk.id),
+        "source_id": str(chunk.source_id),
+        "source_config_id": source_config_id,
+        "rank": chunk.rank,
+        "heading": chunk.heading,
+        "content": chunk.content,
+        "heading_vector": heading_vector,
+        "content_vector": content_vector,
+        "references": chunk.references or [],
+        "chunk_type": "TEXT",
+        "content_length": chunk.chunk_length,
+    }
+
+
+async def _rebuild_chunk_vectors(
+    chunks: Sequence[Any],
+    source_config_id: str,
+    *,
+    embedding_client: Any,
+    vector_store: Any,
+) -> int:
+    """重建缺失的内容与标题向量，让 load 阶段被吞掉的索引失败自愈。
+
+    依赖方 loader 对批量索引的部分失败只记日志不抛错，可能出现 chunk 行
+    已落库但向量记录缺失（或内容向量为空）。chunk 行是最权威的数据源，
+    这里直接用其内容与标题重新生成两组向量并回写，而不是让整篇文档失败。
+    """
+    content_inputs = [str(chunk.content or chunk.heading or "") for chunk in chunks]
+    if any(not value for value in content_inputs):
+        raise RuntimeError("cannot rebuild vectors for an empty chunk")
+    content_vectors = await embedding_client.batch_generate(content_inputs)
+    if len(content_vectors) != len(chunks):
+        raise RuntimeError(
+            "chunk content embedding batch size mismatch: "
+            f"expected={len(chunks)} actual={len(content_vectors)}"
+        )
+
+    heading_inputs = [str(chunk.heading or chunk.content or "") for chunk in chunks]
+    heading_vectors = await embedding_client.batch_generate(heading_inputs)
+    if len(heading_vectors) != len(chunks):
+        raise RuntimeError(
+            "chunk heading embedding batch size mismatch: "
+            f"expected={len(chunks)} actual={len(heading_vectors)}"
+        )
+
+    documents = [
+        _chunk_document(
+            chunk,
+            source_config_id,
+            heading_vector=heading_vector,
+            content_vector=content_vector,
+        )
+        for chunk, heading_vector, content_vector in zip(
+            chunks, heading_vectors, content_vectors, strict=True
+        )
+    ]
+    result = await vector_store.bulk_index(
+        index="source_chunks",
+        documents=documents,
+        return_details=True,
+        routing=source_config_id,
+    )
+    if (
+        not isinstance(result, dict)
+        or int(result.get("error_count", 0))
+        or int(result.get("success_count", 0)) != len(documents)
+    ):
+        raise RuntimeError(f"chunk vector rebuild failed: {result!r}")
+    log.warning(
+        "已重建缺失的切片向量 source_config_id=%s count=%d",
+        source_config_id,
+        len(documents),
+    )
+    return len(documents)
 
 
 async def complete_chunk_heading_vectors(
@@ -33,16 +122,25 @@ async def complete_chunk_heading_vectors(
             routing=source_config_id,
         )
         missing: list[tuple[Any, dict[str, Any]]] = []
+        rebuild: list[Any] = []
         for chunk in batch:
-            chunk_id = str(chunk.id)
-            fields = stored.get(chunk_id)
-            if fields is None:
-                raise RuntimeError(f"chunk vector record is missing after load: {chunk_id}")
+            fields = stored.get(str(chunk.id))
+            if fields is None or fields.get("content_vector") is None:
+                # 向量记录缺失或内容向量为空：load 阶段索引失败被依赖方吞掉，
+                # 直接基于 chunk 行重建内容与标题向量，避免整篇文档失败。
+                rebuild.append(chunk)
+                continue
             if fields.get("heading_vector") is not None:
                 continue
-            if fields.get("content_vector") is None:
-                raise RuntimeError(f"chunk content vector is missing after load: {chunk_id}")
             missing.append((chunk, fields))
+
+        if rebuild:
+            completed += await _rebuild_chunk_vectors(
+                rebuild,
+                source_config_id,
+                embedding_client=embedding_client,
+                vector_store=vector_store,
+            )
 
         if not missing:
             continue
@@ -58,20 +156,12 @@ async def complete_chunk_heading_vectors(
             )
 
         documents = [
-            {
-                "id": str(chunk.id),
-                "chunk_id": str(chunk.id),
-                "source_id": str(chunk.source_id),
-                "source_config_id": source_config_id,
-                "rank": chunk.rank,
-                "heading": chunk.heading,
-                "content": chunk.content,
-                "heading_vector": heading_vector,
-                "content_vector": fields["content_vector"],
-                "references": chunk.references or [],
-                "chunk_type": "TEXT",
-                "content_length": chunk.chunk_length,
-            }
+            _chunk_document(
+                chunk,
+                source_config_id,
+                heading_vector=heading_vector,
+                content_vector=fields["content_vector"],
+            )
             for (chunk, fields), heading_vector in zip(missing, heading_vectors, strict=True)
         ]
         result = await vector_store.bulk_index(

--- a/apps/api/tests/test_chunk_heading_vectors.py
+++ b/apps/api/tests/test_chunk_heading_vectors.py
@@ -118,3 +118,87 @@ async def test_complete_chunk_heading_vectors_does_not_regenerate_existing_vecto
     )
 
     assert completed == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_fields",
+    [
+        None,  # 向量记录整体缺失（load 阶段索引失败被依赖方吞掉）
+        {"heading_vector": None, "content_vector": None},  # 记录在但两个向量都是空的
+    ],
+)
+async def test_complete_chunk_heading_vectors_rebuilds_missing_vector_record(
+    stored_fields,
+):
+    from sag_api.sag.chunk_heading_vectors import complete_chunk_heading_vectors
+
+    chunk = SimpleNamespace(
+        id="chunk-1",
+        source_id="article-1",
+        source_config_id="source-config-1",
+        rank=0,
+        heading="章节标题",
+        content="正文内容",
+        references=[],
+        chunk_length=4,
+    )
+
+    class EmbeddingClient:
+        def __init__(self) -> None:
+            self.inputs: list[list[str]] = []
+
+        async def batch_generate(self, texts: list[str]) -> list[list[float]]:
+            self.inputs.append(texts)
+            return [[0.1, 0.2] for _ in texts]
+
+    class VectorStore:
+        def __init__(self) -> None:
+            self.documents: list[dict] = []
+
+        async def bulk_index(self, *, index, documents, return_details, routing):
+            assert index == "source_chunks"
+            assert return_details is True
+            assert routing == "source-config-1"
+            self.documents.extend(documents)
+            return {
+                "success": True,
+                "success_count": len(documents),
+                "error_count": 0,
+                "errors": [],
+            }
+
+    embedding = EmbeddingClient()
+    vector_store = VectorStore()
+
+    async def fetch_fields(_store, _index, _record_ids, _fields, *, routing):
+        assert routing == "source-config-1"
+        return {} if stored_fields is None else {"chunk-1": stored_fields}
+
+    completed = await complete_chunk_heading_vectors(
+        [chunk],
+        "source-config-1",
+        embedding_client=embedding,
+        vector_store=vector_store,
+        fetch_vector_fields=fetch_fields,
+    )
+
+    assert completed == 1
+    # 先重建内容向量，再重建标题向量
+    assert embedding.inputs == [["正文内容"], ["章节标题"]]
+    assert vector_store.documents == [
+        {
+            "id": "chunk-1",
+            "chunk_id": "chunk-1",
+            "source_id": "article-1",
+            "source_config_id": "source-config-1",
+            "rank": 0,
+            "heading": "章节标题",
+            "content": "正文内容",
+            "heading_vector": [0.1, 0.2],
+            "content_vector": [0.1, 0.2],
+            "references": [],
+            "chunk_type": "TEXT",
+            "content_length": 4,
+        }
+    ]

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -1527,3 +1527,12 @@ async def test_mineru_result_download_rejects_private_hosts():
         await _assert_public_host("127.0.0.1", 80)
     with pytest.raises(UpstreamError, match="内网"):
         await _assert_public_host("169.254.169.254", 80)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fake_ip", ["198.18.0.90", "198.19.255.254"])
+async def test_mineru_result_download_allows_fake_ip_proxy_dns(fake_ip):
+    # Clash/mihomo 等代理的 fake-ip 模式会把域名解析到 198.18.0.0/15，
+    # TUN 网关按映射表转发到真实公网地址；该段不指向任何真实内网服务，
+    # 不应被 SSRF 守卫当作内网拒绝。
+    await _assert_public_host(fake_ip, 443)


### PR DESCRIPTION
## 问题一：fake-ip 代理 DNS 被 SSRF 守卫误拒

Clash/mihomo 等代理的 fake-ip 模式会把 MinerU 官方域名（mineru.net、cdn-mineru.openxlab.org.cn 等）解析到 198.18.0.0/15。容器内 DNS 继承宿主机代理解析后，SSRF 守卫 `_assert_public_host` 把该段判为内网拒绝，官方解析全部失败并回退 MarkItDown（日志：`MinerU 结果 URL 指向了本地或内网地址`）。

**修复**：`_assert_public_host` 放行 198.18.0.0/15——该段为基准测试保留段，不属于任何真实内网服务，非 TUN 环境亦不可路由；TUN 网关按 fake-ip 映射表转发到真实公网地址。loopback / 私网 / 链路本地 / 云元数据地址的拒绝行为保持不变。

## 问题二：load 阶段向量索引部分失败导致文档整体失败

依赖方 loader 对批量索引的部分失败只记日志不抛错，可能出现 chunk 行已落库、向量记录缺失（或内容向量为空）的不一致；随后 SAG 的标题向量补全检查把该不一致当作硬错误（`chunk vector record is missing after load: <id>`），整篇文档处理失败。

**修复**：补全步骤升级为一致性自愈——向量记录缺失或内容向量为空时，直接基于 chunk 行（最权威数据源）重新生成内容向量与标题向量并回写索引，不再让整篇文档失败；标题向量缺失的原有回填路径保持不变。向量后端持续不可用或重建写回失败时仍会失败文档（这是正确行为）。

## 验证

- 新增 fake-ip 放行回归测试 2 组 + 私网拒绝回归保留；test_document_parsing 全套 35 passed
- 新增向量重建回归测试 2 组（记录缺失 / 内容向量为空）+ 既有回填行为测试保留；test_chunk_heading_vectors + test_document_resume → 48 passed；test_insights / test_document_parsing → 37 passed
- 容器内实测：mineru.net → 198.18.0.90 被守卫拒绝（修复前），放行后官方解析链路可用
- ruff / git diff --check 通过