### PR TITLE
fix(web): render LaTeX math in Markdown content and answers

### DIFF
--- a/apps/api/sag_api/generation/prompt.py
+++ b/apps/api/sag_api/generation/prompt.py
@@ -106,6 +106,8 @@ _GUIDANCE = {
         "其他工具返回的 URL 保留为 Markdown 链接，不自行编号。只要使用了带 URL 的外部检索或阅读工具，"
         "关键外部事实就必须在对应论断附近附上可点击的直接来源；无法形成可追溯来源时，明确证据缺口，"
         "不要把该事实写成已确认。\n"
+        "- 证据中的数学公式必须保留 LaTeX：行内公式使用 \\(...\\)，独立公式使用 \\[...\\]；"
+        "不要用反引号或 Markdown 代码块包裹公式，不要删除公式定界符。\n"
         "- 输出前检查：是否回答了真实目标，关键事实是否足够新且有来源，日期与数字是否准确，"
         "引用是否能打开，是否明确了仍存在的不确定性。"
     ),
@@ -150,6 +152,8 @@ _GUIDANCE = {
         "other tools as Markdown links and never fabricate a numbered citation. Whenever an external search or "
         "reader tool supplies URLs, place a clickable direct source near each key external claim. If no traceable "
         "source can be formed, state the evidence gap instead of presenting the claim as confirmed.\n"
+        "- Preserve LaTeX from evidence: use \\(...\\) for inline math and \\[...\\] for display math. Never wrap math "
+        "in backticks or Markdown code fences, and never remove its math delimiters.\n"
         "- Before finishing, verify that the real goal was answered, evidence is fresh enough, dates and numbers "
         "are accurate, citations open, and remaining uncertainty is explicit."
     ),

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3735,6 +3735,11 @@
   .answer-prose p {
     margin: 0.375rem 0;
   }
+  .answer-prose .katex-display {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
   .answer-prose--streaming > :last-child::after {
     display: inline-block;
     width: 2px;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import "katex/dist/katex.min.css";
 
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";

--- a/apps/web/components/features/markdown-content.test.tsx
+++ b/apps/web/components/features/markdown-content.test.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it } from "vitest";
+
+import messages from "@/messages/zh-CN.json";
+import { ChunkedMarkdown, MarkdownContent } from "./markdown-content";
+
+function renderMarkdown(content: string) {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider locale="zh-CN" timeZone="Asia/Shanghai" messages={messages}>
+      <MarkdownContent content={content} />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("MarkdownContent math rendering", () => {
+  it("renders the inline and display LaTeX used in issue #138", () => {
+    const content = String.raw`行内公式：$A$。
+
+$$
+\frac{A}{1 + \frac{1}{n}} \times \frac{1}{n} = \frac{A}{n+1}
+$$
+
+$A^2 + A_i + \Delta + \alpha + \beta + \text{增长率 } 5.2% = 0.052$`;
+
+    const html = renderMarkdown(content);
+
+    expect(html).toContain('class="katex"');
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain("<mfrac>");
+    expect(html).toContain("<msup>");
+    expect(html).toContain("<msub>");
+    expect(html).toContain("Δ");
+    expect(html).toContain("α");
+    expect(html).toContain("β");
+    expect(html).toContain("增长率");
+    expect(html).toContain("<mn>0.052</mn>");
+  });
+
+  it("keeps code examples literal and degrades invalid LaTeX without crashing", () => {
+    const html = renderMarkdown("代码：`$A^2$`\n\n无效公式：$\\notARealCommand{x}$");
+
+    expect(html).toContain("<code>$A^2$</code>");
+    expect(html).toContain('mathcolor="#cc0000"');
+    expect(html).toContain("\\notARealCommand{x}");
+  });
+
+  it("keeps rendering after repeated percent signs and even backslashes", () => {
+    const html = renderMarkdown(String.raw`$12%% = 0.12$
+
+$7 \\% = 0.34$`);
+
+    expect(html).toContain("<mn>0.12</mn>");
+    expect(html).toContain("<mn>0.34</mn>");
+  });
+
+  it("renders display math after large-document chunking", () => {
+    const content = `${"x".repeat(4985)}\n\n$$\n\\frac{1}{n + 1}\n\n+ z + 1\n$$\n\n${"tail ".repeat(50)}`;
+    const html = renderToStaticMarkup(
+      <NextIntlClientProvider locale="zh-CN" timeZone="Asia/Shanghai" messages={messages}>
+        <ChunkedMarkdown content={content} />
+      </NextIntlClientProvider>,
+    );
+
+    expect(html).toContain('class="md-block"');
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain("<mfrac>");
+    expect(html).toContain("<mi>z</mi>");
+  });
+
+  it("renders unambiguous parenthesis and bracket math delimiters", () => {
+    const html = renderMarkdown(String.raw`行内：\(A^2 + \frac{A}{B}\)。
+
+\[
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+\]`);
+
+    expect(html).toContain('class="katex"');
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain("<msup>");
+    expect(html).toContain("<mfrac>");
+  });
+
+  it("never promotes inline or fenced code to math", () => {
+    const html = renderMarkdown("代码：`x`、`a+b`、`key=value`、`a/b`、`<div>`、`$HOME`。\n\n~~~sh\necho $HOME\n~~~");
+
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("<code>x</code>");
+    expect(html).toContain("<code>a+b</code>");
+    expect(html).toContain("<code>key=value</code>");
+    expect(html).toContain("&lt;div&gt;");
+    expect(html).toContain("echo $HOME");
+  });
+
+  it("keeps escaped currency and incomplete streaming delimiters literal", () => {
+    const html = renderMarkdown(String.raw`金额：\$100 到 \$120；流式半截：\(A^2 + \frac{A}{`);
+
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("$100 到 $120");
+    expect(html).toContain(String.raw`\(A^2 + \frac{A}{`);
+  });
+
+  it("keeps ordinary paired currency text out of math rendering", () => {
+    const html = renderMarkdown(
+      "价格从 $100 上涨到 $120，预算为 $100 + $20；变量：$HOME/$PATH；金额 $100，变量 $HOME；路径 $C:/tmp 和 $HOME/bin。",
+    );
+
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("价格从 $100 上涨到 $120，预算为 $100 + $20");
+    expect(html).toContain("$HOME/$PATH");
+    expect(html).toContain("金额 $100，变量 $HOME");
+    expect(html).toContain("路径 $C:/tmp 和 $HOME/bin");
+  });
+
+  it("does not pair display delimiters across code", () => {
+    const html = renderMarkdown("\\[\n```txt\n\\]\n```\n正文");
+
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("<code class=\"language-txt\">\\]");
+  });
+
+  it("does not rewrite delimiters in link destinations or even-slash literals", () => {
+    const html = renderMarkdown(String.raw`[docs](https://example.test/a\(b\))；字面量：\\(x\)。`);
+
+    expect(html).toContain('href="https://example.test/a(b)"');
+    expect(html).toContain(String.raw`\(x\)`);
+    expect(html).not.toContain('class="katex"');
+  });
+
+  it("does not rewrite delimiters in reference definitions or autolinks", () => {
+    const html = renderMarkdown(String.raw`[docs][ref]
+
+[ref]: https://example.test/a\(b\)
+
+<https://example.test/c\(d\)>`);
+
+    expect(html).toContain('href="https://example.test/a(b)"');
+    expect(html).toContain('href="https://example.test/c%5C(d%5C)"');
+    expect(html).not.toContain('class="katex"');
+  });
+
+});

--- a/apps/web/components/features/markdown-content.tsx
+++ b/apps/web/components/features/markdown-content.tsx
@@ -3,7 +3,9 @@
 import * as React from "react";
 import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 
 import { splitMarkdownBlocks } from "@/lib/markdown-blocks";
 import type { Citation } from "@/lib/types";
@@ -17,6 +19,199 @@ type MdNode = {
   children?: MdNode[];
   data?: Record<string, unknown>;
 };
+
+type HastNode = {
+  type?: string;
+  value?: string;
+  properties?: { className?: unknown };
+  children?: HastNode[];
+};
+
+/** Convert paired LaTeX delimiters only; never infer math from its contents. */
+function normalizeExplicitMathDelimiters(content: string): string {
+  let normalized = "";
+  let codeFence: string | null = null;
+  let inlineCodeTicks = 0;
+  let linkDestinationDepth = 0;
+  let autolinkDestination = false;
+
+  const hasOddBackslashRun = (index: number) => {
+    let count = 0;
+    for (let cursor = index; cursor >= 0 && content[cursor] === "\\"; cursor--) count++;
+    return count % 2 === 1;
+  };
+
+  const isEscaped = (index: number) => {
+    let count = 0;
+    for (let cursor = index - 1; cursor >= 0 && content[cursor] === "\\"; cursor--) count++;
+    return count % 2 === 1;
+  };
+
+  const findExplicitClose = (
+    start: number,
+    token: "\\)" | "\\]",
+    inline: boolean,
+  ) => {
+    for (let cursor = start; cursor < content.length - 1; cursor++) {
+      if (inline && content[cursor] === "\n") return -1;
+      if (content[cursor] === "`") return -1;
+      const lineStart = cursor === 0 || content[cursor - 1] === "\n";
+      if (lineStart && /^ {0,3}(?:`{3,}|~{3,})/.test(content.slice(cursor))) return -1;
+      if (content.startsWith(token, cursor) && hasOddBackslashRun(cursor)) return cursor;
+    }
+    return -1;
+  };
+
+  const findNextDollar = (start: number) => {
+    for (let cursor = start; cursor < content.length; cursor++) {
+      if (content[cursor] === "$" && !isEscaped(cursor)) return cursor;
+    }
+    return -1;
+  };
+
+  const startsLiteralDollarToken = (value: string) => {
+    return /^(?:\s*\d|[A-Z][A-Z0-9_]*(?=$|[^A-Z0-9_]))/.test(value);
+  };
+
+  for (let index = 0; index < content.length;) {
+    const lineStart = index === 0 || content[index - 1] === "\n";
+    if (lineStart && inlineCodeTicks === 0) {
+      const fenceMatch = /^( {0,3})(`{3,}|~{3,})/.exec(content.slice(index));
+      if (fenceMatch) {
+        const marker = fenceMatch[2];
+        const newlineIndex = content.indexOf("\n", index);
+        const lineEnd = newlineIndex === -1 ? content.length : newlineIndex + 1;
+        const markerSuffix = content.slice(index + fenceMatch[0].length, lineEnd).trim();
+        if (!codeFence) codeFence = marker;
+        else if (
+          codeFence[0] === marker[0]
+          && marker.length >= codeFence.length
+          && markerSuffix === ""
+        ) codeFence = null;
+        normalized += content.slice(index, lineEnd);
+        index = lineEnd;
+        continue;
+      }
+
+      if (!codeFence && /^ {0,3}\[[^\]\n]+\]:\s*/.test(content.slice(index))) {
+        const newlineIndex = content.indexOf("\n", index);
+        const lineEnd = newlineIndex === -1 ? content.length : newlineIndex + 1;
+        normalized += content.slice(index, lineEnd);
+        index = lineEnd;
+        continue;
+      }
+    }
+
+    if (!codeFence && content[index] === "`") {
+      let runLength = 1;
+      while (content[index + runLength] === "`") runLength++;
+      if (inlineCodeTicks === 0) inlineCodeTicks = runLength;
+      else if (inlineCodeTicks === runLength) inlineCodeTicks = 0;
+      normalized += content.slice(index, index + runLength);
+      index += runLength;
+      continue;
+    }
+
+    if (!codeFence && inlineCodeTicks === 0) {
+      if (autolinkDestination) {
+        if (content[index] === ">" && !isEscaped(index)) autolinkDestination = false;
+        normalized += content[index];
+        index++;
+        continue;
+      }
+      if (
+        content[index] === "<"
+        && /^(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:|[^ <>@]+@)/.test(content.slice(index + 1))
+      ) {
+        autolinkDestination = true;
+        normalized += content[index];
+        index++;
+        continue;
+      }
+      if (linkDestinationDepth > 0) {
+        if (content[index] === "(" && !isEscaped(index)) linkDestinationDepth++;
+        else if (content[index] === ")" && !isEscaped(index)) linkDestinationDepth--;
+        normalized += content[index];
+        index++;
+        continue;
+      }
+      if (content[index] === "(" && content[index - 1] === "]" && !isEscaped(index)) {
+        linkDestinationDepth = 1;
+        normalized += content[index];
+        index++;
+        continue;
+      }
+    }
+
+    if (
+      !codeFence
+      && inlineCodeTicks === 0
+      && content.startsWith("\\(", index)
+      && hasOddBackslashRun(index)
+    ) {
+      const closingIndex = findExplicitClose(index + 2, "\\)", true);
+      if (closingIndex !== -1) {
+        normalized += `$${content.slice(index + 2, closingIndex)}$`;
+        index = closingIndex + 2;
+        continue;
+      }
+      normalized += "\\\\(";
+      index += 2;
+      continue;
+    }
+
+    if (
+      !codeFence
+      && inlineCodeTicks === 0
+      && content.startsWith("\\[", index)
+      && hasOddBackslashRun(index)
+    ) {
+      const closingIndex = findExplicitClose(index + 2, "\\]", false);
+      if (closingIndex !== -1) {
+        const math = content.slice(index + 2, closingIndex).replace(/^\s+|\s+$/g, "");
+        normalized += `\n$$\n${math}\n$$\n`;
+        index = closingIndex + 2;
+        continue;
+      }
+      normalized += "\\\\[";
+      index += 2;
+      continue;
+    }
+
+    if (
+      !codeFence
+      && inlineCodeTicks === 0
+      && content[index] === "$"
+      && !isEscaped(index)
+      && startsLiteralDollarToken(content.slice(index + 1))
+    ) {
+      const closingIndex = findNextDollar(index + 1);
+      if (
+        closingIndex === -1
+        || startsLiteralDollarToken(content.slice(closingIndex + 1))
+      ) {
+        normalized += "\\$";
+        index++;
+        continue;
+      }
+    }
+
+    if (
+      !codeFence
+      && inlineCodeTicks === 0
+      && (content.startsWith("\\)", index) || content.startsWith("\\]", index))
+      && hasOddBackslashRun(index)
+    ) {
+      normalized += `\\\\${content[index + 1]}`;
+      index += 2;
+      continue;
+    }
+
+    normalized += content[index];
+    index++;
+  }
+  return normalized;
+}
 
 function remarkCitationLinks(validNumbers: ReadonlySet<string>) {
   return () => {
@@ -60,6 +255,53 @@ function remarkCitationLinks(validNumbers: ReadonlySet<string>) {
       });
     };
     return visit;
+  };
+}
+
+/**
+ * 知识库与模型输出常把百分号写成 `5.2%`，而 TeX 会把裸 `%` 当作注释起点。
+ * 在 rehype-katex 消费数学 HAST 前补全转义，避免改写普通 Markdown、URL 或代码块。
+ */
+function rehypeMathLiteralPercent() {
+  return (tree: HastNode) => {
+    const escapeLiteralPercents = (value: string) => {
+      let escaped = "";
+      for (let index = 0; index < value.length; index++) {
+        const character = value[index];
+        if (character !== "%") {
+          escaped += character;
+          continue;
+        }
+
+        let precedingBackslashes = 0;
+        for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor--) {
+          precedingBackslashes++;
+        }
+        escaped += precedingBackslashes % 2 === 0 ? "\\%" : "%";
+      }
+      return escaped;
+    };
+
+    const escapeText = (node: HastNode) => {
+      if (node.type === "text" && typeof node.value === "string") {
+        node.value = escapeLiteralPercents(node.value);
+      }
+      node.children?.forEach(escapeText);
+    };
+    const visit = (node: HastNode) => {
+      const rawClassName = node.properties?.className;
+      const classNames = Array.isArray(rawClassName)
+        ? rawClassName.filter((value): value is string => typeof value === "string")
+        : typeof rawClassName === "string"
+          ? rawClassName.split(/\s+/)
+          : [];
+      if (classNames.some((name) => name === "math-inline" || name === "math-display")) {
+        node.children?.forEach(escapeText);
+        return;
+      }
+      node.children?.forEach(visit);
+    };
+    visit(tree);
   };
 }
 
@@ -121,7 +363,20 @@ export const MarkdownContent = React.memo(function MarkdownContent({
       aria-busy={streaming || undefined}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, citationPlugin]}
+        remarkPlugins={[remarkGfm, remarkMath, citationPlugin]}
+        rehypePlugins={[
+          rehypeMathLiteralPercent,
+          [
+            rehypeKatex,
+            {
+              trust: false,
+              throwOnError: false,
+              strict: "warn",
+              maxSize: 100,
+              maxExpand: 1000,
+            },
+          ],
+        ]}
         components={{
           img: MdImage,
           a: ({ href, children, ...props }) => {
@@ -159,7 +414,7 @@ export const MarkdownContent = React.memo(function MarkdownContent({
           },
         }}
       >
-        {content}
+        {normalizeExplicitMathDelimiters(content)}
       </ReactMarkdown>
     </div>
   );

--- a/apps/web/lib/markdown-blocks.test.ts
+++ b/apps/web/lib/markdown-blocks.test.ts
@@ -45,6 +45,51 @@ describe("splitMarkdownBlocks", () => {
     expectLossless(text);
   });
 
+  it("never splits a display-math fence across blocks", () => {
+    const text = `${"x".repeat(4985)}\n\n$$\n\\frac{1}{n + 1}\n\n+ z + 1\n$$\n\n${"tail ".repeat(50)}`;
+    const blocks = splitMarkdownBlocks(text);
+    const formulaBlock = blocks.find((block) => block.includes("\\frac{1}"));
+
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(formulaBlock).toContain("+ z + 1");
+    expect((formulaBlock!.match(/\$\$/g) ?? []).length).toBe(2);
+    expectLossless(text);
+  });
+
+  it("keeps longer remark-math dollar fences intact", () => {
+    const text = `${"x".repeat(4988)}\n\n$$$\na + b\n\n+ c\n$$$\n\n${"tail ".repeat(50)}`;
+    const blocks = splitMarkdownBlocks(text);
+    const formulaBlock = blocks.find((block) => block.includes("a + b"));
+
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(formulaBlock).toContain("+ c");
+    expect((formulaBlock!.match(/\$\$\$/g) ?? []).length).toBe(2);
+    expectLossless(text);
+  });
+
+  it("accepts a closing math fence longer than its opening fence", () => {
+    const text = `$$$\na\n$$$$\n\n${"x".repeat(4988)}\n\n$$$\nb\n\n+ c\n$$$\n\n${"tail ".repeat(50)}`;
+    const blocks = splitMarkdownBlocks(text);
+    const secondFormulaBlock = blocks.find((block) => block.includes("\nb\n"));
+
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(secondFormulaBlock).toContain("$$$\nb");
+    expect(secondFormulaBlock).toContain("+ c");
+    expectLossless(text);
+  });
+
+  it("never splits a bracket display-math fence across blocks", () => {
+    const text = `${"x".repeat(4985)}\n\n\\[\n\\frac{1}{n + 1}\n\n+ z + 1\n\\]\n\n${"tail ".repeat(50)}`;
+    const blocks = splitMarkdownBlocks(text);
+    const formulaBlock = blocks.find((block) => block.includes("\\frac{1}"));
+
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(formulaBlock).toContain("+ z + 1");
+    expect(formulaBlock).toContain("\\[");
+    expect(formulaBlock).toContain("\\]");
+    expectLossless(text);
+  });
+
   it("does not split a large table across blocks", () => {
     const header = "| a | b |\n| --- | --- |\n";
     const rows = Array.from({ length: 400 }, (_, i) => `| ${i} | v${i} |`).join("\n");

--- a/apps/web/lib/markdown-blocks.ts
+++ b/apps/web/lib/markdown-blocks.ts
@@ -2,7 +2,7 @@
  * 把整份 Markdown 切成若干「块」，供分块渲染使用（大文件卡顿优化）。
  *
  * 目标：在顶层空行处断句，但绝不切断跨行结构——代码围栏（``` / ~~~）、
- * 表格连续行——否则各块独立解析会渲染错乱。小段落会合并到 ~TARGET 字符的
+ * 展示公式围栏（$$）、表格连续行——否则各块独立解析会渲染错乱。小段落会合并到 ~TARGET 字符的
  * 目标窗口以控制块数；标题（ATX `#`）优先另起一块，保证章节边界自然。
  *
  * 不变式：blocks.join("") === 原文（不丢字、不改字），仅在边界插入分块点。
@@ -13,6 +13,8 @@
 const TARGET_CHARS = 5000;
 
 const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
+const DISPLAY_MATH_FENCE_RE = /^\s{0,3}(\${2,})\s*$/;
+const BRACKET_DISPLAY_MATH_FENCE_RE = /^\s{0,3}\\([\[\]])\s*$/;
 const HEADING_RE = /^\s{0,3}#{1,6}\s/;
 const TABLE_ROW_RE = /^\s{0,3}\|/;
 
@@ -20,6 +22,17 @@ const TABLE_ROW_RE = /^\s{0,3}\|/;
 function fenceMarker(line: string): string | null {
   const match = FENCE_RE.exec(line);
   return match ? match[1][0] : null;
+}
+
+/** 一行是否是展示公式围栏；返回完整的美元符号标记（$$、$$$ 等）。 */
+function displayMathFenceMarker(line: string): string | null {
+  const match = DISPLAY_MATH_FENCE_RE.exec(line);
+  return match ? match[1] : null;
+}
+
+function bracketDisplayMathFenceMarker(line: string): "[" | "]" | null {
+  const match = BRACKET_DISPLAY_MATH_FENCE_RE.exec(line);
+  return match?.[1] === "[" || match?.[1] === "]" ? match[1] : null;
 }
 
 /**
@@ -31,6 +44,8 @@ function toParagraphs(text: string): string[] {
   const units: string[] = [];
   let current: string[] = [];
   let fence: string | null = null; // 当前打开的围栏标记（null 表示不在围栏内）
+  let displayMathFence: string | null = null;
+  let bracketDisplayMath = false;
 
   const flush = () => {
     if (current.length) {
@@ -53,12 +68,40 @@ function toParagraphs(text: string): string[] {
       continue;
     }
 
+    if (displayMathFence) {
+      current.push(withNl);
+      const closingMathFence = displayMathFenceMarker(line);
+      if (closingMathFence && closingMathFence.length >= displayMathFence.length) {
+        displayMathFence = null;
+      }
+      continue;
+    }
+
+    if (bracketDisplayMath) {
+      current.push(withNl);
+      if (bracketDisplayMathFenceMarker(line) === "]") bracketDisplayMath = false;
+      continue;
+    }
+
     const openMarker = fenceMarker(line);
     if (openMarker) {
       // 段落中途遇到围栏起始：先收尾已有段落，再进入围栏。
       flush();
       current.push(withNl);
       fence = openMarker;
+      continue;
+    }
+
+    const mathFenceMarker = displayMathFenceMarker(line);
+    if (mathFenceMarker) {
+      current.push(withNl);
+      displayMathFence = mathFenceMarker;
+      continue;
+    }
+
+    if (bracketDisplayMathFenceMarker(line) === "[") {
+      current.push(withNl);
+      bracketDisplayMath = true;
       continue;
     }
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -34,6 +34,7 @@
         "clsx": "2.1.1",
         "cmdk": "^1.1.1",
         "d3-force": "^3.0.0",
+        "katex": "^0.16.47",
         "lucide-react": "0.469.0",
         "motion": "^12.42.2",
         "next": "15.5.20",
@@ -43,7 +44,9 @@
         "react-dom": "19.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.9",
+        "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "sonner": "1.7.1",
         "tailwind-merge": "2.6.0",
         "three": "0.185.1"
@@ -5120,6 +5123,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -7548,6 +7557,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -8782,6 +8803,101 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -8808,12 +8924,45 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9563,6 +9712,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10121,6 +10295,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -10431,6 +10624,25 @@
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -11455,6 +11667,18 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11987,6 +12211,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -11997,6 +12240,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -13305,6 +13564,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -13323,6 +13596,20 @@
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13534,6 +13821,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13788,6 +14089,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "clsx": "2.1.1",
     "cmdk": "^1.1.1",
     "d3-force": "^3.0.0",
+    "katex": "^0.16.47",
     "lucide-react": "0.469.0",
     "motion": "^12.42.2",
     "next": "15.5.20",
@@ -51,7 +52,9 @@
     "react-dom": "19.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.9",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "sonner": "1.7.1",
     "tailwind-merge": "2.6.0",
     "three": "0.185.1"


### PR DESCRIPTION
## 改动范围
- Markdown 渲染链接入 `remark-math`、`rehype-katex` 和 KaTeX 样式，支持行内与块级公式，并兼容公式中的常见未转义百分号。
- 大文档分块保护 `$$` 及更长数学围栏，避免跨空行公式在分块边界被拆断。
- 问答输出统一要求模型使用显式 `\(...\)` / `\[...\]` 定界符；前端只转换成对的显式定界符，不再根据反引号内容猜测公式。
- 兼容保护普通金额、环境变量、路径、行内/围栏代码、行内/引用式链接和 autolink，避免正常召回或文档文本及 URL 被误判或改写。
- 更新 Web 依赖与锁文件，并补充 Issue #138 的 Markdown 数学公式回归覆盖。

## 影响功能范围
- 知识文档解析内容、搜索生成摘要和问答助手正文可展示 LaTeX；流式阶段未闭合定界符保持原文，闭合后再渲染；超宽块公式支持横向滚动。
- KaTeX 保持 `trust: false`、尺寸和展开限制；非法公式降级展示，不影响围栏代码块。
- 关联并在合并后关闭对应问题：Fixes #138

## 测试覆盖情况
- 通过：`corepack npm exec vitest run`（Web，78 files / 522 tests；显式定界符专项 23 tests）。
- 通过：`corepack npm run typecheck`、`corepack npm run lint`、`corepack npm run build`（Web）。
- 通过：`uv run ruff check sag_api/generation/prompt.py`，以及 `uv run pytest tests/test_agents.py tests/test_agent_tools.py -q`（14 passed）。
- 通过：Desktop `corepack npm test`（6 passed）、`corepack npm run typecheck`。
- CI：待远程 CI 执行。
