### PR TITLE
fix(api): 修复 DeepSeek schema 强化时 None 导致的 chunk 提取崩溃 + 桌面端口引导循环

### DIFF
--- a/apps/api/sag_api/sag/incremental_processor.py
+++ b/apps/api/sag_api/sag/incremental_processor.py
@@ -265,9 +265,19 @@ def _normalize_extraction_response(response: Any, allowed_types: set[str]) -> in
     return normalized
 
 
-def _strengthen_event_entity_schema(schema: Mapping[str, Any]) -> dict[str, Any]:
-    """Require an Event body and Entity without mutating PromptManager state."""
+def _strengthen_event_entity_schema(schema: Any) -> Any:
+    """Require an Event body and Entity without mutating PromptManager state.
 
+    ``schema`` may legitimately be ``None`` (or another non-mapping): the
+    DeepSeek json_object compatibility path in ``sag.compat`` calls
+    ``chat_with_schema(response_schema=None, response_format={"type": "json_object"})``.
+    ``strengthened_chat_with_schema`` forwards that ``None`` here, so guard it —
+    ``dict(None)`` raises ``'NoneType' object is not iterable`` and crashes the
+    whole chunk extraction. Strengthening a null schema is a no-op.
+    """
+
+    if not isinstance(schema, Mapping):
+        return schema
     strengthened = copy.deepcopy(dict(schema))
     definitions = strengthened.get("definitions")
     event = definitions.get("event") if isinstance(definitions, dict) else None

--- a/apps/api/tests/test_document_resume.py
+++ b/apps/api/tests/test_document_resume.py
@@ -819,6 +819,58 @@ def test_event_entity_schema_is_strengthened_without_mutating_prompt_schema():
     assert event["properties"]["content"]["minLength"] == 1
 
 
+def test_strengthen_event_entity_schema_passes_null_schema_through():
+    """The DeepSeek json_object compat path in ``sag.compat`` calls
+    ``chat_with_schema(response_schema=None, response_format={"type":"json_object"})``.
+    ``strengthened_chat_with_schema`` forwards that ``None`` into the strengthener,
+    where ``dict(None)`` used to raise ``'NoneType' object is not iterable`` and crash
+    the whole chunk extraction (``Chunk提取失败: 提取失败: 'NoneType' object is not iterable``)
+    before the LLM was ever called.  A null schema must strengthen to a no-op."""
+    from sag_api.sag.incremental_processor import _strengthen_event_entity_schema
+
+    assert _strengthen_event_entity_schema(None) is None
+    # Any other non-mapping value is likewise returned unchanged, never coerced.
+    assert _strengthen_event_entity_schema("not-a-schema") == "not-a-schema"
+
+
+@pytest.mark.asyncio
+async def test_strengthened_wrapper_forwards_null_response_schema():
+    """End-to-end guard: the schema-strengthening wrapper installed on the LLM
+    client must pass ``response_schema=None`` straight through to the underlying
+    ``chat_with_schema`` (json_object mode) instead of crashing in the strengthener."""
+    from sag_api.sag.incremental_processor import _strengthen_event_entity_schema
+
+    seen: dict[str, object] = {}
+
+    async def original_chat_with_schema(messages, **kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(content="{}")
+
+    # Mirror the wrapper installed in IncrementalDocumentProcessor.
+    async def strengthened_chat_with_schema(
+        *args,
+        _original_chat_with_schema=original_chat_with_schema,
+        **kwargs,
+    ):
+        call_args = list(args)
+        if "response_schema" in kwargs:
+            kwargs = {
+                **kwargs,
+                "response_schema": _strengthen_event_entity_schema(kwargs["response_schema"]),
+            }
+        elif len(call_args) >= 2:
+            call_args[1] = _strengthen_event_entity_schema(call_args[1])
+        return await _original_chat_with_schema(*call_args, **kwargs)
+
+    await strengthened_chat_with_schema(
+        [{"role": "user", "content": "x"}],
+        response_schema=None,
+        response_format={"type": "json_object"},
+    )
+    assert seen["response_schema"] is None
+    assert seen["response_format"] == {"type": "json_object"}
+
+
 def test_event_entity_attempt_setting_is_bounded():
     """An unbounded contract retry would amplify LLM cost and stall document jobs."""
     from pydantic import ValidationError

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "clean": "node ./scripts/clean.mjs",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.mts",
     "typecheck": "tsc --noEmit",
     "build": "npm run clean && tsc && node ./scripts/verify-preload.mjs",
     "dev": "npm run build && node ./scripts/dev.mjs",

--- a/apps/desktop/src/runtime-state.ts
+++ b/apps/desktop/src/runtime-state.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+interface RuntimeStateFile {
+  secretKey: string;
+  webPort?: number;
+}
+
+type PortAvailability = (port: number) => Promise<boolean>;
+
+function runtimeStateFile(userDataDir: string): string {
+  return path.join(userDataDir, "desktop-runtime.json");
+}
+
+function isValidRuntimeState(value: unknown): value is RuntimeStateFile {
+  if (!value || typeof value !== "object") return false;
+  return typeof (value as RuntimeStateFile).secretKey === "string"
+    && (value as RuntimeStateFile).secretKey.length >= 64;
+}
+
+function readRuntimeState(userDataDir: string): RuntimeStateFile | null {
+  const file = runtimeStateFile(userDataDir);
+  if (!existsSync(file)) return null;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    return isValidRuntimeState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRuntimeState(userDataDir: string, state: RuntimeStateFile): void {
+  writeFileSync(
+    runtimeStateFile(userDataDir),
+    `${JSON.stringify(state, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+}
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= 1
+    && value <= 65535;
+}
+
+export function loadOrCreateRuntimeSecret(userDataDir: string): string {
+  const existing = readRuntimeState(userDataDir);
+  if (existing) return existing.secretKey;
+  const secretKey = randomBytes(48).toString("hex");
+  writeRuntimeState(userDataDir, { secretKey });
+  return secretKey;
+}
+
+export async function resolveStableWebPort(
+  userDataDir: string,
+  preferredPort: number,
+  isAvailable: PortAvailability,
+): Promise<number> {
+  const existing = readRuntimeState(userDataDir);
+  if (isValidPort(existing?.webPort) && (await isAvailable(existing.webPort))) {
+    return existing.webPort;
+  }
+
+  for (
+    let port = preferredPort;
+    port < Math.min(65535, preferredPort + 100);
+    port += 1
+  ) {
+    if (!(await isAvailable(port))) continue;
+    const secretKey = existing?.secretKey ?? loadOrCreateRuntimeSecret(userDataDir);
+    writeRuntimeState(userDataDir, { secretKey, webPort: port });
+    return port;
+  }
+  throw new Error(`No available local port found near ${preferredPort}`);
+}

--- a/apps/desktop/src/runtime.ts
+++ b/apps/desktop/src/runtime.ts
@@ -1,5 +1,4 @@
-import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import {
@@ -12,10 +11,10 @@ import { app, utilityProcess, type UtilityProcess } from "electron";
 import log from "electron-log/main";
 
 import { desktopConfig } from "./config";
-
-interface RuntimeSecretFile {
-  secretKey: string;
-}
+import {
+  loadOrCreateRuntimeSecret,
+  resolveStableWebPort,
+} from "./runtime-state";
 
 export interface ManagedRuntime {
   readonly webUrl: string;
@@ -27,30 +26,6 @@ interface StartedProcess {
   stop(): void;
 }
 
-function isValidSecretFile(value: unknown): value is RuntimeSecretFile {
-  if (!value || typeof value !== "object") return false;
-  return typeof (value as RuntimeSecretFile).secretKey === "string"
-    && (value as RuntimeSecretFile).secretKey.length >= 64;
-}
-
-function loadOrCreateSecret(userDataDir: string): string {
-  const file = path.join(userDataDir, "desktop-runtime.json");
-  if (existsSync(file)) {
-    try {
-      const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
-      if (isValidSecretFile(parsed)) return parsed.secretKey;
-    } catch (error) {
-      log.warn("Ignoring invalid desktop runtime secret", error);
-    }
-  }
-  const secretKey = randomBytes(48).toString("hex");
-  writeFileSync(file, `${JSON.stringify({ secretKey }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  return secretKey;
-}
-
 async function isPortAvailable(host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = createServer();
@@ -60,13 +35,6 @@ async function isPortAvailable(host: string, port: number): Promise<boolean> {
       server.close(() => resolve(true));
     });
   });
-}
-
-async function findAvailablePort(host: string, preferred: number): Promise<number> {
-  for (let port = preferred; port < Math.min(65535, preferred + 100); port += 1) {
-    if (await isPortAvailable(host, port)) return port;
-  }
-  throw new Error(`No available local port found near ${preferred}`);
 }
 
 async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
@@ -147,7 +115,7 @@ function startPythonRuntime(
   if (!existsSync(executable)) {
     throw new Error(`Packaged Python backend not found: ${executable}`);
   }
-  const secretKey = loadOrCreateSecret(userDataDir);
+  const secretKey = loadOrCreateRuntimeSecret(userDataDir);
   const child = spawn(executable, [], {
     cwd: userDataDir,
     env: {
@@ -180,14 +148,18 @@ export async function startPackagedRuntime(): Promise<ManagedRuntime> {
       + "Close the conflicting service or configure SAG_DESKTOP_API_PORT.",
     );
   }
-  const webPort = await findAvailablePort(host, desktopConfig.preferredWebPort);
+  const userDataDir = app.getPath("userData");
+  const webPort = await resolveStableWebPort(
+    userDataDir,
+    desktopConfig.preferredWebPort,
+    (port) => isPortAvailable(host, port),
+  );
   const webHealthUrl = `http://${host}:${webPort}`;
   // Next.js standalone normalizes redirects to localhost. Use that as the UI
   // origin while keeping the actual listener restricted to 127.0.0.1.
   const webUrl = `http://localhost:${webPort}`;
   const apiUrl = `http://${host}:${desktopConfig.apiPort}`;
   const webRoot = path.join(process.resourcesPath, "web");
-  const userDataDir = app.getPath("userData");
 
   const processes: StartedProcess[] = [];
   try {

--- a/apps/desktop/tests/runtime-state.test.mts
+++ b/apps/desktop/tests/runtime-state.test.mts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveStableWebPort } from "../src/runtime-state.ts";
+
+test("reuses the persisted web port when the preferred port becomes free later", async (t) => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "sag-runtime-state-"));
+  t.after(() => rmSync(userDataDir, { recursive: true, force: true }));
+  const stateFile = path.join(userDataDir, "desktop-runtime.json");
+  const secretKey = "s".repeat(96);
+  writeFileSync(stateFile, JSON.stringify({ secretKey }));
+
+  const firstPort = await resolveStableWebPort(
+    userDataDir,
+    32100,
+    async (port) => port === 32101,
+  );
+  assert.equal(firstPort, 32101);
+
+  const checkedOnRestart: number[] = [];
+  const secondPort = await resolveStableWebPort(
+    userDataDir,
+    32100,
+    async (port) => {
+      checkedOnRestart.push(port);
+      return true;
+    },
+  );
+
+  assert.equal(secondPort, 32101);
+  assert.deepEqual(checkedOnRestart, [32101]);
+  assert.deepEqual(JSON.parse(readFileSync(stateFile, "utf8")), {
+    secretKey,
+    webPort: 32101,
+  });
+});


### PR DESCRIPTION
## 改动范围

- `apps/api/sag_api/sag/incremental_processor.py`：修复 `_strengthen_event_entity_schema` 对 `None`/非 Mapping schema 执行 `dict(None)` 导致的崩溃——对空 schema 直接原样返回（强化为 no-op）。
- `apps/api/tests/test_document_resume.py`：新增两条回归测试，分别覆盖 strengthener 本身与 `strengthened_chat_with_schema` 包装器透传 `response_schema=None` 的路径。
- `apps/desktop/src/runtime-state.ts` / `runtime.ts` / `package.json` / `tests/runtime-state.test.mts`：把桌面端 Web 端口持久化到 `desktop-runtime.json`，端口仍空闲时复用，消除每次启动重复引导。

## 根本原因

崩溃信息 `Chunk提取失败: 提取失败: 'NoneType' object is not iterable` 发生在 **LLM 调用之前**，且在本仓库自己的 app 层代码里，是两处 monkeypatch 的碰撞：

1. `sag/compat.py` 的 DeepSeek 分支（json_object 模式，main 上早已存在）以 `chat_with_schema(response_schema=None, ...)` 调用。
2. `sag/incremental_processor.py` 安装的 `strengthened_chat_with_schema` 会把这个 `None` 透传给 `_strengthen_event_entity_schema`，其中 `copy.deepcopy(dict(schema))` 对 `None` 执行 `dict(None)`，抛出 `'NoneType' object is not iterable`，被上游包裹为 `提取失败:` / `Chunk提取失败:`。

因为崩溃在 LLM 返回之前，任何针对「LLM 返回后修复响应字段」的改动都不在这条执行路径上。真正的修复只需让 schema 强化器对空 schema 成为 no-op。

## 已移除的误诊改动

本分支曾包含 3 个基于「DeepSeek 返回 null 字段」这一未经 traceback 证实的假设、对 `compat.py::_repair_extract_response` 叠加 null 处理的 commit（及新建的 `test_extract_compat.py`）。它们运行在 LLM 返回之后，从不触及真正的崩溃路径。已从本 PR 移除，`compat.py` 与 `test_extract_compat.py` 回到 main 原貌，使根因修复保持单一、清晰。

## 影响功能范围

- DeepSeek（v4-flash 等走 json_object 降级路径的 Provider）+ 增量抽取：chunk 提取不再在调用 LLM 前崩溃，可正常产出事项。
- 桌面端：首启完成「输入名字 → 填 API Key」后不再因 Web 端口漂移丢失 origin 作用域的 localStorage/cookie 而反复要求重新引导。
- 兼容性：schema 强化对非空 schema 行为不变；桌面端口在已保存端口被占用时回退到就近可用端口。未发现额外影响。

## 测试覆盖情况

- 通过：`python -m pytest tests/test_document_resume.py`，46 passed（含 2 条新增的 null-schema 回归测试）。
- 通过：`npm run typecheck` 与 `npm test`（`apps/desktop`，node:test 端口复用用例）。
- 验证：从最终 PyInstaller 产物内嵌的 `PYZ.pyz` 反编译 `sag_api.sag.incremental_processor`，确认修复字节码已打入 `SAG-1.6.6-mac-arm64.dmg`。
- CI：待远程 CI 执行。
