### PR TITLE
chore: complete v1.6.6 metadata (lockfiles + README badges)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://arxiv.org/abs/2608.12129"><img alt="论文" src="https://img.shields.io/badge/paper-arXiv%3A2608.12129-18181b" /></a>
   <a href="https://pypi.org/project/zleap-sag/"><img alt="PyPI" src="https://img.shields.io/pypi/v/zleap-sag?label=zleap--sag&color=18181b" /></a>
-  <img alt="SAG 版本" src="https://img.shields.io/badge/SAG-v1.6.5-18181b" />
+  <img alt="SAG 版本" src="https://img.shields.io/badge/SAG-v1.6.6-18181b" />
   <a href="https://github.com/Zleap-AI/SAG/releases/latest"><img alt="桌面版发布" src="https://img.shields.io/github/v/release/Zleap-AI/SAG?label=desktop&color=18181b" /></a>
   <img alt="Python" src="https://img.shields.io/badge/Python-3.11%2B-3776ab" />
   <img alt="Node" src="https://img.shields.io/badge/Node-20%2B-339933" />

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://arxiv.org/abs/2608.12129"><img alt="Paper" src="https://img.shields.io/badge/paper-arXiv%3A2608.12129-18181b" /></a>
   <a href="https://pypi.org/project/zleap-sag/"><img alt="PyPI" src="https://img.shields.io/pypi/v/zleap-sag?label=zleap--sag&color=18181b" /></a>
-  <img alt="SAG version" src="https://img.shields.io/badge/SAG-v1.6.5-18181b" />
+  <img alt="SAG version" src="https://img.shields.io/badge/SAG-v1.6.6-18181b" />
   <a href="https://github.com/Zleap-AI/SAG/releases/latest"><img alt="Desktop release" src="https://img.shields.io/github/v/release/Zleap-AI/SAG?label=desktop&color=18181b" /></a>
   <img alt="Python" src="https://img.shields.io/badge/Python-3.11%2B-3776ab" />
   <img alt="Node" src="https://img.shields.io/badge/Node-20%2B-339933" />

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sag-desktop",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sag-desktop",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "license": "MIT",
       "dependencies": {
         "electron-log": "^5.4.4",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sag-web",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sag-web",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",


### PR DESCRIPTION
#118 只 bump 了 `apps/web/package.json`、`apps/desktop/package.json`、`apps/api/sag_api/__init__.py` 三处，遗漏了发布门禁校验的其余文件：

- `apps/desktop/package-lock.json`、`apps/web/package-lock.json` 两个 lockfile 根版本仍是 1.6.5
- `README.md` / `README-CN.md` 的 SAG 版本徽章仍是 v1.6.5

导致 `scripts/release-public.mjs --verify v1.6.6` 失败，阻塞 v1.6.6 桌面端发布。本 PR 补齐这 4 个文件到 1.6.6。

本地已验证：`release-public.mjs --verify v1.6.6` → metadata verified。