### PR TITLE
fix(api): handle DOCX dangling image relationships

### DIFF
--- a/apps/api/sag_api/parsing/service.py
+++ b/apps/api/sag_api/parsing/service.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import os
+import posixpath
 import tempfile
 import weakref
+import zipfile
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
+from xml.etree import ElementTree
 
 from sag_api.core.config import Settings
 from sag_api.core.errors import (
@@ -23,6 +27,22 @@ from sag_api.parsing.text import TextDecodingError, is_plain_text_path, read_tex
 
 ParseStateCallback = Callable[[dict[str, Any]], Awaitable[None]]
 _PARSE_LOCKS: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+
+_DOCX_EXTENSION = ".docx"
+_IMAGE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+)
+_PACKAGE_RELATIONSHIP_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/relationships"
+_RELATIONSHIP_TAG = f"{{{_PACKAGE_RELATIONSHIP_NAMESPACE}}}Relationship"
+_WORD_RELATIONSHIPS_PREFIX = "word/_rels/"
+_WORDPROCESSING_NAMESPACE = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+_DRAWING_TAG = f"{{{_WORDPROCESSING_NAMESPACE}}}drawing"
+_PICT_TAG = f"{{{_WORDPROCESSING_NAMESPACE}}}pict"
+_OFFICE_DOCUMENT_RELATIONSHIP_NAMESPACE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+)
+_RELATIONSHIP_EMBED_ATTRIBUTE = f"{{{_OFFICE_DOCUMENT_RELATIONSHIP_NAMESPACE}}}embed"
+_RELATIONSHIP_ID_ATTRIBUTE = f"{{{_OFFICE_DOCUMENT_RELATIONSHIP_NAMESPACE}}}id"
 
 
 @dataclass(frozen=True, slots=True)
@@ -479,15 +499,161 @@ def _is_meaningful_markdown(markdown: str) -> bool:
 
 
 def _markitdown_sync(path: str) -> str:
-    from markitdown import MarkItDown
+    from markitdown import MarkItDown, StreamInfo
 
-    result = MarkItDown().convert(path)
+    if path.lower().endswith(_DOCX_EXTENSION):
+        with open(path, "rb") as source:
+            content = _without_dangling_docx_image_relationships(source.read())
+        result = MarkItDown().convert_stream(
+            io.BytesIO(content),
+            stream_info=StreamInfo(
+                filename=os.path.basename(path),
+                mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                extension=_DOCX_EXTENSION,
+            ),
+        )
+    else:
+        result = MarkItDown().convert(path)
     markdown = getattr(result, "markdown", None)
     if markdown is None:  # 兼容 0.0.x / 早期 0.1.x 返回对象
         markdown = getattr(result, "text_content", None)
     if not isinstance(markdown, str):
         raise TypeError("MarkItDown 返回了未知结果格式")
     return markdown
+
+
+def _without_dangling_docx_image_relationships(content: bytes) -> bytes:
+    try:
+        with zipfile.ZipFile(io.BytesIO(content)) as source:
+            entries = source.infolist()
+            names = frozenset(entry.filename for entry in entries)
+            replacements: dict[str, bytes] = {}
+            for entry in entries:
+                if not _is_word_relationships_entry(entry.filename):
+                    continue
+                relationships = source.read(entry)
+                sanitized, removed_relationship_ids = _without_dangling_image_relationships(
+                    relationships=relationships,
+                    relationships_entry=entry.filename,
+                    names=names,
+                )
+                if sanitized != relationships:
+                    replacements[entry.filename] = sanitized
+                if not removed_relationship_ids:
+                    continue
+                source_part = _source_part_for_relationships(entry.filename)
+                if source_part not in names:
+                    continue
+                source_content = source.read(source_part)
+                sanitized_source = _without_image_relationship_references(
+                    content=source_content,
+                    relationship_ids=removed_relationship_ids,
+                )
+                if sanitized_source != source_content:
+                    replacements[source_part] = sanitized_source
+            if not replacements:
+                return content
+            output = io.BytesIO()
+            with zipfile.ZipFile(output, "w") as destination:
+                destination.comment = source.comment
+                for entry in entries:
+                    destination.writestr(
+                        entry,
+                        replacements.get(entry.filename, source.read(entry)),
+                    )
+            return output.getvalue()
+    except (ElementTree.ParseError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        return content
+
+
+def _is_word_relationships_entry(name: str) -> bool:
+    return name.startswith(_WORD_RELATIONSHIPS_PREFIX) and name.endswith(".rels")
+
+
+def _without_dangling_image_relationships(
+    *,
+    relationships: bytes,
+    relationships_entry: str,
+    names: frozenset[str],
+) -> tuple[bytes, frozenset[str]]:
+    root = ElementTree.fromstring(relationships)
+    removed_relationship_ids: set[str] = set()
+    for relationship in root.findall(_RELATIONSHIP_TAG):
+        if relationship.get("Type") != _IMAGE_RELATIONSHIP_TYPE:
+            continue
+        if relationship.get("TargetMode") == "External":
+            continue
+        target = relationship.get("Target")
+        if target is None or not _relationship_target_is_missing(
+            relationships_entry=relationships_entry,
+            target=target,
+            names=names,
+        ):
+            continue
+        relationship_id = relationship.get("Id")
+        if relationship_id is None:
+            continue
+        root.remove(relationship)
+        removed_relationship_ids.add(relationship_id)
+    if not removed_relationship_ids:
+        return relationships, frozenset()
+    return (
+        ElementTree.tostring(root, encoding="utf-8", xml_declaration=True),
+        frozenset(removed_relationship_ids),
+    )
+
+
+def _source_part_for_relationships(relationships_entry: str) -> str:
+    return relationships_entry.replace("/_rels/", "/", 1)[: -len(".rels")]
+
+
+def _without_image_relationship_references(
+    *,
+    content: bytes,
+    relationship_ids: frozenset[str],
+) -> bytes:
+    root = ElementTree.fromstring(content)
+    parents = {child: parent for parent in root.iter() for child in parent}
+    containers: set[ElementTree.Element[str]] = set()
+    for element in root.iter():
+        relationship_id = element.get(_RELATIONSHIP_EMBED_ATTRIBUTE) or element.get(
+            _RELATIONSHIP_ID_ATTRIBUTE
+        )
+        if relationship_id not in relationship_ids:
+            continue
+        container = _image_container(element, parents)
+        if container is not None:
+            containers.add(container)
+    if not containers:
+        return content
+    for container in containers:
+        parent = parents.get(container)
+        if parent is not None:
+            parent.remove(container)
+    return ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _image_container(
+    element: ElementTree.Element[str],
+    parents: dict[ElementTree.Element[str], ElementTree.Element[str]],
+) -> ElementTree.Element[str] | None:
+    current: ElementTree.Element[str] | None = element
+    while current is not None:
+        if current.tag in {_DRAWING_TAG, _PICT_TAG}:
+            return current
+        current = parents.get(current)
+    return None
+
+
+def _relationship_target_is_missing(
+    *,
+    relationships_entry: str,
+    target: str,
+    names: frozenset[str],
+) -> bool:
+    source_part = _source_part_for_relationships(relationships_entry)
+    target_path = posixpath.normpath(posixpath.join(posixpath.dirname(source_part), target))
+    return target_path not in names
 
 
 def _write_markdown(path: str, markdown: str) -> None:

--- a/apps/api/tests/test_document_parsing.py
+++ b/apps/api/tests/test_document_parsing.py
@@ -1128,6 +1128,71 @@ def _simple_docx(path: Path, text: str) -> None:
         )
 
 
+def _docx_with_dangling_image_relationship(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+              <Default Extension="xml" ContentType="application/xml"/>
+              <Override PartName="/word/document.xml"
+                ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+            </Types>""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+              <Relationship Id="rId1"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+                Target="word/document.xml"/>
+            </Relationships>""",
+        )
+        archive.writestr(
+            "word/document.xml",
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <w:body>
+                <w:p><w:r><w:t>DOCX text survives a dangling image relationship.</w:t></w:r></w:p>
+                <w:p><w:r><w:drawing><wp:inline>
+                  <wp:extent cx="990000" cy="792000"/>
+                  <wp:docPr id="1" name="Missing image"/>
+                  <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                    <pic:pic><pic:nvPicPr><pic:cNvPr id="0" name="Missing image"/><pic:cNvPicPr/></pic:nvPicPr>
+                      <pic:blipFill><a:blip r:embed="rId2"/></pic:blipFill><pic:spPr/></pic:pic>
+                  </a:graphicData></a:graphic>
+                </wp:inline></w:drawing></w:r></w:p>
+                <w:sectPr/>
+              </w:body>
+            </w:document>""",
+        )
+        archive.writestr(
+            "word/_rels/document.xml.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+              <Relationship Id="rId2"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+                Target="../NULL"/>
+            </Relationships>""",
+        )
+
+
+def test_real_markitdown_converts_docx_with_dangling_image_relationship(tmp_path):
+    from sag_api.parsing.service import _markitdown_sync
+
+    docx = tmp_path / "dangling-image.docx"
+    _docx_with_dangling_image_relationship(docx)
+
+    markdown = _markitdown_sync(str(docx))
+
+    assert "DOCX text survives a dangling image relationship." in markdown
+
+
 def test_real_markitdown_converts_pdf_and_office_files(tmp_path):
     """依赖安装烟测：核心格式确实能产出可供引擎摄取的 Markdown。"""
     from openpyxl import Workbook


### PR DESCRIPTION
## 改动范围

- `apps/api/sag_api/parsing/service.py`：DOCX 转换前清理指向不存在资源的内部图片关系及对应绘图节点，再交给 MarkItDown 转换；正常图片和其他格式保持原有路径。
- `apps/api/tests/test_document_parsing.py`：新增带悬空图片关系的 DOCX 回归用例，覆盖原始 `KeyError` 场景。

## 影响功能范围

- DOCX 上传解析：修复包含无效图片关系的文档无法解析的问题，并保留有效图片内容。
- 兼容性：未发现对 PDF、纯文本、其他 Office 文件或 MinerU 解析链路的额外影响。

## 测试覆盖情况

- 通过：`uv run --directory apps/api --extra dev pytest -q tests/test_document_parsing.py`，37 passed。
- 通过：`uv run --directory apps/api --extra dev ruff check sag_api/ sag_agent/ tests/`。
- 通过：真实附件 `马龙-有图片.docx` 解析成功，正文标题存在且保留 2 个有效图片标记。
- 失败：`uv run --directory apps/api --extra dev pytest -q`，512 passed、1 skipped、2 failed；失败为既有 SQLite database locked 竞争和 Universe 状态未及时变为 ready，与本次改动文件无关；失败用例单独重跑通过/表现为既有环境波动。
- CI：待远程 CI 执行。
