### PR TITLE
fix(desktop): 稳定重启端口并明确更新签名错误

### DIFF
--- a/apps/desktop/src/runtime-state.ts
+++ b/apps/desktop/src/runtime-state.ts
@@ -45,6 +45,41 @@ function isValidPort(value: unknown): value is number {
     && value <= 65535;
 }
 
+// The persisted port is the desktop app's stable browser origin. When it is busy
+// at launch it is almost always our own just-exited instance still releasing the
+// socket, so poll for it to free before giving up. ~5s total (20 * 250ms) covers
+// a normal shutdown/relaunch race without noticeably delaying a cold start (the
+// happy path returns on the first check).
+const DEFAULT_REUSE_ATTEMPTS = 20;
+const DEFAULT_REUSE_POLL_MS = 250;
+
+export interface ResolveWebPortOptions {
+  /** Extra availability checks after the first before treating the port as foreign-held. */
+  reuseAttempts?: number;
+  /** Delay between reuse attempts, in milliseconds. */
+  reusePollMs?: number;
+  /** Injectable sleep so tests stay fast and deterministic. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function reclaimPersistedPort(
+  port: number,
+  isAvailable: PortAvailability,
+  attempts: number,
+  pollMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<boolean> {
+  for (let attempt = 0; ; attempt += 1) {
+    if (await isAvailable(port)) return true;
+    if (attempt >= attempts) return false;
+    await sleep(pollMs);
+  }
+}
+
 export function loadOrCreateRuntimeSecret(userDataDir: string): string {
   const existing = readRuntimeState(userDataDir);
   if (existing) return existing.secretKey;
@@ -57,10 +92,37 @@ export async function resolveStableWebPort(
   userDataDir: string,
   preferredPort: number,
   isAvailable: PortAvailability,
+  options: ResolveWebPortOptions = {},
 ): Promise<number> {
+  const {
+    reuseAttempts = DEFAULT_REUSE_ATTEMPTS,
+    reusePollMs = DEFAULT_REUSE_POLL_MS,
+    sleep = delay,
+  } = options;
   const existing = readRuntimeState(userDataDir);
-  if (isValidPort(existing?.webPort) && (await isAvailable(existing.webPort))) {
-    return existing.webPort;
+  if (isValidPort(existing?.webPort)) {
+    // Keep the browser origin (localhost:<port>) stable across launches. The
+    // login cookie (sag_token_<port>) and onboarding/model-setup localStorage are
+    // isolated per origin, so drifting to a new port silently logs the user out
+    // and makes the app demand model reconfiguration every launch. Wait for our
+    // own prior instance to release the socket rather than switching ports.
+    if (
+      await reclaimPersistedPort(
+        existing.webPort,
+        isAvailable,
+        reuseAttempts,
+        reusePollMs,
+        sleep,
+      )
+    ) {
+      return existing.webPort;
+    }
+    // Still held after the grace window: a foreign process owns the port. Fail
+    // loudly instead of drifting to a new origin and dropping the user's config.
+    throw new Error(
+      `Persisted desktop web port ${existing.webPort} is held by another process. `
+      + "Close whatever is using it and relaunch SAG.",
+    );
   }
 
   for (

--- a/apps/desktop/src/runtime.ts
+++ b/apps/desktop/src/runtime.ts
@@ -154,6 +154,7 @@ export async function startPackagedRuntime(): Promise<ManagedRuntime> {
     desktopConfig.preferredWebPort,
     (port) => isPortAvailable(host, port),
   );
+  log.info(`Resolved stable web port ${webPort} (origin http://localhost:${webPort})`);
   const webHealthUrl = `http://${host}:${webPort}`;
   // Next.js standalone normalizes redirects to localhost. Use that as the UI
   // origin while keeping the actual listener restricted to 127.0.0.1.

--- a/apps/desktop/src/updater-error.ts
+++ b/apps/desktop/src/updater-error.ts
@@ -1,0 +1,42 @@
+import type { UpdateState } from "./channels";
+
+const OFFICIAL_RELEASE_URL = "https://github.com/Zleap-AI/SAG/releases/latest";
+
+export interface UpdaterErrorPresentation {
+  kind: "signature-mismatch" | "generic";
+  title: string;
+  message: string;
+  detail: string;
+  actionLabel?: string;
+  actionUrl?: string;
+}
+
+export function shouldPresentUpdaterError(previousState: UpdateState): boolean {
+  return previousState.status === "downloaded";
+}
+
+export function describeUpdaterError(error: unknown): UpdaterErrorPresentation {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const signatureMismatch = /code signature.*did not pass validation/i.test(errorMessage);
+
+  if (signatureMismatch) {
+    return {
+      kind: "signature-mismatch",
+      title: "无法自动更新",
+      message: "当前安装的 SAG 无法验证正式更新包的签名。",
+      detail:
+        "这通常发生在从本地测试版升级到正式签名版时。"
+        + "请从官方发布页下载最新版并覆盖安装一次；现有数据不会被删除，"
+        + "之后即可继续使用自动更新。",
+      actionLabel: "打开官方下载页",
+      actionUrl: OFFICIAL_RELEASE_URL,
+    };
+  }
+
+  return {
+    kind: "generic",
+    title: "更新失败",
+    message: "SAG 未能完成自动更新。",
+    detail: errorMessage || "未知错误，请导出诊断日志后重试。",
+  };
+}

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -1,12 +1,16 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import { app, type BrowserWindow, dialog } from "electron";
+import { app, type BrowserWindow, dialog, shell } from "electron";
 import log from "electron-log/main";
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from "electron-updater";
 
 import { DESKTOP_CHANNELS, type UpdateState } from "./channels";
 import { desktopConfig } from "./config";
+import {
+  describeUpdaterError,
+  shouldPresentUpdaterError,
+} from "./updater-error";
 
 export interface UpdaterController {
   check(): Promise<{ supported: boolean }>;
@@ -30,6 +34,31 @@ export function createUpdaterController(
     const window = getWindow();
     if (window && !window.isDestroyed()) {
       window.webContents.send(DESKTOP_CHANNELS.updateState, state);
+    }
+  };
+
+  const showUpdaterError = async (error: unknown): Promise<void> => {
+    const presentation = describeUpdaterError(error);
+    const window = getWindow();
+    if (!window || window.isDestroyed()) return;
+    const buttons = presentation.actionLabel
+      ? ["知道了", presentation.actionLabel]
+      : ["知道了"];
+    try {
+      const result = await dialog.showMessageBox(window, {
+        type: "error",
+        title: presentation.title,
+        message: presentation.message,
+        detail: presentation.detail,
+        buttons,
+        defaultId: presentation.actionLabel ? 1 : 0,
+        cancelId: 0,
+      });
+      if (presentation.actionUrl && result.response === 1) {
+        await shell.openExternal(presentation.actionUrl);
+      }
+    } catch (dialogError) {
+      log.error("Failed to present updater error", dialogError);
     }
   };
 
@@ -64,12 +93,15 @@ export function createUpdaterController(
     });
     autoUpdater.on("error", (error) => {
       log.error("Updater error", error);
+      const presentError = shouldPresentUpdaterError(currentState);
       publish({ status: "error", message: error.message });
+      if (presentError) void showUpdaterError(error);
     });
     autoUpdater.on("update-downloaded", async (info: UpdateInfo) => {
       publish({ status: "downloaded", version: info.version });
       const window = getWindow();
       if (!window || window.isDestroyed()) return;
+
       const result = await dialog.showMessageBox(window, {
         type: "info",
         title: "SAG 更新已就绪",
@@ -80,7 +112,13 @@ export function createUpdaterController(
         cancelId: 0,
       });
       if (result.response === 1) {
-        autoUpdater.quitAndInstall(false, true);
+        try {
+          log.info("Applying update via quitAndInstall(false, true)");
+          autoUpdater.quitAndInstall(false, true);
+        } catch (error) {
+          log.error("quitAndInstall failed", error);
+          await showUpdaterError(error);
+        }
       }
     });
 
@@ -99,8 +137,15 @@ export function createUpdaterController(
       if (!supported || currentState.status !== "downloaded") {
         return { started: false };
       }
-      autoUpdater.quitAndInstall(false, true);
-      return { started: true };
+      try {
+        log.info("Applying update via quitAndInstall(false, true)");
+        autoUpdater.quitAndInstall(false, true);
+        return { started: true };
+      } catch (error) {
+        log.error("quitAndInstall failed", error);
+        void showUpdaterError(error);
+        return { started: false };
+      }
     },
     dispose: () => {
       if (delayTimer) clearTimeout(delayTimer);

--- a/apps/desktop/tests/runtime-state.test.mts
+++ b/apps/desktop/tests/runtime-state.test.mts
@@ -37,3 +37,63 @@ test("reuses the persisted web port when the preferred port becomes free later",
     webPort: 32101,
   });
 });
+
+test("waits for a transiently-busy persisted port to free instead of drifting", async (t) => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "sag-runtime-state-"));
+  t.after(() => rmSync(userDataDir, { recursive: true, force: true }));
+  const stateFile = path.join(userDataDir, "desktop-runtime.json");
+  const secretKey = "s".repeat(96);
+  writeFileSync(stateFile, JSON.stringify({ secretKey, webPort: 32100 }));
+
+  // The prior instance still holds the socket for the first two checks, then
+  // releases it (the common quit->relaunch race).
+  let checks = 0;
+  const sleeps: number[] = [];
+  const resolved = await resolveStableWebPort(
+    userDataDir,
+    40000,
+    async () => {
+      checks += 1;
+      return checks > 2;
+    },
+    { reusePollMs: 5, sleep: async (ms) => { sleeps.push(ms); } },
+  );
+
+  assert.equal(resolved, 32100);
+  assert.equal(checks, 3);
+  assert.deepEqual(sleeps, [5, 5]);
+  // Origin must not drift: the persisted port is unchanged.
+  assert.deepEqual(JSON.parse(readFileSync(stateFile, "utf8")), {
+    secretKey,
+    webPort: 32100,
+  });
+});
+
+test("fails without suggesting an ineffective port override when the persisted port stays busy", async (t) => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "sag-runtime-state-"));
+  t.after(() => rmSync(userDataDir, { recursive: true, force: true }));
+  const stateFile = path.join(userDataDir, "desktop-runtime.json");
+  const secretKey = "s".repeat(96);
+  writeFileSync(stateFile, JSON.stringify({ secretKey, webPort: 32100 }));
+
+  await assert.rejects(
+    resolveStableWebPort(
+      userDataDir,
+      40000,
+      async () => false, // never frees
+      { reuseAttempts: 2, sleep: async () => {} },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /held by another process/);
+      assert.doesNotMatch(error.message, /SAG_DESKTOP_WEB_PORT/);
+      return true;
+    },
+  );
+
+  // No silent drift: the persisted origin is left untouched for a later retry.
+  assert.deepEqual(JSON.parse(readFileSync(stateFile, "utf8")), {
+    secretKey,
+    webPort: 32100,
+  });
+});

--- a/apps/desktop/tests/updater-error.test.mts
+++ b/apps/desktop/tests/updater-error.test.mts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  describeUpdaterError,
+  shouldPresentUpdaterError,
+} from "../src/updater-error.ts";
+
+test("guides signature-mismatched test builds to the official download", () => {
+  const presentation = describeUpdaterError(
+    new Error(
+      "Code signature at URL file:///tmp/SAG.app/ did not pass validation: "
+      + "代码未能满足指定的代码要求",
+    ),
+  );
+
+  assert.equal(presentation.kind, "signature-mismatch");
+  assert.match(presentation.message, /无法验证正式更新包的签名/);
+  assert.match(presentation.detail, /覆盖安装一次/);
+  assert.equal(
+    presentation.actionUrl,
+    "https://github.com/Zleap-AI/SAG/releases/latest",
+  );
+});
+
+test("keeps an unexpected updater error visible for diagnosis", () => {
+  const presentation = describeUpdaterError(new Error("network connection reset"));
+
+  assert.equal(presentation.kind, "generic");
+  assert.match(presentation.detail, /network connection reset/);
+  assert.equal(presentation.actionUrl, undefined);
+});
+
+test("presents errors after an update download without interrupting background checks", () => {
+  assert.equal(shouldPresentUpdaterError({ status: "downloaded" }), true);
+  assert.equal(shouldPresentUpdaterError({ status: "checking" }), false);
+  assert.equal(shouldPresentUpdaterError({ status: "downloading" }), false);
+});


### PR DESCRIPTION
## 改动范围
- 桌面端运行时：启动时等待并复用已持久化的 Web 端口；端口持续被占用时明确失败，避免浏览器 origin 静默漂移。
- 自动更新：根据真实的 Squirrel.Mac 签名校验错误展示官方下载和覆盖安装引导，并保留其他更新错误的诊断信息；后台定时检查失败不会主动弹窗打断用户。
- 测试：新增端口短暂占用、持续冲突、运行时状态保持、更新错误分类和错误展示时机的回归测试。

## 影响功能范围
- Electron 桌面端启动/重启：登录 Cookie、模型配置和 onboarding 所在的浏览器 origin 保持稳定。
- macOS 自动更新：本地临时签名版本无法跨签名自动升级时，用户可以看到真实原因和可执行的官方下载入口；该安全边界保持不变。
- 兼容性：未修改 API、数据库或 Web 端接口；未发现额外影响。

## 测试覆盖情况
- 通过：`cd apps/desktop && npm test`，6 个桌面端单元测试通过。
- 通过：`cd apps/desktop && npm run typecheck`，TypeScript 类型检查通过。
- 通过：`cd apps/desktop && npm run build`，桌面端编译及 preload 校验通过。
- CI：待远程 CI 执行。
