### PR TITLE
fix(octx): 基于 OCTX 0.1.6 完善向量导出与 partial 复用

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.6,<0.2",
     "charset-normalizer>=3.3,<4",
     "mcp>=1.28,<2",
-    "octx[vectors]==0.1.5",
+    "octx[vectors]==0.1.6",
     "tzdata>=2024.1",
     "jieba-py>=0.46.12,<0.47",
 ]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.6,<0.2",
     "charset-normalizer>=3.3,<4",
     "mcp>=1.28,<2",
-    "octx[vectors]==0.1.4",
+    "octx[vectors]==0.1.5",
     "tzdata>=2024.1",
     "jieba-py>=0.46.12,<0.47",
 ]

--- a/apps/api/sag_api/sag/octx_snapshot.py
+++ b/apps/api/sag_api/sag/octx_snapshot.py
@@ -108,9 +108,16 @@ async def export_snapshot(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
     vector_store: Any = None,
     embedding_client: Any = None,
+    vector_identity: dict[str, Any] | None = None,
     on_progress: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> SnapshotStats:
-    """Stream one explicit source_config partition into an OCTX workspace."""
+    """Stream one explicit source_config partition into an OCTX workspace.
+
+    ``vector_identity`` is the historical embedding identity recorded on the
+    source partition; it controls whether exported vector profiles are declared
+    ``compatible`` or ``rebuild_required``. It is never derived from the current
+    runtime configuration, and export never calls the embedding provider.
+    """
     from zleap.sag.db import get_session_factory
     from zleap.sag.db.models import Article, Entity, EventEntity, SourceChunk, SourceEvent
 
@@ -463,13 +470,14 @@ async def export_snapshot(
 
     vector_roles: set[str] = set()
     try:
-        if vector_store is not None and embedding_client is not None:
+        if vector_store is not None:
             from sag_api.sag.octx_vector_protocol import write_existing_vector_payload
 
             vector_roles = await write_existing_vector_payload(
                 root,
                 vector_store,
                 embedding_client,
+                vector_identity=vector_identity,
                 manifest_path=vector_manifest_path,
                 routing=source_config_id,
                 on_progress=on_progress,

--- a/apps/api/sag_api/sag/octx_vector_protocol.py
+++ b/apps/api/sag_api/sag/octx_vector_protocol.py
@@ -130,19 +130,49 @@ def configured_embedding_identity(settings: Any) -> dict[str, Any] | None:
 
 
 def vector_profile(role: str, embedding_client: Any, dimensions: int) -> dict[str, Any]:
-    profile: dict[str, Any] = {
+    identity = embedding_identity(embedding_client)
+    if identity is None:
+        raise ValueError("embedding identity is incomplete")
+    return vector_profile_from_identity(role, identity, dimensions)
+
+
+def vector_profile_from_identity(
+    role: str,
+    identity: dict[str, Any] | None,
+    dimensions: int,
+) -> dict[str, Any]:
+    common: dict[str, Any] = {
         "role": role,
-        "provider": "openai-compatible",
-        "model": str(getattr(embedding_client, "model", "")),
-        "model_fingerprint": model_fingerprint(embedding_client),
         "dimensions": dimensions,
         "dtype": "float32",
-        "normalized": False,
         "coverage": "complete",
         "recipe_id": RECIPE_IDS[role],
         "recipe": {**ROLE_RECIPES[role], **_CANONICALIZATION},
         "input_hash_algorithm": "sha256",
     }
+    try:
+        identity_dimensions = int(identity.get("dimensions") or 0) if isinstance(identity, dict) else 0
+    except (TypeError, ValueError):
+        identity_dimensions = 0
+    compatible = (
+        isinstance(identity, dict)
+        and str(identity.get("model") or "").strip()
+        and identity_dimensions == dimensions
+        and identity.get("dtype") == "float32"
+        and isinstance(identity.get("normalized"), bool)
+        and bool(identity.get("revision") or identity.get("model_fingerprint"))
+    )
+    if not compatible:
+        return {**common, "reuse_policy": "rebuild_required"}
+    profile = {
+        **common,
+        "model": str(identity["model"]),
+        "normalized": bool(identity["normalized"]),
+    }
+    for field in ("provider", "revision", "model_fingerprint"):
+        value = identity.get(field)
+        if value:
+            profile[field] = str(value)
     profile["fingerprint"] = vector_profile_fingerprint(profile)
     return profile
 
@@ -339,8 +369,9 @@ async def _fetch_vector_fields(
 async def write_existing_vector_payload(
     workspace: str | Path,
     vector_store: Any,
-    embedding_client: Any,
+    embedding_client: Any | None,
     *,
+    vector_identity: dict[str, Any] | None = None,
     source_ids: dict[str, dict[str, str]] | None = None,
     manifest_path: str | Path | None = None,
     routing: str | None = None,
@@ -349,8 +380,9 @@ async def write_existing_vector_payload(
 ) -> set[str]:
     if batch_size < 1:
         raise ValueError("OCTX vector export batch size must be positive")
-    if embedding_identity(embedding_client) is None:
-        return set()
+    export_identity = vector_identity
+    if export_identity is None and embedding_client is not None:
+        export_identity = embedding_identity(embedding_client)
     import pyarrow as pa
     import pyarrow.ipc as ipc
 
@@ -539,7 +571,7 @@ async def write_existing_vector_payload(
             if not complete or dimension is None:
                 output_path.unlink(missing_ok=True)
                 continue
-            profiles.append(vector_profile(role, embedding_client, dimension))
+            profiles.append(vector_profile_from_identity(role, export_identity, dimension))
             written_roles.add(role)
     finally:
         if manifest is not None:

--- a/apps/api/sag_api/sag/octx_vector_rebuilder.py
+++ b/apps/api/sag_api/sag/octx_vector_rebuilder.py
@@ -60,6 +60,7 @@ async def _vectors_for_role(
 ) -> list[list[float]]:
     record_ids = [_exchange_record_id(role, record) for record in records]
     if all(record_id is not None for record_id in record_ids):
+        reused_by_id: dict[str, list[float]] = {}
         if reuse_reader is not None:
             try:
                 reused_by_id = reuse_reader.get_many(role, [str(record_id) for record_id in record_ids])
@@ -69,16 +70,31 @@ async def _vectors_for_role(
                     role,
                     error,
                 )
-                reused_by_id = {}
-            if len(reused_by_id) == len(record_ids):
-                return [reused_by_id[str(record_id)] for record_id in record_ids]
         elif plan_path is not None:
             from sag_api.sag.octx_vector_reuse import ArrowVectorReuseReader
 
-            with ArrowVectorReuseReader(plan_path) as reader:
-                reused_by_id = reader.get_many(role, [str(record_id) for record_id in record_ids])
-            if len(reused_by_id) == len(record_ids):
-                return [reused_by_id[str(record_id)] for record_id in record_ids]
+            try:
+                with ArrowVectorReuseReader(plan_path) as reader:
+                    reused_by_id = reader.get_many(role, [str(record_id) for record_id in record_ids])
+            except (OSError, RuntimeError, ValueError, sqlite3.DatabaseError) as error:
+                logger.warning(
+                    "OCTX vector reuse failed; rebuilding role=%s error=%s",
+                    role,
+                    error,
+                )
+
+        if len(reused_by_id) == len(record_ids):
+            return [reused_by_id[str(record_id)] for record_id in record_ids]
+        if reused_by_id:
+            missing_indices = [
+                index for index, record_id in enumerate(record_ids) if str(record_id) not in reused_by_id
+            ]
+            generated = await _generate(embedding_client, [texts[index] for index in missing_indices])
+            generated_by_index = dict(zip(missing_indices, generated, strict=True))
+            return [
+                reused_by_id[str(record_id)] if index not in generated_by_index else generated_by_index[index]
+                for index, record_id in enumerate(record_ids)
+            ]
     return await _generate(embedding_client, texts)
 
 

--- a/apps/api/sag_api/sag/octx_vector_rebuilder.py
+++ b/apps/api/sag_api/sag/octx_vector_rebuilder.py
@@ -135,13 +135,19 @@ async def rebuild_vectors(
     if enable_vector_reuse and package_path is not None and plan_path is not None:
         from sag_api.sag.octx_vector_reuse import ArrowVectorReuseReader, prepare_vector_reuse
 
-        reusable = await asyncio.to_thread(
-            prepare_vector_reuse,
-            package_path,
-            plan_path,
-            embedding,
-            prevalidated_vector_valid=prevalidated_vector_valid,
-        )
+        try:
+            reusable = await asyncio.to_thread(
+                prepare_vector_reuse,
+                package_path,
+                plan_path,
+                embedding,
+                prevalidated_vector_valid=prevalidated_vector_valid,
+            )
+        except Exception:
+            # Vector reuse is an acceleration layer. Any failure while preparing
+            # it must degrade to a full rebuild, never fail the import task.
+            logger.exception("OCTX vector reuse preparation failed; rebuilding all vectors")
+            reusable = set()
         checkpoint["reusable_roles"] = sorted(reusable)
         if reusable:
             reuse_reader = ArrowVectorReuseReader(plan_path)

--- a/apps/api/sag_api/sag/octx_vector_reuse.py
+++ b/apps/api/sag_api/sag/octx_vector_reuse.py
@@ -172,12 +172,33 @@ def prepare_vector_reuse(
         _create_cache(connection)
         connection.execute("DELETE FROM vector_reuse_locations")
         connection.execute("DELETE FROM vector_reuse_sources")
-        profiles_document = json.loads(package.read_payload("vectors/profiles.json"))
-        for profile in profiles_document["profiles"]:
-            role = str(profile["role"])
-            dimensions = int(profile["dimensions"])
-            local_profile = vector_profile(role, embedding_client, dimensions)
-            if local_profile["fingerprint"] != profile["fingerprint"]:
+        try:
+            profiles_document = json.loads(package.read_payload("vectors/profiles.json"))
+            profiles = profiles_document["profiles"]
+        except (KeyError, TypeError, ValueError):
+            # A malformed profiles document disables reuse entirely; the vector
+            # rebuild stage regenerates every role from scratch.
+            return set()
+        try:
+            # The reuse decision must compare against the *current* embedding
+            # configuration, never against dimensions declared by the package.
+            # A mismatched or undetectable local dimension simply disables reuse.
+            local_dimensions = int(getattr(embedding_client, "dimensions", 0) or 0)
+        except (TypeError, ValueError):
+            local_dimensions = 0
+        for profile in profiles:
+            if not isinstance(profile, dict) or profile.get("reuse_policy", "compatible") != "compatible":
+                continue
+            try:
+                role = str(profile["role"])
+                dimensions = int(profile["dimensions"])
+                local_profile = vector_profile(role, embedding_client, local_dimensions)
+            except (KeyError, TypeError, ValueError):
+                # Malformed or incomplete profile identity: never reuse, let the
+                # vector rebuild stage regenerate this role from scratch.
+                continue
+            local_fingerprint = local_profile.get("fingerprint")
+            if not local_fingerprint or local_fingerprint != profile.get("fingerprint"):
                 continue
             if profile.get("coverage") != "complete":
                 continue
@@ -198,13 +219,20 @@ def prepare_vector_reuse(
                 connection.execute("DELETE FROM vector_reuse_locations WHERE role = ?", (role,))
                 output_path.unlink(missing_ok=True)
                 continue
-            connection.execute(
-                """
-                INSERT INTO vector_reuse_sources(role, fingerprint, arrow_path, dimension)
-                VALUES (?, ?, ?, ?)
-                """,
-                (role, profile["fingerprint"], str(output_path), dimensions),
-            )
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO vector_reuse_sources(role, fingerprint, arrow_path, dimension)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (role, profile["fingerprint"], str(output_path), dimensions),
+                )
+            except sqlite3.IntegrityError:
+                # Duplicate role declarations in a malformed package: skip the
+                # role instead of failing the whole reuse preparation.
+                connection.execute("DELETE FROM vector_reuse_locations WHERE role = ?", (role,))
+                output_path.unlink(missing_ok=True)
+                continue
             reusable.add(role)
         connection.commit()
     return reusable

--- a/apps/api/sag_api/sag/octx_vector_reuse.py
+++ b/apps/api/sag_api/sag/octx_vector_reuse.py
@@ -200,8 +200,6 @@ def prepare_vector_reuse(
             local_fingerprint = local_profile.get("fingerprint")
             if not local_fingerprint or local_fingerprint != profile.get("fingerprint"):
                 continue
-            if profile.get("coverage") != "complete":
-                continue
             target = ROLE_TARGETS[role]
             logical_path = f"vectors/{target}.arrow"
             output_path = reuse_root / f"{target}.arrow"

--- a/apps/api/sag_api/services/octx_transfer_service.py
+++ b/apps/api/sag_api/services/octx_transfer_service.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import hashlib
 import json
+import logging
 import math
 import shutil
 import time
@@ -79,6 +80,8 @@ from sag_api.services.octx_diagnostics_service import append_octx_trace
 
 if TYPE_CHECKING:
     from sag_api.jobs import JobQueue
+
+logger = logging.getLogger(__name__)
 
 
 _EXPORT_SNAPSHOT_RANGES = {
@@ -1647,36 +1650,28 @@ async def execute_export(
             source,
         )
 
-    # Vector export is an optional acceleration layer. Only reuse vectors when
-    # the source partition records the exact identity of the current embedding
-    # configuration. Export never calls the embedding provider: the descriptor
-    # below is metadata-only and vectors are read from the existing vector store.
+    # Vector export is a portable data layer, not a reuse decision. Always try
+    # to carry complete vectors from the source partition. The stored identity
+    # controls whether the profile is compatible or rebuild_required; importers
+    # make the final reuse decision and export never calls the embedding provider.
     from zleap.sag.db.models import SourceConfig
 
-    from sag_api.sag.octx_vector_protocol import embedding_identity
-
-    descriptor = embedding_client
-    if descriptor is None:
+    async with sag_session_factory() as sag_session:
+        source_config = await sag_session.get(SourceConfig, source.sag_source_config_id)
+    target_config = source_config.target_config if source_config is not None else None
+    stored_vector_identity = target_config.get("octx_vector_identity") if isinstance(target_config, dict) else None
+    if not isinstance(stored_vector_identity, dict):
+        stored_vector_identity = None
+    if vector_store is None:
         try:
-            from zleap.sag.core.ai.factory import get_embedding_client
+            from zleap.sag.core.storage.client import get_vector_client
 
-            descriptor = await get_embedding_client(scenario="general")
+            vector_store = get_vector_client()
         except Exception:
-            # Vector export is optional. Missing local model configuration must
-            # not block a valid structured-only OCTX export.
-            descriptor = None
-    current_vector_identity = embedding_identity(descriptor) if descriptor is not None else None
-    trusted_vector_export = False
-    if current_vector_identity is not None:
-        async with sag_session_factory() as sag_session:
-            source_config = await sag_session.get(SourceConfig, source.sag_source_config_id)
-        target_config = source_config.target_config if source_config is not None else None
-        stored_vector_identity = target_config.get("octx_vector_identity") if isinstance(target_config, dict) else None
-        trusted_vector_export = stored_vector_identity == current_vector_identity
-    if trusted_vector_export and vector_store is None:
-        from zleap.sag.core.storage.client import get_vector_client
-
-        vector_store = get_vector_client()
+            # Missing vector storage must not block a valid structured export,
+            # but the degradation must stay diagnosable in task logs.
+            logger.warning("OCTX export vector storage unavailable; exporting structured data only", exc_info=True)
+            vector_store = None
 
     async def save_export_progress(detail: dict[str, Any]) -> None:
         await _ensure_transfer_active(session, transfer, stage=str(detail.get("phase") or "export"))
@@ -1704,8 +1699,9 @@ async def execute_export(
             selected_article_ids=selected_article_ids,
             producer_state_path=producer_ids,
             session_factory=sag_session_factory,
-            vector_store=vector_store if trusted_vector_export else None,
-            embedding_client=descriptor if trusted_vector_export else None,
+            vector_store=vector_store,
+            embedding_client=None,
+            vector_identity=stored_vector_identity,
             on_progress=save_export_progress,
         )
     await _ensure_transfer_active(session, transfer, stage="after_snapshot")

--- a/apps/api/tests/test_octx_transfer_service.py
+++ b/apps/api/tests/test_octx_transfer_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from io import BytesIO
 
 import pytest
@@ -445,12 +446,12 @@ async def test_structured_import_activates_source_only_after_shadow_is_ready(tra
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("trusted_vectors", [True, False])
+@pytest.mark.parametrize("stored_identity_model", ["test/embedding", "previous/embedding", None])
 @pytest.mark.parametrize("export_scope", ["source", "document"])
 async def test_export_transfer_builds_immutable_fully_validated_release(
     transfer_sessions,
     tmp_path,
-    trusted_vectors,
+    stored_identity_model,
     export_scope,
 ):
     from contextlib import asynccontextmanager
@@ -516,18 +517,23 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
     entity_id = str(__import__("uuid").uuid4())
     type_id = str(__import__("uuid").uuid4())
     async with sag_sessions() as sag_session:
-        vector_identity = embedding_identity(
-            SimpleNamespace(
-                model="test/embedding" if trusted_vectors else "previous/embedding",
-                base_url="https://embedding.invalid/v1",
-                dimensions=2,
+        vector_identity = (
+            embedding_identity(
+                SimpleNamespace(
+                    model=stored_identity_model,
+                    base_url="https://embedding.invalid/v1",
+                    dimensions=2,
+                )
             )
+            if stored_identity_model is not None
+            else None
         )
+        target_config = {"octx_vector_identity": vector_identity} if vector_identity is not None else {}
         sag_session.add(
             SourceConfig(
                 id="src_export",
                 name="Export",
-                target_config={"octx_vector_identity": vector_identity},
+                target_config=target_config,
             )
         )
         sag_session.add(
@@ -695,7 +701,14 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
             with open_octx(artifact) as package:
                 assert package.manifest["capabilities"]["sag-structured"]["version"] == "0.1"
                 vector_capability = package.manifest["capabilities"].get("vectors")
-                assert (vector_capability or {}).get("version") == ("0.1" if trusted_vectors else None)
+                assert (vector_capability or {}).get("version") == "0.1"
+                profiles = json.loads(package.read_payload("vectors/profiles.json"))["profiles"]
+                if stored_identity_model is None:
+                    assert {profile["reuse_policy"] for profile in profiles} == {"rebuild_required"}
+                    assert all("model" not in profile and "fingerprint" not in profile for profile in profiles)
+                else:
+                    assert {profile.get("reuse_policy", "compatible") for profile in profiles} == {"compatible"}
+                    assert {profile["model"] for profile in profiles} == {stored_identity_model}
                 assert len(list(package.iter_documents())) == 1
             validation = validate_octx(artifact)
             assert validation.valid and validation.fully_validated
@@ -748,7 +761,7 @@ async def test_export_transfer_builds_immutable_fully_validated_release(
                 "event_entities": 1,
             }
 
-            if trusted_vectors:
+            if stored_identity_model == "test/embedding":
 
                 class NoRoundTripEmbedding:
                     model = "test/embedding"

--- a/apps/api/tests/test_octx_vector_protocol.py
+++ b/apps/api/tests/test_octx_vector_protocol.py
@@ -349,7 +349,7 @@ async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_mismatch(tmp_p
     assert embedding.calls == [["Head\n\nBody"]]
 
 
-async def test_partial_coverage_role_is_rebuilt_while_complete_roles_reuse(tmp_path: Path) -> None:
+async def test_partial_coverage_role_reuses_available_rows_and_rebuilds_missing(tmp_path: Path) -> None:
     from octx import vector_profile_fingerprint
 
     from sag_api.sag.octx_importer import build_structured_plan
@@ -388,9 +388,9 @@ async def test_partial_coverage_role_is_rebuilt_while_complete_roles_reuse(tmp_p
             return [[0.4, 0.5, 0.6] for _ in texts]
 
     embedding = Embedding()
-    # Current policy: partial coverage roles are rebuilt as a whole role; only
-    # complete roles participate in reuse.
-    assert prepare_vector_reuse(package, plan_path, embedding) == {"chunk.heading"}
+    # Compatible partial coverage should index the available rows so only the
+    # missing records are regenerated.
+    assert prepare_vector_reuse(package, plan_path, embedding) == {"chunk.heading", "chunk.content"}
 
     from sag_api.sag.octx_vector_rebuilder import _vectors_for_role
 
@@ -415,8 +415,8 @@ async def test_partial_coverage_role_is_rebuilt_while_complete_roles_reuse(tmp_p
         embedding,
         plan_path=plan_path,
     )
-    assert regenerated_content == [[0.4, 0.5, 0.6], [0.4, 0.5, 0.6]]
-    assert embedding.calls == [["Head\n\nBody", "Head2\n\nBody2"]]
+    assert regenerated_content == [pytest.approx([0.1, 0.2, 0.3]), pytest.approx([0.4, 0.5, 0.6])]
+    assert embedding.calls == [["Head2\n\nBody2"]]
 
 
 async def test_import_reuses_declared_roles_and_rebuilds_undeclared_roles(tmp_path: Path) -> None:

--- a/apps/api/tests/test_octx_vector_protocol.py
+++ b/apps/api/tests/test_octx_vector_protocol.py
@@ -27,6 +27,75 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
     path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
 
 
+def _transport_only_vector_package(tmp_path: Path) -> Path:
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+
+    document_id = "019c1234-5678-7abc-8def-0123456789ab"
+    chunk_id = "019c2222-2222-7222-8222-222222222222"
+    source = tmp_path / "transport-source"
+    source.mkdir()
+    (source / "guide.md").write_text(
+        f"---\ntype: Reference\ntitle: Guide\noctx:\n  document_id: {document_id}\n---\n# Guide\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "transport-workspace"
+    create_octx(workspace, source=source, name="Transport vectors", output=tmp_path / "transport-base.octx")
+    _write_jsonl(
+        workspace / "data/chunks.jsonl",
+        [{"id": chunk_id, "document_id": document_id, "ordinal": 0, "heading": "Head", "text": "Body"}],
+    )
+    _write_jsonl(workspace / "data/events.jsonl", [])
+    _write_jsonl(workspace / "data/entities.jsonl", [])
+    _write_jsonl(workspace / "relations/chunk-events.jsonl", [])
+    _write_jsonl(workspace / "relations/event-entities.jsonl", [])
+    vectors = workspace / "vectors"
+    vectors.mkdir()
+    profile = {
+        "role": "chunk.content",
+        "reuse_policy": "rebuild_required",
+        "dimensions": 3,
+        "dtype": "float32",
+        "coverage": "complete",
+        "recipe_id": "sag.chunk-content/1",
+        "recipe": {
+            "fields": ["heading", "text"],
+            "separator": "\n\n",
+            "encoding": "UTF-8",
+            "unicode_normalization": "NFC",
+            "newline": "LF",
+            "null_as": "",
+            "trim": False,
+        },
+        "input_hash_algorithm": "sha256",
+    }
+    (vectors / "profiles.json").write_text(json.dumps({"profiles": [profile]}) + "\n", encoding="utf-8")
+    schema = pa.schema(
+        [
+            pa.field("record_id", pa.string(), nullable=False),
+            pa.field("input_sha256", pa.string(), nullable=False),
+            pa.field("vector", pa.list_(pa.float32(), 3), nullable=False),
+        ]
+    )
+    table = pa.Table.from_arrays(
+        [
+            pa.array([chunk_id]),
+            pa.array([input_sha256("Head\n\nBody")]),
+            pa.array([[0.1, 0.2, 0.3]], type=pa.list_(pa.float32(), 3)),
+        ],
+        schema=schema,
+    )
+    with pa.OSFile(str(vectors / "chunk_content.arrow"), "wb") as output:
+        with ipc.new_file(output, schema) as writer:
+            writer.write_table(table)
+    return create_octx(
+        workspace,
+        version="1.1.0",
+        output=tmp_path / "transport-only.octx",
+        capabilities={"sag-structured": "0.1", "vectors": "0.1"},
+    ).output
+
+
 def test_role_input_is_canonical_across_unicode_and_newlines() -> None:
     record = {"heading": "Cafe\u0301\r\nTitle", "text": "Body\rLine"}
 
@@ -63,6 +132,479 @@ def test_embedding_identity_distinguishes_service_endpoints_without_exposing_the
 
     assert first_identity != second_identity
     assert "base_url" not in first_identity
+
+
+def test_malformed_stored_identity_falls_back_to_rebuild_required_profile() -> None:
+    from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
+
+    profile = vector_profile_from_identity(
+        "chunk.content",
+        {
+            "model": "legacy/embedding",
+            "model_fingerprint": "legacy-fingerprint",
+            "dimensions": "not-a-number",
+            "dtype": "float32",
+            "normalized": False,
+        },
+        3,
+    )
+
+    assert profile["reuse_policy"] == "rebuild_required"
+    assert "model" not in profile
+
+
+async def test_prepare_vector_reuse_skips_rebuild_required_profiles(tmp_path: Path) -> None:
+    from sag_api.sag.octx_importer import build_structured_plan
+    from sag_api.sag.octx_vector_rebuilder import _vectors_for_role
+
+    package = _transport_only_vector_package(tmp_path)
+    plan_path = tmp_path / "transport-only-plan.sqlite3"
+    build_structured_plan(package, plan_path, str(uuid.uuid4()))
+
+    class Embedding:
+        model = "test/embedding"
+        base_url = "https://embedding.invalid/v1"
+        dimensions = 3
+
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def batch_generate(self, texts):
+            self.calls.append(list(texts))
+            return [[0.4, 0.5, 0.6] for _ in texts]
+
+    embedding = Embedding()
+    assert prepare_vector_reuse(package, plan_path, embedding) == set()
+    generated = await _vectors_for_role(
+        "chunk.content",
+        [SimpleNamespace(extra_data={"octx": {"record_id": "019c2222-2222-7222-8222-222222222222"}})],
+        ["Head\n\nBody"],
+        embedding,
+        plan_path=plan_path,
+    )
+
+    assert generated == [[0.4, 0.5, 0.6]]
+    assert embedding.calls == [["Head\n\nBody"]]
+
+
+def _compatible_reuse_package(
+    tmp_path: Path,
+    *,
+    name: str,
+    profiles: list[dict],
+    arrow_rows: dict[str, list[tuple[str, list[float]]]],
+    dimensions: int = 3,
+    chunk_count: int = 1,
+) -> Path:
+    """Build a sag-structured package whose declared vector profiles are *compatible*.
+
+    Structured data contains `chunk_count` chunks, one event, one entity and one
+    event-entity relation; only the first chunk relates to the event. Arrow rows
+    are written with input_sha256 values computed from the same records so reuse
+    indexing accepts them.
+    """
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+
+    from sag_api.sag.octx_vector_protocol import ROLE_RECIPES, ROLE_TARGETS, render_recipe_input
+
+    document_id = "019c1234-5678-7abc-8def-0123456789ab"
+    chunk_ids = ["019c2222-2222-7222-8222-222222222222", "019c3333-3333-7333-8333-333333333333"][:chunk_count]
+    event_id = "019c4444-4444-7444-8444-444444444444"
+    entity_id = "019c5555-5555-7555-8555-555555555555"
+    source = tmp_path / f"{name}-source"
+    source.mkdir()
+    (source / "guide.md").write_text(
+        f"---\ntype: Reference\ntitle: Guide\noctx:\n  document_id: {document_id}\n---\n# Guide\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / f"{name}-workspace"
+    create_octx(workspace, source=source, name=name, output=tmp_path / f"{name}-base.octx")
+    chunk_records = {
+        chunk_id: {
+            "id": chunk_id,
+            "document_id": document_id,
+            "ordinal": index,
+            "heading": f"Head{index or ''}",
+            "text": f"Body{index or ''}",
+        }
+        for index, chunk_id in enumerate(chunk_ids)
+    }
+    _write_jsonl(workspace / "data/chunks.jsonl", list(chunk_records.values()))
+    _write_jsonl(
+        workspace / "data/events.jsonl",
+        [{"id": event_id, "title": "Event", "content": "Event body"}],
+    )
+    _write_jsonl(workspace / "data/entities.jsonl", [{"id": entity_id, "name": "Entity", "type": "term"}])
+    _write_jsonl(workspace / "relations/chunk-events.jsonl", [{"chunk_id": chunk_ids[0], "event_id": event_id}])
+    _write_jsonl(
+        workspace / "relations/event-entities.jsonl",
+        [{"event_id": event_id, "entity_id": entity_id}],
+    )
+
+    def record_for(role: str, record_id: str) -> dict:
+        if role.startswith("chunk."):
+            return chunk_records[record_id]
+        if role.startswith("event."):
+            return {"id": event_id, "title": "Event", "content": "Event body"}
+        if role == "entity.name":
+            return {"id": entity_id, "name": "Entity", "type": "term"}
+        return {
+            "event_id": event_id,
+            "entity_id": entity_id,
+            "event": {"id": event_id, "title": "Event", "content": "Event body"},
+            "entity": {"id": entity_id, "name": "Entity", "type": "term"},
+        }
+
+    vectors = workspace / "vectors"
+    vectors.mkdir()
+    (vectors / "profiles.json").write_text(json.dumps({"profiles": profiles}) + "\n", encoding="utf-8")
+    for role, rows in arrow_rows.items():
+        target = ROLE_TARGETS[role]
+        recipe = ROLE_RECIPES[role]
+        hashes = [
+            input_sha256(render_recipe_input(recipe, record_for(role, record_id)))
+            for record_id, _vector in rows
+        ]
+        schema = pa.schema(
+            [
+                pa.field("record_id", pa.string(), nullable=False),
+                pa.field("input_sha256", pa.string(), nullable=False),
+                pa.field("vector", pa.list_(pa.float32(), dimensions), nullable=False),
+            ]
+        )
+        table = pa.Table.from_arrays(
+            [
+                pa.array([record_id for record_id, _vector in rows]),
+                pa.array(hashes),
+                pa.array([vector for _record_id, vector in rows], type=pa.list_(pa.float32(), dimensions)),
+            ],
+            schema=schema,
+        )
+        with pa.OSFile(str(vectors / f"{target}.arrow"), "wb") as output:
+            with ipc.new_file(output, schema) as writer:
+                writer.write_table(table)
+    return create_octx(
+        workspace,
+        version="1.1.0",
+        output=tmp_path / f"{name}.octx",
+        capabilities={"sag-structured": "0.1", "vectors": "0.1"},
+    ).output
+
+
+def _compatible_identity(dimensions: int) -> dict:
+    from sag_api.sag.octx_vector_protocol import embedding_identity
+
+    return embedding_identity(
+        SimpleNamespace(
+            model="test/embedding",
+            base_url="https://embedding.invalid/v1",
+            dimensions=dimensions,
+        )
+    )
+
+
+async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_mismatch(tmp_path: Path) -> None:
+    from sag_api.sag.octx_importer import build_structured_plan
+    from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
+
+    chunk_id = "019c2222-2222-7222-8222-222222222222"
+    profile = vector_profile_from_identity("chunk.content", _compatible_identity(3), 3)
+    package = _compatible_reuse_package(
+        tmp_path,
+        name="dim-mismatch",
+        profiles=[profile],
+        arrow_rows={"chunk.content": [(chunk_id, [0.1, 0.2, 0.3])]},
+    )
+    assert validate_octx(package).capabilities["vectors"].valid
+    plan_path = tmp_path / "dim-mismatch-plan.sqlite3"
+    build_structured_plan(package, plan_path, str(uuid.uuid4()))
+
+    class TwoDimEmbedding:
+        model = "test/embedding"
+        base_url = "https://embedding.invalid/v1"
+        dimensions = 2
+
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def batch_generate(self, texts):
+            self.calls.append(list(texts))
+            return [[0.4, 0.5] for _ in texts]
+
+    embedding = TwoDimEmbedding()
+    # A dimension mismatch must disable reuse without crashing the import.
+    assert prepare_vector_reuse(package, plan_path, embedding) == set()
+
+    from sag_api.sag.octx_vector_rebuilder import _vectors_for_role
+
+    regenerated = await _vectors_for_role(
+        "chunk.content",
+        [SimpleNamespace(extra_data={"octx": {"record_id": chunk_id}})],
+        ["Head\n\nBody"],
+        embedding,
+        plan_path=plan_path,
+    )
+    assert regenerated == [[0.4, 0.5]]
+    assert embedding.calls == [["Head\n\nBody"]]
+
+
+async def test_partial_coverage_role_is_rebuilt_while_complete_roles_reuse(tmp_path: Path) -> None:
+    from octx import vector_profile_fingerprint
+
+    from sag_api.sag.octx_importer import build_structured_plan
+    from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
+
+    chunk_id = "019c2222-2222-7222-8222-222222222222"
+    chunk2_id = "019c3333-3333-7333-8333-333333333333"
+    heading_profile = vector_profile_from_identity("chunk.heading", _compatible_identity(3), 3)
+    content_profile = vector_profile_from_identity("chunk.content", _compatible_identity(3), 3)
+    content_profile["coverage"] = "partial"
+    content_profile["fingerprint"] = vector_profile_fingerprint(content_profile)
+    package = _compatible_reuse_package(
+        tmp_path,
+        name="partial-coverage",
+        profiles=[heading_profile, content_profile],
+        arrow_rows={
+            "chunk.heading": [(chunk_id, [0.1, 0.2, 0.3]), (chunk2_id, [0.2, 0.3, 0.4])],
+            "chunk.content": [(chunk_id, [0.1, 0.2, 0.3])],
+        },
+        chunk_count=2,
+    )
+    assert validate_octx(package).capabilities["vectors"].valid
+    plan_path = tmp_path / "partial-coverage-plan.sqlite3"
+    build_structured_plan(package, plan_path, str(uuid.uuid4()))
+
+    class Embedding:
+        model = "test/embedding"
+        base_url = "https://embedding.invalid/v1"
+        dimensions = 3
+
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def batch_generate(self, texts):
+            self.calls.append(list(texts))
+            return [[0.4, 0.5, 0.6] for _ in texts]
+
+    embedding = Embedding()
+    # Current policy: partial coverage roles are rebuilt as a whole role; only
+    # complete roles participate in reuse.
+    assert prepare_vector_reuse(package, plan_path, embedding) == {"chunk.heading"}
+
+    from sag_api.sag.octx_vector_rebuilder import _vectors_for_role
+
+    records = [
+        SimpleNamespace(extra_data={"octx": {"record_id": chunk_id}}),
+        SimpleNamespace(extra_data={"octx": {"record_id": chunk2_id}}),
+    ]
+    reused_heading = await _vectors_for_role(
+        "chunk.heading",
+        records,
+        ["Head", "Head2"],
+        embedding,
+        plan_path=plan_path,
+    )
+    assert reused_heading == [pytest.approx([0.1, 0.2, 0.3]), pytest.approx([0.2, 0.3, 0.4])]
+    assert embedding.calls == []
+
+    regenerated_content = await _vectors_for_role(
+        "chunk.content",
+        records,
+        ["Head\n\nBody", "Head2\n\nBody2"],
+        embedding,
+        plan_path=plan_path,
+    )
+    assert regenerated_content == [[0.4, 0.5, 0.6], [0.4, 0.5, 0.6]]
+    assert embedding.calls == [["Head\n\nBody", "Head2\n\nBody2"]]
+
+
+async def test_import_reuses_declared_roles_and_rebuilds_undeclared_roles(tmp_path: Path) -> None:
+    from sag_api.sag.octx_importer import build_structured_plan, import_structured_plan
+    from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
+    from sag_api.sag.octx_vector_rebuilder import rebuild_vectors
+
+    chunk_id = "019c2222-2222-7222-8222-222222222222"
+    identity = _compatible_identity(3)
+    profiles = [
+        vector_profile_from_identity("chunk.heading", identity, 3),
+        vector_profile_from_identity("chunk.content", identity, 3),
+    ]
+    package = _compatible_reuse_package(
+        tmp_path,
+        name="partial-roles",
+        profiles=profiles,
+        arrow_rows={
+            "chunk.heading": [(chunk_id, [0.1, 0.2, 0.3])],
+            "chunk.content": [(chunk_id, [0.1, 0.2, 0.3])],
+        },
+    )
+    assert validate_octx(package).capabilities["vectors"].valid
+
+    class TrackingEmbedding:
+        model = "test/embedding"
+        base_url = "https://embedding.invalid/v1"
+        dimensions = 3
+
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def batch_generate(self, texts):
+            self.calls.append(list(texts))
+            return [[0.4, 0.5, 0.6] for _ in texts]
+
+    embedding = TrackingEmbedding()
+    plan_path = tmp_path / "partial-roles-plan.sqlite3"
+    namespace = str(uuid.uuid4())
+    build_structured_plan(package, plan_path, namespace)
+    assert prepare_vector_reuse(package, plan_path, embedding) == {"chunk.heading", "chunk.content"}
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from zleap.sag.db.base import Base
+
+    class VectorStore:
+        indexes: list[str] = []
+
+        def __init__(self) -> None:
+            self.documents: dict[str, list[dict]] = {}
+
+        async def bulk_index(self, *, index, documents, return_details, routing):
+            assert routing == "shadow-partial-roles"
+            self.indexes.append(index)
+            self.documents.setdefault(index, []).extend(documents)
+            return {"success_count": len(documents), "error_count": 0}
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'partial-roles-sag.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    await import_structured_plan(
+        plan_path,
+        namespace,
+        source_config_id="shadow-partial-roles",
+        source_name="Shadow",
+        session_factory=sessions,
+    )
+    store = VectorStore()
+    try:
+        stats = await rebuild_vectors(
+            "shadow-partial-roles",
+            {},
+            session_factory=sessions,
+            embedding_client=embedding,
+            vector_store=store,
+            package_path=package,
+            plan_path=plan_path,
+        )
+    finally:
+        await engine.dispose()
+
+    assert stats == {"chunks": 1, "events": 1, "entities": 1, "event_entities": 1}
+    assert store.indexes == ["source_chunks", "event_vectors", "entity_vectors", "event_entity_vectors"]
+    # Declared chunk roles are reused: no embedding call and stored vectors
+    # match the package payload.
+    assert store.documents["source_chunks"][0]["heading_vector"] == pytest.approx([0.1, 0.2, 0.3])
+    assert store.documents["source_chunks"][0]["content_vector"] == pytest.approx([0.1, 0.2, 0.3])
+    # Undeclared roles are rebuilt through the embedding provider.
+    assert embedding.calls == [
+        ["Event"],
+        ["Event\n\nEvent body"],
+        ["Entity"],
+        ["Event\n\nEntity"],
+    ]
+
+
+def test_export_profile_is_rebuild_required_when_stored_dimensions_disagree() -> None:
+    from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
+
+    # The stored identity claims 3 dimensions but the role really holds 2:
+    # the identity is no longer provable, so the profile must degrade to
+    # rebuild_required instead of claiming compatibility.
+    profile = vector_profile_from_identity("chunk.content", _compatible_identity(3), 2)
+
+    assert profile["reuse_policy"] == "rebuild_required"
+    assert "model" not in profile
+    assert "fingerprint" not in profile
+
+
+async def test_rebuild_vectors_falls_back_to_generation_when_reuse_preparation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from zleap.sag.db.models import SourceChunk, SourceConfig
+
+    from sag_api.sag import octx_vector_reuse
+    from sag_api.sag.octx_vector_rebuilder import rebuild_vectors
+
+    def broken_prepare(*_args, **_kwargs):
+        raise OSError("temporary vector payload disappeared")
+
+    monkeypatch.setattr(octx_vector_reuse, "prepare_vector_reuse", broken_prepare)
+
+    class TrackingEmbedding:
+        model = "test/embedding"
+        base_url = "https://embedding.invalid/v1"
+        dimensions = 3
+
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def batch_generate(self, texts):
+            self.calls.append(list(texts))
+            return [[0.4, 0.5, 0.6] for _ in texts]
+
+    class VectorStore:
+        def __init__(self) -> None:
+            self.indexes: list[str] = []
+
+        async def bulk_index(self, *, index, documents, return_details, routing):
+            self.indexes.append(index)
+            return {"success_count": len(documents), "error_count": 0}
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from zleap.sag.db.base import Base
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'fallback-sag.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    async with sessions() as session:
+        session.add(SourceConfig(id="src-fallback", name="Fallback", target_config={}))
+        session.add(
+            SourceChunk(
+                id="019c2222-2222-7222-8222-222222222222",
+                source_config_id="src-fallback",
+                source_type="article",
+                source_id="article-fallback",
+                heading="Head",
+                content="Body",
+                rank=0,
+                chunk_length=8,
+            )
+        )
+        await session.commit()
+
+    embedding = TrackingEmbedding()
+    store = VectorStore()
+    checkpoint: dict = {}
+    try:
+        stats = await rebuild_vectors(
+            "src-fallback",
+            checkpoint,
+            session_factory=sessions,
+            embedding_client=embedding,
+            vector_store=store,
+            package_path=tmp_path / "unused.octx",
+            plan_path=tmp_path / "unused-plan.sqlite3",
+        )
+    finally:
+        await engine.dispose()
+
+    assert stats == {"chunks": 1, "events": 0, "entities": 0, "event_entities": 0}
+    assert store.indexes == ["source_chunks"]
+    assert checkpoint["reusable_roles"] == []
+    # The failure degraded to a full generation path instead of crashing.
+    assert embedding.calls == [["Head\n\nBody"], ["Head"]]
 
 
 def test_vector_arrow_conversion_reuses_float_lists_without_flattening_them() -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -2012,7 +2012,7 @@ wheels = [
 
 [[package]]
 name = "octx"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
@@ -2020,9 +2020,9 @@ dependencies = [
     { name = "rfc8785" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1fbcab4975470f33558ef8bdc554e9b5200a4f92360e490947b828bd6/octx-0.1.4.tar.gz", hash = "sha256:8223109954e723d3953e40d49afbecee07eebfd342928f51c9340adf392fdaf9", size = 175665, upload-time = "2026-08-12T11:56:57.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/57/22696b57f7a6a62de1310908485727a16dc694b1f3940afc9cab9423846b/octx-0.1.5.tar.gz", hash = "sha256:4ad009250f8b0692e2f10804600406a341ff445f6acb390186cd31cc51357859", size = 177714, upload-time = "2026-08-14T07:53:50.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/66/ba11bf61eb5299e33fe32224234d109a2bd4a2a92be63f170b3cb0aac0de/octx-0.1.4-py3-none-any.whl", hash = "sha256:58115fe65e17441d842580fe0aaafcdc2cba39731e393586f0d691aac3fa3509", size = 81256, upload-time = "2026-08-12T11:56:55.708Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/eb/9da1461699dfbdfa19517dbb8eb7a2d0ccef40e1bf9611b0435a2f009227/octx-0.1.5-py3-none-any.whl", hash = "sha256:568cdece2bddda6620cee16d763f0a1c0b38ad33a34d810b2b63108542563947", size = 81933, upload-time = "2026-08-14T07:53:49.122Z" },
 ]
 
 [package.optional-dependencies]
@@ -3349,7 +3349,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.92,<2" },
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xls", "xlsx"], specifier = ">=0.1.6,<0.2" },
     { name = "mcp", specifier = ">=1.28,<2" },
-    { name = "octx", extras = ["vectors"], specifier = "==0.1.4" },
+    { name = "octx", extras = ["vectors"], specifier = "==0.1.5" },
     { name = "orjson", specifier = ">=3.11.6,<4" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.3" },

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -2012,7 +2012,7 @@ wheels = [
 
 [[package]]
 name = "octx"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
@@ -2020,9 +2020,9 @@ dependencies = [
     { name = "rfc8785" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/57/22696b57f7a6a62de1310908485727a16dc694b1f3940afc9cab9423846b/octx-0.1.5.tar.gz", hash = "sha256:4ad009250f8b0692e2f10804600406a341ff445f6acb390186cd31cc51357859", size = 177714, upload-time = "2026-08-14T07:53:50.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/99/bc1e62ddd5e0c528b8d1981ba3279a2edae4fc2d0560df83f5321ed9ae9d/octx-0.1.6.tar.gz", hash = "sha256:ce71113859795c92d0f0936f8a473dc666a1ba79fa769b6afc3a582cf09c41a0", size = 179327, upload-time = "2026-08-18T03:01:47.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/eb/9da1461699dfbdfa19517dbb8eb7a2d0ccef40e1bf9611b0435a2f009227/octx-0.1.5-py3-none-any.whl", hash = "sha256:568cdece2bddda6620cee16d763f0a1c0b38ad33a34d810b2b63108542563947", size = 81933, upload-time = "2026-08-14T07:53:49.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/cc/58c51a31703e611ed5a636e8f315a810d10da9b17ccaee5cd5f191365616/octx-0.1.6-py3-none-any.whl", hash = "sha256:21f5f65ceed84b0a421969f21406244402caa6b7d03ee4583ed1e6996ba56a7e", size = 82815, upload-time = "2026-08-18T03:01:44.618Z" },
 ]
 
 [package.optional-dependencies]
@@ -3349,7 +3349,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.92,<2" },
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xls", "xlsx"], specifier = ">=0.1.6,<0.2" },
     { name = "mcp", specifier = ">=1.28,<2" },
-    { name = "octx", extras = ["vectors"], specifier = "==0.1.5" },
+    { name = "octx", extras = ["vectors"], specifier = "==0.1.6" },
     { name = "orjson", specifier = ">=3.11.6,<4" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.3" },


### PR DESCRIPTION
## 改动范围
- [OCTX 依赖]：将 API 依赖和锁文件更新到已发布的 `octx==0.1.6`，不使用本地路径依赖。
- [向量导出]：导出已有向量时根据历史身份声明 `compatible` 或 `rebuild_required`，无法确认身份时保留向量数据，不阻塞结构化导出。
- [向量导入复用]：支持 `coverage: partial`，复用包内已有记录，仅为缺失记录重新生成向量。
- [测试]：补充 partial 向量复用与缺失记录重建验证。

## 影响功能范围
- [OCTX 导入导出]：兼容向量可跳过 Embedding；身份未知或不兼容的向量按角色安全重建。
- [兼容性]：保留旧 Profile 和无向量包的导入行为，不改变 SAG 数据库结构、影子分区和索引构建流程。
- [校验边界]：继续校验向量维度、记录引用、Arrow 完整性、哈希格式和覆盖率，不放宽数据完整性校验。

## 测试覆盖情况
- 通过：`pytest -q -k 'octx'`，130 passed，覆盖 OCTX 导入导出、向量协议、复用和重建路径。
- 通过：`pytest -q`，512 passed，1 skipped。
- 通过：修改文件 Ruff 检查。
- CI：待远程 CI 执行。
