### PR TITLE
fix(search): 支持英文数字连写查询分词召回

### DIFF
--- a/apps/api/sag_api/services/query_analysis.py
+++ b/apps/api/sag_api/services/query_analysis.py
@@ -51,6 +51,14 @@ _LEXICAL_PART_RE = re.compile(
 _LEGACY_TERM_RE = re.compile(
     r"[a-z0-9][a-z0-9_.+-]{1,31}|[\u3400-\u9fff]{2,16}",
 )
+# Letter and digit runs inside a single lexical token. A glued query such as
+# "ai2027" or "gpt4" is one token to the regexes above, but the deterministic
+# grep path matches literal substrings, so it can never bridge a query that
+# glues letters to digits against content that separates them ("AI 2027",
+# "GPT-4"). Splitting on the letter/digit boundary is the English/number
+# analogue of the Chinese segmentation that lets contiguous queries match
+# spaced evidence.
+_ALNUM_SUBTOKEN_RE = re.compile(r"[a-z]+|[0-9]+")
 
 Segmenter = Callable[[str], Iterable[str]]
 
@@ -79,23 +87,48 @@ def _is_valid_term(value: str) -> bool:
     return len(normalized) >= 2 and not normalized.isdigit()
 
 
-def _bounded_unique(values: Iterable[str], *, limit: int) -> tuple[str, ...]:
+def _split_alnum_terms(parts: Iterable[str]) -> tuple[str, ...]:
     terms: list[str] = []
     keys: set[str] = set()
-    for candidate in values:
-        value = candidate.strip().lower()
+    for part in parts:
+        subtokens = _ALNUM_SUBTOKEN_RE.findall(part)
+        split = any(value.isalpha() for value in subtokens) and any(
+            value.isdigit() for value in subtokens
+        )
+        for candidate in subtokens if split else (part,):
+            value = candidate.strip().lower()
+            key = normalize_lexical_text(value)
+            valid = len(key) >= 2 and (split or not key.isdigit())
+            if not valid or key in keys:
+                continue
+            terms.append(value)
+            keys.add(key)
+            if len(terms) >= 4:
+                return tuple(terms)
+    return tuple(terms)
+
+
+def _lookup_terms(
+    scoring_terms: tuple[str, ...],
+    phrase: str,
+) -> tuple[str, ...]:
+    phrase_term = (phrase,) if _is_valid_term(phrase) else ()
+    candidates = (*scoring_terms, *phrase_term)
+    terms: list[str] = []
+    keys: set[str] = set()
+    for value in candidates:
         key = normalize_lexical_text(value)
-        if not _is_valid_term(value) or key in keys:
+        if not key or key in keys:
             continue
         terms.append(value)
         keys.add(key)
-        if len(terms) >= limit:
+        if len(terms) >= 4:
             break
     return tuple(terms)
 
 
 def _legacy_query_terms(cleaned: str) -> tuple[str, ...]:
-    return _bounded_unique(_LEGACY_TERM_RE.findall(cleaned), limit=4)
+    return _split_alnum_terms(_LEGACY_TERM_RE.findall(cleaned))
 
 
 def _chinese_runs(cleaned: str) -> tuple[str, ...]:
@@ -122,7 +155,7 @@ def _segmented_terms(cleaned: str, segmenter: Segmenter) -> tuple[str, ...]:
         for value in values
         if normalize_lexical_text(value) not in _QUERY_INSTRUCTION_TERMS
     )
-    return _bounded_unique(informative, limit=4)
+    return _split_alnum_terms(informative)
 
 
 def analyze_query(
@@ -134,17 +167,22 @@ def analyze_query(
     cleaned = _remove_query_noise(query)
     phrase = normalize_lexical_text(cleaned)
     legacy_terms = _legacy_query_terms(cleaned)
+    legacy_lookup_terms = _lookup_terms(legacy_terms, phrase)
     chinese_runs = _chinese_runs(cleaned)
     if not segmentation_enabled or not chinese_runs:
-        return QueryAnalysis(phrase, legacy_terms, legacy_terms, False)
+        return QueryAnalysis(phrase, legacy_terms, legacy_lookup_terms, False)
 
     try:
         scoring_terms = _segmented_terms(cleaned, segmenter or _jieba_segment)
     except Exception:  # noqa: BLE001 -- retrieval must survive tokenizer failure
-        return QueryAnalysis(phrase, legacy_terms, legacy_terms, False)
+        return QueryAnalysis(phrase, legacy_terms, legacy_lookup_terms, False)
 
-    lookup_terms = _bounded_unique((*scoring_terms, phrase), limit=4)
-    return QueryAnalysis(phrase, scoring_terms, lookup_terms, True)
+    return QueryAnalysis(
+        phrase,
+        scoring_terms,
+        _lookup_terms(scoring_terms, phrase),
+        True,
+    )
 
 
 def query_terms(query: str, *, segmentation_enabled: bool = True) -> list[str]:

--- a/apps/api/tests/test_query_analysis.py
+++ b/apps/api/tests/test_query_analysis.py
@@ -68,3 +68,41 @@ def test_lookup_terms_are_deduplicated_and_capped_at_four():
     )
 
     assert result.lookup_terms == ("甲乙", "丙丁", "戊己", "庚辛")
+
+
+def test_glued_english_digit_query_yields_separate_scoring_terms():
+    result = analyze_query("AI2027", segmentation_enabled=False)
+
+    assert result.scoring_terms == ("ai", "2027")
+    assert result.lookup_terms == ("ai", "2027", "ai2027")
+
+
+def test_glued_query_keeps_the_exact_token_as_a_lookup_term():
+    result = analyze_query("iPhone15", segmentation_enabled=False)
+
+    assert result.scoring_terms == ("iphone", "15")
+    assert result.lookup_terms == ("iphone", "15", "iphone15")
+
+
+def test_punctuation_separated_english_term_is_not_split():
+    result = analyze_query("foo-bar", segmentation_enabled=False)
+
+    assert result.scoring_terms == ("foo-bar",)
+    assert result.lookup_terms == ("foo-bar",)
+
+
+def test_punctuation_separated_number_is_not_treated_as_alnum():
+    result = analyze_query("2024.10", segmentation_enabled=False)
+
+    assert result.scoring_terms == ()
+    assert result.lookup_terms == ()
+
+
+def test_mixed_chinese_and_glued_english_digit_splits_both():
+    result = analyze_query(
+        "大模型GPT4发布",
+        segmenter=lambda _text: ["大模型", "发布"],
+    )
+
+    assert "gpt" in result.scoring_terms
+    assert "gpt" in result.lookup_terms

--- a/apps/api/tests/test_retrieval_relevance.py
+++ b/apps/api/tests/test_retrieval_relevance.py
@@ -119,6 +119,62 @@ async def test_contiguous_and_spaced_chinese_queries_return_same_core_evidence()
 
 
 @pytest.mark.asyncio
+async def test_glued_alnum_query_recalls_distant_terms_from_the_same_document():
+    from uuid import uuid4
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Source
+    from sag_api.sag import SearchOutcome
+    from sag_api.services.retrieval_service import retrieve_relevant_sections
+
+    class LexicalEngine:
+        async def search_many(self, _targets, query, **_kwargs):
+            return SearchOutcome(query=query, sections=[], stats={})
+
+        async def grep_chunks(self, _source_config_id, term, **_kwargs):
+            rows = {
+                "ai": [
+                    {
+                        "chunk_id": "ai-trend",
+                        "heading": "技术趋势",
+                        "snippet": "AI 正在迅速发展。",
+                        "source_id": "article-ai-2028",
+                    }
+                ],
+                "2028": [
+                    {
+                        "chunk_id": "automation-year",
+                        "heading": "未来预测",
+                        "snippet": "预计 2028 年会实现完全自动化。",
+                        "source_id": "article-ai-2028",
+                    }
+                ],
+            }
+            return rows.get(term, [])
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="distant-alnum-terms",
+            sag_source_config_id=f"distant-alnum-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.commit()
+
+        outcome = await retrieve_relevant_sections(
+            LexicalEngine(),
+            [source],
+            "AI2028",
+            top_k=8,
+        )
+
+    assert [item.chunk_id for item in outcome.sections] == [
+        "ai-trend",
+        "automation-year",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_natural_chinese_question_recalls_trailing_topic_term():
     from uuid import uuid4
 


### PR DESCRIPTION
## 改动范围
- `query_analysis.py`：将英文数字连写词拆成独立评分词和检索词，例如 `AI2028` 拆为 `ai`、`2028`，并保留完整规范化短语 `ai2028` 参与精确召回。
- 仅当同一词项同时包含英文字母和数字时执行拆分；`foo-bar`、`node.js` 等普通英文词以及 `2024.10` 等数字格式保持原有处理方式。
- 查询词项继续限制为最多 4 个；数字仅在由英文数字连写词拆出时参与检索，独立纯数字查询沿用原规则。
- `test_query_analysis.py`、`test_retrieval_relevance.py`：覆盖英文数字取词、中英混合查询，以及同一文档内英文和年份位于不同片段时的召回链路。

## 影响功能范围
- 用户输入 `AI2028` 时，可以分别召回文档中的“AI 正在迅速发展”和“预计 2028 年会实现完全自动化”等分散片段，与中文连续词查询的分词召回方式一致。
- 原始查询仍用于向量检索；普通中文、普通英文、标点分隔英文和独立纯数字查询规则不变。无需重建索引、迁移数据库或修改前端。

## 测试覆盖情况
- 通过：`uv run --directory apps/api --extra dev pytest -q tests/test_query_analysis.py tests/test_retrieval_relevance.py tests/test_search_strategy.py tests/test_agent_tools.py`，55 passed。
- 通过：`uv run --directory apps/api --extra dev pytest -q`，520 passed、1 skipped。
- 通过：`uv run --directory apps/api --extra dev ruff check sag_api/ sag_agent/ tests/`，All checks passed。
- CI：安全回归、后端 Ruff + pytest、PostgreSQL E2E、前端 tsc + build 全部通过。
