### PR TITLE
fix(fnos): MinerU SSRF 守卫放行 fake-ip 代理 DNS

### DIFF
--- a/apps/api/sag_api/parsing/mineru.py
+++ b/apps/api/sag_api/parsing/mineru.py
@@ -541,6 +541,12 @@ def _is_http_url(value: str) -> bool:
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
+# Clash/mihomo 等代理的 fake-ip 模式会把域名解析到 198.18.0.0/15（基准测试保留段），
+# 由 TUN 网关按 fake-ip 映射表转发到真实公网地址。该段不属于任何真实内网服务，
+# 非 TUN 环境亦不可路由，放行不会引入可访问内网目标的 SSRF 面。
+_FAKE_IP_POOL = ipaddress.ip_network("198.18.0.0/15")
+
+
 async def _assert_public_host(host: str, port: int) -> None:
     """拒绝 loopback、私网、链路本地与保留地址，降低结果下载 SSRF 风险。"""
     if host == "localhost" or host.endswith((".localhost", ".local", ".internal")):
@@ -560,7 +566,7 @@ async def _assert_public_host(host: str, port: int) -> None:
         resolved = [ipaddress.ip_address(address) for address in addresses]
     else:
         resolved = [literal]
-    if any(not address.is_global for address in resolved):
+    if any(not address.is_global and address not in _FAKE_IP_POOL for address in resolved):
         raise UpstreamError("MinerU 结果 URL 指向了本地或内网地址")
 
 

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -1550,3 +1550,12 @@ async def test_mineru_result_download_rejects_private_hosts():
         await _assert_public_host("127.0.0.1", 80)
     with pytest.raises(UpstreamError, match="内网"):
         await _assert_public_host("169.254.169.254", 80)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fake_ip", ["198.18.0.90", "198.19.255.254"])
+async def test_mineru_result_download_allows_fake_ip_proxy_dns(fake_ip):
+    # Clash/mihomo 等代理的 fake-ip 模式会把域名解析到 198.18.0.0/15，
+    # TUN 网关按映射表转发到真实公网地址；该段不指向任何真实内网服务，
+    # 不应被 SSRF 守卫当作内网拒绝。
+    await _assert_public_host(fake_ip, 443)


### PR DESCRIPTION
## 问题

与 main 的 PR #114 同源：Clash/mihomo 等代理的 fake-ip 模式会把 MinerU 官方域名解析到 198.18.0.0/15，SSRF 守卫 `_assert_public_host` 把该段判为内网拒绝，代理环境下官方解析全部回退 MarkItDown。

## 修复

`_assert_public_host` 放行 198.18.0.0/15（基准测试保留段，不指向任何真实内网服务）；loopback / 私网 / 链路本地 / 云元数据地址的拒绝行为不变。

## 说明

PR #114 的另一个修复（缺失切片向量自愈重建）**不适用 fnos**：`chunk_heading_vectors.py` 模块在 fnos/develop 上不存在，该错误类不会在 fnos 发生，无需移植。

## 验证

- fnos 分支 test_document_parsing + test_settings → 54 passed
- 新增 fake-ip 放行回归 + 私网拒绝回归均通过