### PR TITLE
fix(api): align official MinerU pause callback

### DIFF
--- a/apps/api/sag_api/parsing/mineru_official.py
+++ b/apps/api/sag_api/parsing/mineru_official.py
@@ -19,7 +19,7 @@ from sag_api.core.errors import (
     ValidationError,
 )
 from sag_api.parsing import mineru as mineru_core
-from sag_api.parsing.mineru import MinerU302Client, StateCallback
+from sag_api.parsing.mineru import MinerU302Client, ParsePaused, PauseCallback, StateCallback
 
 _PENDING_STATES = {"waiting-file", "pending", "running", "converting"}
 
@@ -42,6 +42,7 @@ class OfficialMinerUClient(MinerU302Client):
         *,
         state: dict[str, Any] | None = None,
         on_state: StateCallback | None = None,
+        should_pause: PauseCallback | None = None,
     ) -> str:
         filename = os.path.basename(path)
         current = dict(state or {})
@@ -78,7 +79,11 @@ class OfficialMinerUClient(MinerU302Client):
             if on_state:
                 await on_state(dict(current))
 
-        result_url = await self._poll_batch(batch_id, filename)
+        result_url = await self._poll_batch(
+            batch_id,
+            filename,
+            should_pause=should_pause,
+        )
         markdown = await self._download_markdown(result_url)
         if on_state:
             await on_state({**current, "status": "done"})
@@ -136,9 +141,17 @@ class OfficialMinerUClient(MinerU302Client):
             ) from exc
         self._checked(response, "上传 PDF 到 MinerU 官方服务")
 
-    async def _poll_batch(self, batch_id: str, filename: str) -> str:
+    async def _poll_batch(
+        self,
+        batch_id: str,
+        filename: str,
+        *,
+        should_pause: PauseCallback | None = None,
+    ) -> str:
         deadline = time.monotonic() + self._poll_timeout
         while True:
+            if should_pause is not None and await should_pause():
+                raise ParsePaused()
             response = await self._official_request(
                 "GET", f"extract-results/batch/{batch_id}"
             )

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -1305,6 +1305,104 @@ async def test_official_mineru_issue_105_upload_poll_and_download(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_official_mineru_service_entrypoint_accepts_pause_callback(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "paper.pdf"
+    source.write_bytes(b"%PDF-fake")
+    upload_url = "https://upload.example.test/paper.pdf"
+    result_url = "https://cdn-mineru.openxlab.org.cn/result.zip"
+    _FakeAsyncClient.reset(
+        [
+            _response(
+                json={
+                    "code": 0,
+                    "msg": "ok",
+                    "trace_id": "trace-service-105",
+                    "data": {
+                        "batch_id": "batch-service-105",
+                        "file_urls": [upload_url],
+                    },
+                },
+                url="https://mineru.net/api/v4/file-urls/batch",
+            ),
+            _response(content=b"", url=upload_url),
+            _response(
+                json={
+                    "code": 0,
+                    "msg": "ok",
+                    "trace_id": "trace-service-poll-105",
+                    "data": {
+                        "batch_id": "batch-service-105",
+                        "extract_result": [
+                            {
+                                "file_name": "paper.pdf",
+                                "state": "done",
+                                "err_msg": "",
+                                "full_zip_url": result_url,
+                            }
+                        ],
+                    },
+                },
+                url=(
+                    "https://mineru.net/api/v4/extract-results/batch/"
+                    "batch-service-105"
+                ),
+            ),
+            _response(
+                content=_result_zip("# Official service entrypoint result"),
+                content_type="application/zip",
+                url=result_url,
+            ),
+        ]
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    async def allow_public_test_hosts(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "sag_api.parsing.mineru._assert_public_host", allow_public_test_hosts
+    )
+    pause_checks = 0
+
+    async def never_pause() -> bool:
+        nonlocal pause_checks
+        pause_checks += 1
+        return False
+
+    prepared = await service.prepare_document(
+        str(source),
+        _settings(
+            document_parser="mineru",
+            mineru_provider="official",
+            mineru_base_url="https://mineru.net/api/v4/file-urls/batch",
+            mineru_api_key="official-test-token",
+            mineru_official_model="vlm",
+            mineru_poll_interval=0.001,
+            mineru_poll_timeout=1,
+        ),
+        should_pause=never_pause,
+    )
+
+    assert prepared.provider == "mineru"
+    assert Path(prepared.path).read_text(encoding="utf-8") == (
+        "# Official service entrypoint result\n"
+    )
+    assert pause_checks == 1
+    assert [call[:2] for call in _FakeAsyncClient.calls] == [
+        ("POST", "https://mineru.net/api/v4/file-urls/batch"),
+        ("PUT", upload_url),
+        (
+            "GET",
+            "https://mineru.net/api/v4/extract-results/batch/"
+            "batch-service-105",
+        ),
+        ("DOWNLOAD", result_url),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_official_mineru_resume_polls_existing_uploaded_batch(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## 改动范围
- `apps/api/sag_api/parsing/mineru_official.py`：让官方 MinerU 适配器实现统一解析接口，接收并处理 `should_pause` 回调。
- `apps/api/tests/test_document_parsing.py`：增加从 `service.prepare_document()` 进入官方 MinerU 的回归测试，覆盖真实调用链和暂停回调。

## 影响功能范围
- 修复官方 MinerU 配置下 PDF 首次解析因参数签名不一致而直接失败的问题。
- 保留官方 MinerU 轮询期间的暂停能力；未发现对 302 MinerU 或 MarkItDown 路径的额外影响。

## 测试覆盖情况
- 通过：`uv run --extra dev pytest -q tests/test_document_parsing.py`（36 passed）。
- 通过：`uv run --extra dev pytest -q`（513 passed, 1 skipped）。
- 通过：`uv run --extra dev ruff check sag_api tests`。
- CI：待远程 CI 执行。

Closes #130
