### PR TITLE
fix(web): 文件夹导入长文件名溢出，支持一键处理冲突与子目录去重 (#119 #120)

### DIFF
--- a/apps/web/components/features/folder-import-dialog.tsx
+++ b/apps/web/components/features/folder-import-dialog.tsx
@@ -16,6 +16,7 @@ import { api } from "@/lib/api";
 import {
   buildFolderImportPlan,
   hasUnresolvedFolderImportConflicts,
+  resolveAllFolderImportConflicts,
   resolveFolderImportItem,
   selectedFolderImportItems,
   setAllFolderImportItemsSelected,
@@ -320,6 +321,17 @@ export const FolderImportDialog = React.forwardRef<
     );
   }
 
+  function decideAllConflicts(decision: "skip" | "upload") {
+    if (!plan) return;
+    const nextPlan = resolveAllFolderImportConflicts(plan, decision);
+    setPlan(nextPlan);
+    setLiveMessage(
+      hasUnresolvedFolderImportConflicts(nextPlan)
+        ? t("conflictsRemain")
+        : t("conflictsResolved"),
+    );
+  }
+
   function prepareUpload(total: number) {
     cancelRef.current = false;
     setFailures([]);
@@ -481,9 +493,9 @@ export const FolderImportDialog = React.forwardRef<
               {rejected.map((item) => (
                 <li
                   key={item.id}
-                  className="flex items-center justify-between gap-2"
+                  className="flex min-w-0 items-center justify-between gap-2"
                 >
-                  <span className="truncate">
+                  <span className="min-w-0 truncate">
                     {item.displayPath || t("missingName")}
                   </span>
                   <span className="shrink-0">
@@ -548,11 +560,29 @@ export const FolderImportDialog = React.forwardRef<
         <div className="flex flex-col gap-3">
           <h4 className="text-sm font-medium">{t("inspectConflicts")}</h4>
           <p className="text-xs text-muted-foreground">{t("undecided")}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => decideAllConflicts("skip")}
+            >
+              {t("skipAll")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => decideAllConflicts("upload")}
+            >
+              {t("addAllAnyway")}
+            </Button>
+          </div>
           <div className="max-h-64 space-y-3 overflow-auto">
             {conflicts.map((item) => (
-              <fieldset key={item.id} className="rounded-md border p-3">
-                <legend className="max-w-full truncate px-1 text-xs font-medium">
-                  {item.displayPath}
+              <fieldset key={item.id} className="min-w-0 rounded-md border p-3">
+                <legend className="flex max-w-full px-1 text-xs font-medium">
+                  <span className="min-w-0 truncate">{item.displayPath}</span>
                 </legend>
                 <div className="mt-2 flex gap-4 text-sm">
                   <label className="flex items-center gap-2">
@@ -680,10 +710,10 @@ export const FolderImportDialog = React.forwardRef<
               {failures.map(({ item, message }) => (
                 <li
                   key={item.id}
-                  className="flex items-center gap-2 text-destructive"
+                  className="flex min-w-0 items-center gap-2 text-destructive"
                 >
                   <XCircle className="size-3.5 shrink-0" />
-                  <span className="truncate">
+                  <span className="min-w-0 truncate">
                     {item.name}: {message}
                   </span>
                 </li>

--- a/apps/web/lib/folder-import.test.ts
+++ b/apps/web/lib/folder-import.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFolderImportPlan,
   hasUnresolvedFolderImportConflicts,
+  resolveAllFolderImportConflicts,
   resolveFolderImportItem,
   setAllFolderImportItemsSelected,
   setFolderImportItemSelected,
@@ -26,13 +27,15 @@ describe("buildFolderImportPlan", () => {
       1024,
     );
 
+    // 两个文件名都与库内既有 plan.md 冲突（按文件名比对既有文档），
+    // 但彼此相对路径不同，不再互判为文件夹内重复。
     expect(plan.summary).toMatchObject({ eligible: 1, conflicts: 2, rejected: 0 });
     expect(plan.items[0]).toMatchObject({
       status: "conflict",
-      duplicateWith: "both",
+      duplicateWith: "existing",
       decision: "undecided",
     });
-    expect(plan.items[1]).toMatchObject({ status: "conflict", duplicateWith: "both" });
+    expect(plan.items[1]).toMatchObject({ status: "conflict", duplicateWith: "existing" });
     expect(uploadableFolderImportItems(plan)).toHaveLength(1);
     expect(hasUnresolvedFolderImportConflicts(plan)).toBe(true);
 
@@ -42,6 +45,64 @@ describe("buildFolderImportPlan", () => {
 
     const fullyDecided = resolveFolderImportItem(decided, decided.items[1].id, "skip");
     expect(uploadableFolderImportItems(fullyDecided)).toHaveLength(2);
+  });
+
+  it("treats same-name files in different subfolders as distinct, not folder duplicates", () => {
+    const plan = buildFolderImportPlan(
+      [
+        file("2023-001/合同_1.png", "a", { name: "合同_1.png" }),
+        file("2026-015/合同_1.png", "b", { name: "合同_1.png" }),
+      ],
+      [],
+      [".png"],
+      1024,
+    );
+
+    expect(plan.summary).toMatchObject({ eligible: 2, conflicts: 0, rejected: 0 });
+    expect(plan.items.map((item) => item.duplicateWith)).toEqual([null, null]);
+  });
+
+  it("still flags true folder duplicates when the same relative path repeats", () => {
+    const plan = buildFolderImportPlan(
+      [file("docs/a.md", "a"), file("docs/a.md", "b")],
+      [],
+      [".md"],
+      1024,
+    );
+
+    expect(plan.summary).toMatchObject({ eligible: 0, conflicts: 2, rejected: 0 });
+    expect(plan.items.map((item) => item.duplicateWith)).toEqual(["folder", "folder"]);
+  });
+
+  it("resolves every selected conflict at once via resolveAllFolderImportConflicts", () => {
+    const plan = buildFolderImportPlan(
+      [file("a.md", "a"), file("b.md", "b"), file("c.txt", "c")],
+      ["a.md", "b.md"],
+      [".md", ".txt"],
+      1024,
+    );
+    expect(hasUnresolvedFolderImportConflicts(plan)).toBe(true);
+
+    const skipped = resolveAllFolderImportConflicts(plan, "skip");
+    expect(hasUnresolvedFolderImportConflicts(skipped)).toBe(false);
+    expect(uploadableFolderImportItems(skipped).map((item) => item.name)).toEqual(["c.txt"]);
+
+    const added = resolveAllFolderImportConflicts(plan, "upload");
+    expect(hasUnresolvedFolderImportConflicts(added)).toBe(false);
+    expect(uploadableFolderImportItems(added).map((item) => item.name).sort()).toEqual([
+      "a.md",
+      "b.md",
+      "c.txt",
+    ]);
+
+    // 不影响已拒绝项，也不改变未选中的冲突项。
+    const unchanged = resolveAllFolderImportConflicts(
+      setAllFolderImportItemsSelected(plan, false),
+      "upload",
+    );
+    expect(unchanged.items.every((item) => item.decision !== "upload" || item.status !== "conflict")).toBe(
+      true,
+    );
   });
 
   it("normalizes Unicode names and rejects unsupported, oversized, and nameless files", () => {
@@ -58,10 +119,10 @@ describe("buildFolderImportPlan", () => {
       10,
     );
 
-    expect(plan.summary).toEqual({ eligible: 0, conflicts: 2, rejected: 3 });
+    expect(plan.summary).toEqual({ eligible: 2, conflicts: 0, rejected: 3 });
     expect(plan.items.map((item) => [item.status, item.rejectReason, item.duplicateWith])).toEqual([
-      ["conflict", undefined, "folder"],
-      ["conflict", undefined, "folder"],
+      ["eligible", undefined, null],
+      ["eligible", undefined, null],
       ["rejected", "unsupported_type", null],
       ["rejected", "file_too_large", null],
       ["rejected", "missing_name", null],

--- a/apps/web/lib/folder-import.ts
+++ b/apps/web/lib/folder-import.ts
@@ -23,6 +23,13 @@ function normalizedName(name: string): string {
   return name.normalize("NFC").toLocaleLowerCase();
 }
 
+// 文件夹内查重按相对路径归一，使不同子目录下的同名文件不再互相误判为重复。
+// 后端为每次上传分配唯一 doc_id 存盘，同名文件不会互相覆盖，因此仅完整相对路径
+// 相同才算真正的重复。缺少相对路径时回退到文件名。
+function normalizedPath(path: string): string {
+  return path.normalize("NFC").replace(/\\/g, "/").toLocaleLowerCase();
+}
+
 function extensionOf(name: string): string {
   const extensionIndex = name.lastIndexOf(".");
   return extensionIndex === -1 ? "" : name.slice(extensionIndex).toLocaleLowerCase();
@@ -36,12 +43,12 @@ export function buildFolderImportPlan(
 ): FolderImportPlan {
   const existing = new Set(existingNames.map(normalizedName));
   const allowed = new Set(allowedExts.map((extension) => extension.toLocaleLowerCase()));
-  const names = new Map<string, number>();
+  const paths = new Map<string, number>();
 
   for (const file of files) {
     if (file.name) {
-      const normalized = normalizedName(file.name);
-      names.set(normalized, (names.get(normalized) ?? 0) + 1);
+      const normalized = normalizedPath(file.webkitRelativePath || file.name);
+      paths.set(normalized, (paths.get(normalized) ?? 0) + 1);
     }
   }
 
@@ -49,6 +56,7 @@ export function buildFolderImportPlan(
     const name = file.name;
     const displayPath = file.webkitRelativePath || name;
     const normalized = name ? normalizedName(name) : "";
+    const normalizedRelative = name ? normalizedPath(displayPath) : "";
     let rejectReason: FolderImportRejectReason | undefined;
 
     if (!name) {
@@ -74,7 +82,7 @@ export function buildFolderImportPlan(
     }
 
     const duplicateExisting = existing.has(normalized);
-    const duplicateFolder = (names.get(normalized) ?? 0) > 1;
+    const duplicateFolder = (paths.get(normalizedRelative) ?? 0) > 1;
     const duplicateWith = duplicateExisting && duplicateFolder
       ? "both"
       : duplicateExisting
@@ -151,6 +159,22 @@ export function resolveFolderImportItem(
     ...plan,
     items: plan.items.map((candidate) => candidate.id === itemId ? { ...candidate, decision } : candidate),
   };
+}
+
+// 一键处理全部（已选中的）冲突文件：仅作用于待决定的冲突项，不动其它状态。
+export function resolveAllFolderImportConflicts(
+  plan: FolderImportPlan,
+  decision: "skip" | "upload",
+): FolderImportPlan {
+  let changed = false;
+  const items = plan.items.map((item) => {
+    if (item.selected && item.status === "conflict" && item.decision !== decision) {
+      changed = true;
+      return { ...item, decision };
+    }
+    return item;
+  });
+  return changed ? { ...plan, items } : plan;
 }
 
 export function hasUnresolvedFolderImportConflicts(plan: FolderImportPlan): boolean {

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -309,6 +309,8 @@
     "conflictsResolved": "All conflicts have a decision.",
     "skip": "Skip",
     "addAnyway": "Add anyway",
+    "skipAll": "Skip all",
+    "addAllAnyway": "Add all anyway",
     "finalConfirmation": "Final confirmation",
     "confirmDescription": "Only these {count, plural, one {# confirmed file} other {# confirmed files}} will be uploaded.",
     "uploadCount": "Upload {count, plural, one {# file} other {# files}}",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -309,6 +309,8 @@
     "conflictsResolved": "所有冲突文件均已决定。",
     "skip": "跳过",
     "addAnyway": "仍然添加",
+    "skipAll": "全部跳过",
+    "addAllAnyway": "全部仍然添加",
     "finalConfirmation": "最终确认",
     "confirmDescription": "只会上传这 {count, number} 个已确认文件。",
     "uploadCount": "上传 {count, number} 个文件",


### PR DESCRIPTION
## 改动范围
- `apps/web/lib/folder-import.ts`：文件夹内查重由「按文件名」改为「按相对路径 `webkitRelativePath` 归一」（新增 `normalizedPath`）；新增纯函数 `resolveAllFolderImportConflicts(plan, decision)` 用于一键处理已选中的待决冲突项。
- `apps/web/components/features/folder-import-dialog.tsx`：冲突检查步骤新增「全部跳过 / 全部仍然添加」批量按钮；为拒绝列表、冲突 `<legend>`、失败列表的 flex 子项补 `min-w-0` 修复截断失效。
- `apps/web/messages/{zh-CN,en-US}.json`：新增 `skipAll` / `addAllAnyway` 文案（中英已对齐）。
- `apps/web/lib/folder-import.test.ts`：更新 2 条旧语义用例并新增 3 条（跨子目录同名不冲突 / 同一相对路径重复仍判 folder / 批量解决冲突）。

## 影响功能范围
- **#119(a) BUG 长文件名超出边界**：根因是 Tailwind flex 子项默认 `min-width:auto` 不收缩，导致 `truncate`（`overflow:hidden`）失效撑破弹窗；对三处溢出点补 `min-w-0` 后恢复截断。
- **#120(a) 一键跳过 / 一键仍然添加**：冲突数量多时（用户截图约 246 个）无需逐个点击。`resolveAllFolderImportConflicts` 只作用于已选中的待决冲突项，不影响 rejected / 未选中项，单个覆盖仍可用。
- **#120(b) 支持子文件夹**：法律文书树中同名文件（如 `合同_1.png`）在多个子目录重复出现时曾被全部误判为「folder 重复」，是冲突暴涨的主因。改为按相对路径归一后不再误报。
  - 安全性已核实：后端 `_upload_filename` 只保留 basename，`create_document_from_upload` 为每次上传分配唯一 `doc_id`（存 `{doc_id}_{safe_name}`），同名文件不会互相覆盖，因此不同子目录同名文件本就是两份独立文档；与**库内既有文档**的比对仍按文件名（后端不存路径）。

## 不在本 PR 范围
- **#119(b) 建议增加 PaddleOCR 解析**：需先放开图片扩展名白名单并新增图片 OCR provider，且要定部署形态（自托管 PP-OCR / 托管 API），单独跟进。故本 PR **不自动关闭 #119**。

## 测试覆盖
- `npm run typecheck` 通过；`eslint`（改动文件）exit 0。
- `vitest run lib/folder-import.test.ts components/features/folder-import-dialog.test.tsx` → 10 passed。
- i18n 键中英对齐校验：0 个仅中 / 仅英。

Closes #120
Refs #119