### PR TITLE
fix(search): preserve complex model identifiers

### DIFF
--- a/apps/api/sag_api/services/query_analysis.py
+++ b/apps/api/sag_api/services/query_analysis.py
@@ -69,6 +69,7 @@ class QueryAnalysis:
     scoring_terms: tuple[str, ...]
     lookup_terms: tuple[str, ...]
     chinese_segmentation_used: bool
+    expanded_terms: tuple[str, ...] = ()
 
 
 def normalize_lexical_text(value: str) -> str:
@@ -87,13 +88,19 @@ def _is_valid_term(value: str) -> bool:
     return len(normalized) >= 2 and not normalized.isdigit()
 
 
-def _split_alnum_terms(parts: Iterable[str]) -> tuple[str, ...]:
+def _split_alnum_terms(
+    parts: Iterable[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     terms: list[str] = []
+    expanded_terms: list[str] = []
     keys: set[str] = set()
     for part in parts:
         subtokens = _ALNUM_SUBTOKEN_RE.findall(part)
-        split = any(value.isalpha() for value in subtokens) and any(
-            value.isdigit() for value in subtokens
+        split = (
+            part.isalnum()
+            and len(subtokens) == 2
+            and any(value.isalpha() for value in subtokens)
+            and any(value.isdigit() for value in subtokens)
         )
         for candidate in subtokens if split else (part,):
             value = candidate.strip().lower()
@@ -102,10 +109,12 @@ def _split_alnum_terms(parts: Iterable[str]) -> tuple[str, ...]:
             if not valid or key in keys:
                 continue
             terms.append(value)
+            if split:
+                expanded_terms.append(value)
             keys.add(key)
             if len(terms) >= 4:
-                return tuple(terms)
-    return tuple(terms)
+                return tuple(terms), tuple(expanded_terms)
+    return tuple(terms), tuple(expanded_terms)
 
 
 def _lookup_terms(
@@ -127,7 +136,9 @@ def _lookup_terms(
     return tuple(terms)
 
 
-def _legacy_query_terms(cleaned: str) -> tuple[str, ...]:
+def _legacy_query_terms(
+    cleaned: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     return _split_alnum_terms(_LEGACY_TERM_RE.findall(cleaned))
 
 
@@ -141,7 +152,10 @@ def _jieba_segment(text: str) -> Iterable[str]:
     return jieba.cut(text, cut_all=False)
 
 
-def _segmented_terms(cleaned: str, segmenter: Segmenter) -> tuple[str, ...]:
+def _segmented_terms(
+    cleaned: str,
+    segmenter: Segmenter,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     values: list[str] = []
     for part in _LEXICAL_PART_RE.findall(cleaned):
         if _CHINESE_RUN_RE.fullmatch(part):
@@ -166,22 +180,38 @@ def analyze_query(
 ) -> QueryAnalysis:
     cleaned = _remove_query_noise(query)
     phrase = normalize_lexical_text(cleaned)
-    legacy_terms = _legacy_query_terms(cleaned)
+    legacy_terms, legacy_expanded_terms = _legacy_query_terms(cleaned)
     legacy_lookup_terms = _lookup_terms(legacy_terms, phrase)
     chinese_runs = _chinese_runs(cleaned)
     if not segmentation_enabled or not chinese_runs:
-        return QueryAnalysis(phrase, legacy_terms, legacy_lookup_terms, False)
+        return QueryAnalysis(
+            phrase,
+            legacy_terms,
+            legacy_lookup_terms,
+            False,
+            legacy_expanded_terms,
+        )
 
     try:
-        scoring_terms = _segmented_terms(cleaned, segmenter or _jieba_segment)
+        scoring_terms, expanded_terms = _segmented_terms(
+            cleaned,
+            segmenter or _jieba_segment,
+        )
     except Exception:  # noqa: BLE001 -- retrieval must survive tokenizer failure
-        return QueryAnalysis(phrase, legacy_terms, legacy_lookup_terms, False)
+        return QueryAnalysis(
+            phrase,
+            legacy_terms,
+            legacy_lookup_terms,
+            False,
+            legacy_expanded_terms,
+        )
 
     return QueryAnalysis(
         phrase,
         scoring_terms,
         _lookup_terms(scoring_terms, phrase),
         True,
+        expanded_terms,
     )
 
 

--- a/apps/api/sag_api/services/retrieval_service.py
+++ b/apps/api/sag_api/services/retrieval_service.py
@@ -245,6 +245,7 @@ def rerank_sections(
     semantic: list[RetrievedSection],
     *,
     lexical: list[RetrievedSection] | None = None,
+    exact_lexical_keys: set[tuple[str, str]] | None = None,
     limit: int,
     analysis: QueryAnalysis | None = None,
 ) -> RerankResult:
@@ -255,7 +256,12 @@ def rerank_sections(
         segmentation_enabled=settings.search_chinese_segmentation_enabled,
     )
     lexical = lexical or []
-    exact_keys = {_section_key(section) for section in lexical}
+    lexical_keys = {_section_key(section) for section in lexical}
+    exact_keys = (
+        lexical_keys
+        if exact_lexical_keys is None
+        else lexical_keys.intersection(exact_lexical_keys)
+    )
     merged: dict[tuple[str, str], tuple[RetrievedSection, int]] = {}
     for index, section in enumerate([*semantic, *lexical]):
         key = _section_key(section)
@@ -284,14 +290,18 @@ def rerank_sections(
         key: _lexical_relevance(query, section, analysis=effective)
         for key, (section, _index) in candidates
     }
-    has_lexical_signal = any(key in exact_keys or score >= 0.2 for key, score in lexical_scores.items())
+    has_lexical_signal = any(
+        key in lexical_keys or score >= 0.2
+        for key, score in lexical_scores.items()
+    )
     ranked: list[tuple[float, float, int, RetrievedSection]] = []
 
     for position, (key, (section, original_index)) in enumerate(candidates):
         raw = max(0.0, min(1.0, float(section.score or 0.0)))
         lexical_score = lexical_scores[key]
         exact = key in exact_keys
-        if _is_boilerplate(section) and not exact and lexical_score < 0.35:
+        lexical_match = key in lexical_keys
+        if _is_boilerplate(section) and not lexical_match and lexical_score < 0.35:
             continue
         rank_score = 1.0 - position / denominator
         combined = min(
@@ -299,7 +309,7 @@ def rerank_sections(
             raw * 0.5 + rank_score * 0.2 + lexical_score * 0.3 + (0.15 if exact else 0.0),
         )
         if has_lexical_signal:
-            relevant = exact or lexical_score >= 0.2
+            relevant = lexical_match or lexical_score >= 0.2
         else:
             relevant = raw >= semantic_floor
         if not relevant:
@@ -326,15 +336,22 @@ async def _lexical_sections(
     *,
     analysis: QueryAnalysis,
     exclude_source_ids_by_config: DocumentSourceExclusions | None = None,
-) -> list[RetrievedSection]:
+) -> tuple[list[RetrievedSection], set[tuple[str, str]]]:
     grep_chunks = getattr(engine_manager, "grep_chunks", None)
     terms = analysis.lookup_terms
     if not callable(grep_chunks) or not terms:
-        return []
+        return [], set()
 
     semaphore = asyncio.Semaphore(max(1, settings.search_source_concurrency))
+    expanded_keys = {
+        normalize_lexical_text(term)
+        for term in analysis.expanded_terms
+    }
 
-    async def one(source: SearchSource, term: str) -> list[RetrievedSection]:
+    async def one(
+        source: SearchSource,
+        term: str,
+    ) -> tuple[list[RetrievedSection], bool]:
         async with semaphore:
             try:
                 options: dict[str, Any] = {
@@ -361,8 +378,8 @@ async def _lexical_sections(
                     **options,
                 )
             except Exception:  # noqa: BLE001
-                return []
-        return [
+                return [], False
+        sections = [
             RetrievedSection(
                 chunk_id=row.get("chunk_id"),
                 heading=row.get("heading") or "精确匹配",
@@ -374,9 +391,17 @@ async def _lexical_sections(
             )
             for index, row in enumerate(rows)
         ]
+        return sections, normalize_lexical_text(term) not in expanded_keys
 
     groups = await asyncio.gather(*(one(source, term) for source in sources for term in terms))
-    return [section for group in groups for section in group]
+    sections = [section for group, _strong in groups for section in group]
+    exact_keys = {
+        _section_key(section)
+        for group, strong in groups
+        if strong
+        for section in group
+    }
+    return sections, exact_keys
 
 
 async def retrieve_relevant_sections(
@@ -413,7 +438,7 @@ async def retrieve_relevant_sections(
         and exclusions
     ):
         search_options["exclude_source_ids_by_config"] = exclusions
-    outcome, lexical = await asyncio.gather(
+    outcome, lexical_recall = await asyncio.gather(
         engine_manager.search_many(targets, query, **search_options),
         _lexical_sections(
             engine_manager,
@@ -422,6 +447,7 @@ async def retrieve_relevant_sections(
             exclude_source_ids_by_config=exclusions,
         ),
     )
+    lexical, exact_lexical_keys = lexical_recall
     # A delete can commit while either engine query is in flight. Re-read the
     # persisted barrier before returning evidence so the delete is linearized.
     hidden = await _hidden_document_derivatives(sources)
@@ -439,6 +465,7 @@ async def retrieve_relevant_sections(
         query,
         semantic_sections,
         lexical=lexical_sections,
+        exact_lexical_keys=exact_lexical_keys,
         limit=requested_limit,
         analysis=analysis,
     )

--- a/apps/api/tests/test_query_analysis.py
+++ b/apps/api/tests/test_query_analysis.py
@@ -84,6 +84,25 @@ def test_glued_query_keeps_the_exact_token_as_a_lookup_term():
     assert result.lookup_terms == ("iphone", "15", "iphone15")
 
 
+def test_complex_model_identifier_is_not_split_into_numeric_fragments():
+    segments = {
+        "冰箱型号为": ["冰箱", "型号"],
+        "的温度最低是": ["温度", "最低"],
+        "吗": ["吗"],
+    }
+
+    result = analyze_query(
+        "冰箱型号为dw-2412p30的温度最低是-200°吗？",
+        segmenter=lambda text: segments[text],
+    )
+
+    assert "dw-2412p30" in result.scoring_terms
+    assert "dw-2412p30" in result.lookup_terms
+    assert "2412" not in result.lookup_terms
+    assert "30" not in result.lookup_terms
+    assert "200" not in result.lookup_terms
+
+
 def test_punctuation_separated_english_term_is_not_split():
     result = analyze_query("foo-bar", segmentation_enabled=False)
 

--- a/apps/api/tests/test_retrieval_relevance.py
+++ b/apps/api/tests/test_retrieval_relevance.py
@@ -175,6 +175,62 @@ async def test_glued_alnum_query_recalls_distant_terms_from_the_same_document():
 
 
 @pytest.mark.asyncio
+async def test_exact_glued_token_ranks_above_expansion_only_match():
+    from uuid import uuid4
+
+    from sag_api.core.db import SessionLocal, init_db
+    from sag_api.db.models import Source
+    from sag_api.sag import SearchOutcome
+    from sag_api.services.retrieval_service import retrieve_relevant_sections
+
+    class LexicalEngine:
+        async def search_many(self, _targets, query, **_kwargs):
+            return SearchOutcome(query=query, sections=[], stats={})
+
+        async def grep_chunks(self, _source_config_id, term, **_kwargs):
+            rows = {
+                "ai": [
+                    {
+                        "chunk_id": "expansion-only",
+                        "heading": "AI 项目 2028 路线图",
+                        "snippet": "这是两个分散词的普通匹配。",
+                        "source_id": "article-expansion",
+                    }
+                ],
+                "ai2028": [
+                    {
+                        "chunk_id": "exact-token",
+                        "heading": "产品编号",
+                        "snippet": "正式编号为 AI2028。",
+                        "source_id": "article-exact",
+                    }
+                ],
+            }
+            return rows.get(term, [])
+
+    await init_db()
+    async with SessionLocal() as session:
+        source = Source(
+            name="exact-token-priority",
+            sag_source_config_id=f"exact-token-{uuid4().hex}",
+        )
+        session.add(source)
+        await session.commit()
+
+        outcome = await retrieve_relevant_sections(
+            LexicalEngine(),
+            [source],
+            "AI2028",
+            top_k=8,
+        )
+
+    assert [item.chunk_id for item in outcome.sections] == [
+        "exact-token",
+        "expansion-only",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_natural_chinese_question_recalls_trailing_topic_term():
     from uuid import uuid4
 


### PR DESCRIPTION
## 改动范围
- 查询分析模块：仅拆分简单的英文数字连写词，复杂型号（如 `dw-2412p30`）保持为完整检索词，避免生成 `2412`、`30` 等无关碎片。
- 检索排序与测试：区分完整词命中和拆分扩展词命中，扩展词继续参与召回但不再获得完整词的额外精确匹配加分；补充型号保留和排序优先级回归测试。

## 影响功能范围
- 知识库搜索：提升产品型号、设备编号等复杂标识符查询的准确性，同时保留 `AI2028`、`iPhone15` 等简单英文数字连写查询的跨片段召回能力。
- 兼容性：`QueryAnalysis` 新字段提供默认值，排序函数新增参数为可选关键字参数；未新增分词依赖，未发现额外接口影响。

## 测试覆盖情况
- 通过：`uv run --project apps/api pytest -q apps/api/tests/test_query_analysis.py apps/api/tests/test_retrieval_relevance.py`，29 个查询分析与检索排序测试通过。
- 通过：`uv run --project apps/api ruff check apps/api/sag_api/services/query_analysis.py apps/api/sag_api/services/retrieval_service.py apps/api/tests/test_query_analysis.py apps/api/tests/test_retrieval_relevance.py`，相关文件静态检查通过。
- 失败：`uv run --project apps/api pytest -q apps/api/tests`，最近一次为 519 passed、1 skipped、3 failed；失败集中在任务队列、Insights、Universe 测试的 SQLite 锁竞争和共享状态残留，未涉及本次查询分析或检索排序代码。
- CI：待远程 CI 执行。
