### PR TITLE
fix: surface MinerU parse progress and make source delete responsive

### DIFF
--- a/apps/api/sag_api/api/v1/sources.py
+++ b/apps/api/sag_api/api/v1/sources.py
@@ -81,14 +81,20 @@ async def delete_(
 ) -> Ok:
     from sag_api.core.config import settings
 
-    async with acquire_source_exclusive_lease(SessionLocal, source_id, "source-delete"):
-        await delete_source(
-            session,
-            source_id,
-            engine_manager=engine_manager,
-            upload_dir=settings.upload_dir,
-            job_queue=job_queue,
-        )
+    # 先请求在途处理任务尽快让路：解析/抽取会在下一个安全检查点释放处理租约，
+    # 使独占租约的 drain 能在 HTTP 窗口内完成，而非被动等待任务自然结束。
+    job_queue.request_source_stop(source_id)
+    try:
+        async with acquire_source_exclusive_lease(SessionLocal, source_id, "source-delete"):
+            await delete_source(
+                session,
+                source_id,
+                engine_manager=engine_manager,
+                upload_dir=settings.upload_dir,
+                job_queue=job_queue,
+            )
+    finally:
+        job_queue.clear_source_stop(source_id)
     return Ok(detail="信源已删除")
 
 

--- a/apps/api/sag_api/jobs/inproc.py
+++ b/apps/api/sag_api/jobs/inproc.py
@@ -118,6 +118,7 @@ class InProcessAsyncQueue(JobQueue):
         self._source_maintenance_ready: set[str] = set()
         self._source_maintenance_dispatched: dict[str, str] = {}
         self._source_maintenance_closing: set[str] = set()
+        self._source_stop_requested: set[str] = set()
         self._started = False
 
     async def enqueue(self, job_id: str) -> None:
@@ -179,6 +180,15 @@ class InProcessAsyncQueue(JobQueue):
 
     def source_maintenance_requested(self, source_id: str) -> bool:
         return bool(self._source_maintenance_jobs.get(source_id))
+
+    def request_source_stop(self, source_id: str) -> None:
+        self._source_stop_requested.add(source_id)
+
+    def clear_source_stop(self, source_id: str) -> None:
+        self._source_stop_requested.discard(source_id)
+
+    def source_stop_requested(self, source_id: str) -> bool:
+        return source_id in self._source_stop_requested
 
     def _schedule_source_maintenance(self, source_id: str) -> None:
         current = self._source_maintenance_tasks.get(source_id)

--- a/apps/api/sag_api/jobs/queue.py
+++ b/apps/api/sag_api/jobs/queue.py
@@ -30,6 +30,16 @@ class JobQueue(ABC):
     async def finish_source_maintenance(self, source_id: str, job_id: str) -> None:
         """结束维护任务；最后一个维护任务结束后唤醒临时让行的任务。"""
 
+    def request_source_stop(self, source_id: str) -> None:  # noqa: B027 - 可选钩子
+        """请求某信源在途处理任务在安全检查点尽快让路（用于同步删除）。"""
+
+    def clear_source_stop(self, source_id: str) -> None:  # noqa: B027
+        """清除信源停止请求。"""
+
+    def source_stop_requested(self, source_id: str) -> bool:
+        """当前信源是否被请求停止在途处理任务。"""
+        return False
+
     async def start(self) -> None:  # noqa: B027 - 可选生命周期钩子
         """启动后台 worker（如有）。"""
 

--- a/apps/api/sag_api/jobs/tasks.py
+++ b/apps/api/sag_api/jobs/tasks.py
@@ -31,7 +31,7 @@ from sag_api.jobs.octx_tasks import (
     preflight_octx,
 )
 from sag_api.jobs.scheduling import SOURCE_MAINTENANCE
-from sag_api.parsing import prepare_document
+from sag_api.parsing import ParsePaused, prepare_document
 from sag_api.sag import EngineManager
 from sag_api.sag.dto import ProcessCheckpoint
 from sag_api.services.source_operation_service import (
@@ -293,19 +293,50 @@ async def _process_document_unlocked(
         if job_queue is not None and job_queue.source_maintenance_requested(source.id):
             scheduler_yield_reason = SOURCE_MAINTENANCE
             return True
+        # 信源正在被删除：请求在途处理任务尽快让路并释放处理租约，使同步删除
+        # 能在 HTTP 窗口内完成，而非被动等待解析/抽取自然结束。此处按“暂停”语义
+        # 处理（不设置 yield 原因）——文档随后会随信源级联删除。
+        if job_queue is not None and job_queue.source_stop_requested(source.id):
+            return True
         return False
+
+    async def _pause_or_yield() -> None:
+        """把当前文档落到 PAUSED 或让行，供解析/抽取两个阶段共用。"""
+        await session.refresh(document)
+        if scheduler_yield_reason == SOURCE_MAINTENANCE and document.status not in _CONTROL_TRANSITION_STATES:
+            raise JobYielded(SOURCE_MAINTENANCE)
+        if document.status in _DELETE_CONTROL_STATES:
+            raise JobPaused()
+        expected_status = document.status
+        paused = await session.execute(
+            update(Document)
+            .where(
+                Document.id == document.id,
+                Document.status == expected_status,
+            )
+            .values(status=DocumentStatus.PAUSED, error=None)
+            .execution_options(synchronize_session=False)
+        )
+        if paused.rowcount != 1:
+            await _yield_after_document_transition_lost(session, document)
+        await session.commit()
+        raise JobPaused()
 
     try:
         prepared = None
         parser_stage = False
         if not checkpoint.chunk_ids:
             parser_stage = True
-            prepared = await prepare_document(
-                document.storage_path,
-                settings,
-                state=(job.payload or {}).get("document_parser"),
-                on_state=on_parser_state,
-            )
+            try:
+                prepared = await prepare_document(
+                    document.storage_path,
+                    settings,
+                    state=(job.payload or {}).get("document_parser"),
+                    on_state=on_parser_state,
+                    should_pause=should_pause,
+                )
+            except ParsePaused:
+                await _pause_or_yield()
             parser_stage = False
             parser_state = (job.payload or {}).get("document_parser")
             for field, value in _prepared_parser_values(prepared, parser_state).items():
@@ -333,25 +364,7 @@ async def _process_document_unlocked(
             document_title=Path(document.filename).stem.strip(),
         )
         if outcome.paused:
-            await session.refresh(document)
-            if scheduler_yield_reason == SOURCE_MAINTENANCE and document.status not in _CONTROL_TRANSITION_STATES:
-                raise JobYielded(SOURCE_MAINTENANCE)
-            if document.status in _DELETE_CONTROL_STATES:
-                raise JobPaused()
-            expected_status = document.status
-            paused = await session.execute(
-                update(Document)
-                .where(
-                    Document.id == document.id,
-                    Document.status == expected_status,
-                )
-                .values(status=DocumentStatus.PAUSED, error=None)
-                .execution_options(synchronize_session=False)
-            )
-            if paused.rowcount != 1:
-                await _yield_after_document_transition_lost(session, document)
-            await session.commit()
-            raise JobPaused()
+            await _pause_or_yield()
     except (JobPaused, JobYielded):
         raise
     except Exception as e:  # noqa: BLE001 - 记录到文档后再上抛给 worker

--- a/apps/api/sag_api/parsing/__init__.py
+++ b/apps/api/sag_api/parsing/__init__.py
@@ -1,5 +1,11 @@
 """把上传文件规范化为 zleap-sag 可摄取的 Markdown。"""
 
+from sag_api.parsing.mineru import ParsePaused
 from sag_api.parsing.service import ParseStateCallback, PreparedDocument, prepare_document
 
-__all__ = ["ParseStateCallback", "PreparedDocument", "prepare_document"]
+__all__ = [
+    "ParsePaused",
+    "ParseStateCallback",
+    "PreparedDocument",
+    "prepare_document",
+]

--- a/apps/api/sag_api/parsing/mineru.py
+++ b/apps/api/sag_api/parsing/mineru.py
@@ -11,6 +11,7 @@ import asyncio
 import io
 import ipaddress
 import json
+import logging
 import os
 import re
 import socket
@@ -31,6 +32,29 @@ from sag_api.core.errors import (
 )
 
 StateCallback = Callable[[dict[str, Any]], Awaitable[None]]
+PauseCallback = Callable[[], Awaitable[bool]]
+
+log = logging.getLogger(__name__)
+
+
+class ParsePaused(Exception):
+    """解析过程中收到暂停/让路信号，用于协作式中断长时间轮询。
+
+    该异常属于解析层的中性信号，由上层任务层捕获后转换为任务暂停/让行，
+    避免解析层反向依赖 jobs 控制流类型。
+    """
+
+
+# pending 轮询状态归一：区分“仍在排队”与“已在处理”。已进入处理或状态未知
+# 时如实展示“解析中”，避免文档长时间停留在“排队中”造成用户误解。
+_QUEUE_PENDING_STATES = {"created", "pending", "queued", "queueing"}
+
+
+def _pending_parser_status(raw: str) -> str:
+    normalized = (raw or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in _QUEUE_PENDING_STATES:
+        return "queued"
+    return "running"
 
 _PENDING_STATES = {
     "created",
@@ -91,6 +115,7 @@ class MinerU302Client:
         *,
         state: dict[str, Any] | None = None,
         on_state: StateCallback | None = None,
+        should_pause: PauseCallback | None = None,
     ) -> str:
         state = dict(state or {})
         upload_url = state.get("upload_url")
@@ -117,7 +142,12 @@ class MinerU302Client:
             if on_state:
                 await on_state(dict(state))
 
-        markdown = await self._poll(str(task_id))
+        markdown = await self._poll(
+            str(task_id),
+            state=state,
+            on_state=on_state,
+            should_pause=should_pause,
+        )
         if on_state:
             await on_state({**state, "status": "done"})
         return markdown
@@ -172,6 +202,7 @@ class MinerU302Client:
                 raise UpstreamError(f"MinerU 创建任务失败：{value}")
         task_id = _find_task_id(payload)
         if task_id:
+            log.info("MinerU 已创建解析任务 task=%s", task_id)
             return "task", task_id
         kind, value = _interpret_poll_payload(payload, "")
         if kind in {"url", "markdown"}:
@@ -180,9 +211,21 @@ class MinerU302Client:
             raise UpstreamError(f"MinerU 创建任务失败：{value}")
         raise UpstreamError("MinerU 已接受请求，但响应中没有任务 ID")
 
-    async def _poll(self, task_id: str) -> str:
+    async def _poll(
+        self,
+        task_id: str,
+        *,
+        state: dict[str, Any] | None = None,
+        on_state: StateCallback | None = None,
+        should_pause: PauseCallback | None = None,
+    ) -> str:
         deadline = time.monotonic() + self._poll_timeout
+        base_state = dict(state or {})
+        last_status: str | None = None
         while True:
+            if should_pause is not None and await should_pause():
+                log.info("MinerU 轮询收到暂停信号，协作式中断 task=%s", task_id)
+                raise ParsePaused()
             response = await self._api_request(
                 "GET", "/302/v2/mineru/task", params={"task_id": task_id}
             )
@@ -193,9 +236,21 @@ class MinerU302Client:
                 return await self._download_markdown(value)
             if kind == "failed":
                 raise UpstreamError(f"MinerU 解析失败：{value}")
+            # kind == "pending"：透出真实进度，避免 UI 长时间停留在“排队中”。
+            status = _pending_parser_status(value)
+            if status != last_status:
+                last_status = status
+                log.info(
+                    "MinerU 轮询 task=%s upstream=%s status=%s", task_id, value, status
+                )
+                if on_state is not None:
+                    await on_state({**base_state, "status": status})
             if time.monotonic() >= deadline:
+                log.warning(
+                    "MinerU 轮询超时 task=%s timeout=%.0fs", task_id, self._poll_timeout
+                )
                 raise ServiceUnavailableError(
-                    f"MinerU 解析等待超时（任务 {task_id}），后台将继续重试"
+                    f"MinerU 解析等待超时（任务 {task_id}）"
                 )
             await asyncio.sleep(self._poll_interval)
 

--- a/apps/api/sag_api/parsing/service.py
+++ b/apps/api/sag_api/parsing/service.py
@@ -18,7 +18,7 @@ from sag_api.core.errors import (
     UpstreamError,
     ValidationError,
 )
-from sag_api.parsing.mineru import MinerUClient
+from sag_api.parsing.mineru import MinerUClient, PauseCallback
 from sag_api.parsing.text import TextDecodingError, is_plain_text_path, read_text_file
 
 ParseStateCallback = Callable[[dict[str, Any]], Awaitable[None]]
@@ -40,6 +40,7 @@ async def prepare_document(
     *,
     state: dict[str, Any] | None = None,
     on_state: ParseStateCallback | None = None,
+    should_pause: PauseCallback | None = None,
 ) -> PreparedDocument:
     """返回可直接交给 zleap-sag 的 Markdown 路径，保留原始上传文件。"""
     suffix = os.path.splitext(path)[1].lower()
@@ -83,6 +84,7 @@ async def prepare_document(
             settings,
             state=state,
             on_state=on_state,
+            should_pause=should_pause,
         )
 
 
@@ -140,6 +142,7 @@ async def _prepare_and_cache(
     *,
     state: dict[str, Any] | None,
     on_state: ParseStateCallback | None,
+    should_pause: PauseCallback | None = None,
 ) -> PreparedDocument:
     parser_state = _compatible_state(state, provider, signature, settings)
     current_state = dict(parser_state)
@@ -189,7 +192,7 @@ async def _prepare_and_cache(
             )
         try:
             markdown = await MinerUClient(settings).parse(
-                path, state=parser_state, on_state=track_state
+                path, state=parser_state, on_state=track_state, should_pause=should_pause
             )
         except ApiError as mineru_error:
             return await _prepare_markitdown_fallback(

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -173,7 +173,7 @@ async def test_only_pdf_uses_configured_mineru(tmp_path, monkeypatch):
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             seen.append(path)
             return "# From MinerU\n"
 
@@ -216,7 +216,7 @@ async def test_mineru_failure_falls_back_to_markitdown_and_reuses_cache(tmp_path
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             nonlocal mineru_calls
             mineru_calls += 1
             if on_state:
@@ -266,7 +266,7 @@ async def test_document_fails_only_when_mineru_and_markitdown_both_fail(tmp_path
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             raise ServiceUnavailableError("remote parser failed")
 
     def fail_locally(_path: str) -> str:
@@ -296,7 +296,7 @@ async def test_mineru_state_callback_failure_does_not_trigger_markitdown(tmp_pat
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             assert on_state is not None
             await on_state({**(state or {}), "task_id": "task-1"})
             return "# Never reached\n"
@@ -337,7 +337,7 @@ async def test_changed_mineru_config_retries_remote_after_cached_fallback(tmp_pa
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             nonlocal mineru_calls
             mineru_calls += 1
             raise UpstreamError("remote unavailable")
@@ -379,7 +379,7 @@ async def test_concurrent_pdf_parsing_creates_only_one_mineru_task(tmp_path, mon
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             nonlocal calls
             calls += 1
             started.set()
@@ -413,7 +413,7 @@ async def test_concurrent_mineru_failure_creates_one_task_and_one_fallback(tmp_p
         def __init__(self, _settings):
             pass
 
-        async def parse(self, path, *, state=None, on_state=None):
+        async def parse(self, path, *, state=None, on_state=None, should_pause=None):
             nonlocal mineru_calls
             mineru_calls += 1
             await asyncio.sleep(0.01)
@@ -494,7 +494,7 @@ async def test_document_job_sends_parsed_markdown_to_engine(monkeypatch):
     prepared_calls: list[str] = []
     stage_errors: list[tuple[str, str | None]] = []
 
-    async def fake_prepare(path, settings, *, state=None, on_state=None):
+    async def fake_prepare(path, settings, *, state=None, on_state=None, should_pause=None):
         prepared_calls.append(path)
         return PreparedDocument("/uploads/original.pdf.parsed.markitdown.md", "markitdown")
 
@@ -624,7 +624,7 @@ async def test_document_job_persists_successful_mineru_outcome(
         async def execute(self, _statement):
             return SimpleNamespace(rowcount=1)
 
-    async def fake_prepare(path, settings, *, state=None, on_state=None):
+    async def fake_prepare(path, settings, *, state=None, on_state=None, should_pause=None):
         assert on_state is not None
         await on_state(
             {
@@ -699,7 +699,7 @@ async def test_document_job_persists_mineru_markitdown_fallback(monkeypatch, cap
         async def execute(self, _statement):
             return SimpleNamespace(rowcount=1)
 
-    async def fake_prepare(path, settings, *, state=None, on_state=None):
+    async def fake_prepare(path, settings, *, state=None, on_state=None, should_pause=None):
         assert on_state is not None
         await on_state(
             {
@@ -809,7 +809,7 @@ async def test_document_job_redacts_parser_failure_from_public_error(
                 document.error = values["error"]
             return SimpleNamespace(rowcount=1)
 
-    async def fake_prepare(path, settings, *, state=None, on_state=None):
+    async def fake_prepare(path, settings, *, state=None, on_state=None, should_pause=None):
         assert on_state is not None
         await on_state(
             {
@@ -899,7 +899,7 @@ async def test_document_job_preserves_engine_error_before_first_checkpoint(
                 document.error = values["error"]
             return SimpleNamespace(rowcount=1)
 
-    async def fake_prepare(path, settings, *, state=None, on_state=None):
+    async def fake_prepare(path, settings, *, state=None, on_state=None, should_pause=None):
         assert on_state is not None
         await on_state(
             {


### PR DESCRIPTION
## 修复两个上传/删除相关的问题

### Bug 1：上传文档一直卡在 "MinerU·302.AI·2.5·排队中"
**根因**：`_poll()` 轮询期间不发送任何状态，UI 一直停留在首次拿到 task_id 时的「排队中」，直到轮询超时才降级。

**修复**（`parsing/mineru.py`）：
- 每轮轮询把上游真实状态映射为 `queued`/`running`，通过 `on_state` 透出 → UI 从「排队中」切到「解析中」。
- 新增任务创建 / 轮询 / 超时日志。
- 轮询支持 `should_pause` 回调，可协作式中断（`ParsePaused`）。
- 贯穿 `service.py`、`parsing/__init__.py`、`jobs/tasks.py` 把 `should_pause` 传到轮询。

### Bug 2：删除信源 loading 很久后提示「网络超时」，刷新后信源已消失
**根因**：DELETE 路由同步持有独占租约，被动 drain 在途处理租约（最长 1800s、无取消），而前端 30s 就超时；在途任务通常卡在 MinerU 轮询。

**修复**：新增轻量的 per-source stop 信号。
- 路由在 drain 前调用 `request_source_stop`（`finally` 里 `clear_source_stop`）。
- 在途任务在 `should_pause` 中观察到信号，于下一个安全检查点（约 1 个轮询周期）落 PAUSED、释放处理租约。
- drain 快速返回，删除在 HTTP 窗口内完成；文档随信源级联删除。
- `queue.py` ABC 加默认 no-op，`inproc.py` 提供 `_source_stop_requested` 实现。

## 测试
`cd apps/api && pytest -q` → **504 passed, 1 skipped**。
更新了 `test_document_parsing.py` 中的 `parse` / `fake_prepare` 桩函数以接受新的 `should_pause` 参数。
