### PR TITLE
fix(fnos): 同步上传限制与模型配置入口

### DIFF
--- a/apps/web/components/features/quick-model-setup-dialog.test.tsx
+++ b/apps/web/components/features/quick-model-setup-dialog.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { expect, it, vi } from "vitest";
+
+import messages from "@/messages/zh-CN.json";
+import { QuickModelSetupDialog } from "./quick-model-setup-dialog";
+
+it("links first-time model configuration to the 302.cn portal", () => {
+  render(
+    <NextIntlClientProvider locale="zh-CN" messages={messages}>
+      <QuickModelSetupDialog open onOpenChange={vi.fn()} onConfigured={vi.fn()} />
+    </NextIntlClientProvider>,
+  );
+
+  expect(screen.getByRole("link", { name: "获取 API Key" })).toHaveAttribute(
+    "href",
+    "https://302ai.cn/",
+  );
+});

--- a/apps/web/components/features/quick-model-setup-dialog.tsx
+++ b/apps/web/components/features/quick-model-setup-dialog.tsx
@@ -135,7 +135,7 @@ export function QuickModelSetupDialog({
               <div className="flex items-center justify-between gap-2">
                 <FieldLabel htmlFor="quick-setup-api-key">302.AI API Key</FieldLabel>
                 <a
-                  href="https://302.ai/"
+                  href="https://302ai.cn/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"

--- a/apps/web/components/features/upload-zone.test.tsx
+++ b/apps/web/components/features/upload-zone.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { expect, it, vi } from "vitest";
+
+import messages from "@/messages/zh-CN.json";
+import { api } from "@/lib/api";
+import { UploadZone } from "./upload-zone";
+
+vi.mock("@/lib/api", async (original) => {
+  const actual = await original<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: { ...actual.api, uploadDocumentWithProgress: vi.fn() },
+  };
+});
+
+it("rejects an oversized file before starting its upload", async () => {
+  render(
+    <NextIntlClientProvider locale="zh-CN" messages={messages}>
+      <UploadZone sourceId="source-1" maxMb={1} onUploaded={vi.fn()} />
+    </NextIntlClientProvider>,
+  );
+
+  const file = new File(["x"], "too-large.pdf", { type: "application/pdf" });
+  Object.defineProperty(file, "size", { value: 1024 * 1024 + 1 });
+  fireEvent.change(screen.getByRole("button").querySelector("input")!, {
+    target: { files: [file] },
+  });
+
+  await waitFor(() => {
+    expect(vi.mocked(api.uploadDocumentWithProgress)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/features/upload-zone.tsx
+++ b/apps/web/components/features/upload-zone.tsx
@@ -49,6 +49,10 @@ export function UploadZone({
         toast.error(t("unsupportedType", { name: file.name }));
         continue;
       }
+      if (file.size > maxMb * 1024 * 1024) {
+        toast.error(t("fileTooLarge", { name: file.name, maxMb }));
+        continue;
+      }
       try {
         const idx = ok + 1;
         setProgress({ name: file.name, pct: 0, idx, total: files.length });

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -227,6 +227,7 @@
   },
   "UploadZone": {
     "unsupportedType": "{name}: Unsupported file type",
+    "fileTooLarge": "{name}: exceeds the {maxMb, number} MB file limit",
     "fileFailed": "{name}: {error}",
     "uploadFailed": "Upload failed",
     "uploaded": "{count, plural, one {# file uploaded} other {# files uploaded}}. Background processing has started.",

--- a/apps/web/messages/zh-CN.json
+++ b/apps/web/messages/zh-CN.json
@@ -227,6 +227,7 @@
   },
   "UploadZone": {
     "unsupportedType": "{name}：不支持的文件类型",
+    "fileTooLarge": "{name}：超过单文件 {maxMb, number}MB 上限",
     "fileFailed": "{name}：{error}",
     "uploadFailed": "上传失败",
     "uploaded": "已完成 {count, number} 个文件上传，已进入后台处理",


### PR DESCRIPTION
## 改动范围
- `UploadZone`：从 8 月 17 日 main 修复中同步单文件大小的客户端前置拦截，并补充中英文提示与回归测试。
- `QuickModelSetupDialog`：首次模型配置的 API Key 跳转地址改为 `https://302ai.cn/`，并补充链接回归测试。

## 影响功能范围
- 飞牛客户端上传超过系统单文件上限的文档时，不再发起无效上传请求。
- 首次模型配置会打开新的 302.AI 门户地址。
- 未同步桌面专属端口逻辑；DeepSeek 修复依赖的 schema-strengthening 调用链不在飞牛分支，未引入无效差异。

## 测试覆盖情况
- 通过：`npm run typecheck`、`npm run lint`、`npm run test:unit`（469 通过），覆盖飞牛 Web 变更及完整前端单测。
- 通过：`uv run --extra dev ruff check sag_api sag_agent tests`、`uv run --extra dev pytest -q`（560 通过，2 跳过），覆盖后端回归。
- 通过：`node --test scripts/tests/fnos-native-package.test.mjs scripts/tests/fnos-native-lifecycle.test.mjs scripts/tests/fnos-native-release-workflow.test.mjs scripts/tests/fnos-version.test.mjs`（78 通过，3 跳过）及 x86 FPK 本地构建。
- CI：待远程 CI 执行。
