### PR TITLE
fix(octx): 优化导出包文件命名

### DIFF
--- a/apps/api/sag_api/api/v1/octx.py
+++ b/apps/api/sag_api/api/v1/octx.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from fastapi import APIRouter, Depends, File, Header, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -150,13 +152,12 @@ async def download_artifact(
     if not path.is_file():
         raise NotFoundError("OCTX artifact is missing")
     digest = str(transfer.package_digest or "")
+    raw_name = str((transfer.checkpoint or {}).get("asset_name") or transfer.asset_id or transfer.id)
+    filename_stem = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", raw_name.strip()).rstrip(". ")[:80] or "source"
     return FileResponse(
         path,
         media_type="application/vnd.octx+zip",
-        filename=(
-            f"{str((transfer.checkpoint or {}).get('asset_name') or transfer.asset_id or transfer.id)}"
-            f"-{transfer.package_version or 'release'}.octx"
-        ),
+        filename=f"{filename_stem}-OCTX.octx",
         headers={"ETag": f'"{digest}"', "Digest": digest},
     )
 

--- a/apps/api/tests/test_octx_transfer_service.py
+++ b/apps/api/tests/test_octx_transfer_service.py
@@ -2045,7 +2045,7 @@ async def test_download_ready_transfer_restores_migrated_artifact(
             artifact_key=key,
             package_digest=digest,
             package_version="1.0.0",
-            checkpoint={"asset_name": "Migrated"},
+            checkpoint={"asset_name": "AI 手册"},
         )
         session.add(transfer)
         await session.commit()
@@ -2053,6 +2053,7 @@ async def test_download_ready_transfer_restores_migrated_artifact(
         response = await octx_api.download_artifact(transfer.id, object(), session)
 
     assert Path(response.path).read_bytes() == package.read_bytes()
+    assert response.filename == "AI 手册-OCTX.octx"
 
 
 @pytest.mark.asyncio

--- a/apps/web/components/features/octx-export-provider.test.ts
+++ b/apps/web/components/features/octx-export-provider.test.ts
@@ -1,6 +1,45 @@
 import { describe, expect, it } from "vitest";
 
-import { projectDesktopDiagnostics } from "./octx-export-provider";
+import type { PersistedOctxExportTask } from "@/lib/octx-export-tasks";
+
+import { artifactFilename, projectDesktopDiagnostics } from "./octx-export-provider";
+
+describe("artifactFilename", () => {
+  it("preserves the knowledge base name and uses the OCTX suffix", () => {
+    const task = {
+      transferId: "transfer-1",
+      sourceId: "source-1",
+      sourceName: "AI 手册",
+      filenameHint: "AI 手册",
+      autoDownloaded: false,
+      createdAt: "2026-08-24T00:00:00.000Z",
+      transfer: {
+        id: "transfer-1",
+        direction: "export",
+        status: "ready",
+        progress: 1,
+        asset: null,
+        release: { id: "release-1", version: "1.0.0", package_digest: "sha256:test" },
+        target_source_id: "source-1",
+        installation_id: null,
+        allowed_actions: [],
+        decision_token: null,
+        conflicts: [],
+        excluded_documents: [],
+        record_counts: {},
+        capabilities: {},
+        validation_report: null,
+        warnings: [],
+        error: null,
+        cancellation_requested: false,
+        created_at: "2026-08-24T00:00:00.000Z",
+        updated_at: "2026-08-24T00:00:00.000Z",
+      },
+    } satisfies PersistedOctxExportTask;
+
+    expect(artifactFilename(task)).toBe("AI 手册-OCTX.octx");
+  });
+});
 
 describe("projectDesktopDiagnostics", () => {
   it("omits raw desktop log data from OCTX diagnostics downloads", () => {

--- a/apps/web/components/features/octx-export-provider.tsx
+++ b/apps/web/components/features/octx-export-provider.tsx
@@ -48,12 +48,13 @@ function triggerDownload(blob: Blob, filename: string) {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-function artifactFilename(task: PersistedOctxExportTask): string {
-  const version = task.transfer.release?.version ?? "release";
+export function artifactFilename(task: PersistedOctxExportTask): string {
   const stem = (task.filenameHint ?? task.transfer.asset?.name ?? task.sourceName ?? "source")
-    .replace(/[^\w.\-]+/g, "_")
-    .slice(0, 60);
-  return `${stem}-${version}.octx`;
+    .trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, "_")
+    .replace(/[. ]+$/g, "")
+    .slice(0, 80) || "source";
+  return `${stem}-OCTX.octx`;
 }
 
 function downloadJson(value: unknown, filename: string) {


### PR DESCRIPTION
## 改动范围
- 统一 OCTX 导出下载命名为“知识库名称-OCTX.octx”，移除不直观的内部版本号。
- 前端保留中文、空格等正常名称字符，仅替换文件系统不允许的字符；服务端直接下载使用相同规则。
- 增加前后端命名回归测试，覆盖中文知识库名称导出。

## 影响功能范围
- 知识库及单文档 OCTX 导出包的下载文件名更容易识别；重复下载继续由浏览器或系统追加序号，避免覆盖已有文件。
- 不改变 OCTX 包内容、Asset/Release 版本、存储键、导入流程或向量处理逻辑。

## 测试覆盖情况
- 通过：后端 Ruff 检查。
- 通过：后端完整测试，561 passed、1 skipped。
- 通过：Web TypeScript 类型检查、ESLint、542 个单元测试及 Next.js 生产构建。
- CI：发布安全回归、后端 Ruff + Pytest、PostgreSQL E2E、前端 TypeScript + Next.js 构建均通过。
