### PR TITLE
fix(storage): 修复 Windows 存量 OCTX 迁移续跑失败

### DIFF
--- a/apps/api/sag_api/upgrades/backup.py
+++ b/apps/api/sag_api/upgrades/backup.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from sag_api.upgrades.octx_files import copy_durable_octx
 from sag_api.upgrades.types import StorageLayout, StorageUpgradeError
 
 
@@ -133,10 +134,23 @@ def create_backup(layout: StorageLayout, migration_id: str, *, source_version: s
     temporary = Path(tempfile.mkdtemp(prefix=f".{migration_id}.", dir=layout.backups))
     try:
         engine_copy = temporary / "engine"
+        engine_octx = layout.engine / "octx"
+
+        def ignore_octx_root(directory: str, names: list[str]) -> set[str]:
+            if Path(directory) == layout.engine and "octx" in names:
+                return {"octx"}
+            return set()
+
         # Backup data bytes only. copy2 also replays source metadata, which can
         # turn OCTX artifacts into Windows read-only files and fail with
         # WinError 5 while copying or cleaning an interrupted backup.
-        shutil.copytree(layout.engine, engine_copy, copy_function=shutil.copyfile)
+        shutil.copytree(
+            layout.engine,
+            engine_copy,
+            ignore=ignore_octx_root,
+            copy_function=shutil.copyfile,
+        )
+        copy_durable_octx(engine_octx, engine_copy / "octx")
         engine_size, engine_sha256 = _tree_stats(engine_copy)
 
         sag_copy: Path | None = None

--- a/apps/api/sag_api/upgrades/octx_files.py
+++ b/apps/api/sag_api/upgrades/octx_files.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from pathlib import Path
+
+
+def _ignore_transient_staging(source: Path):
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        if Path(directory) == source and "staging" in names:
+            return {"staging"}
+        return set()
+
+    return ignore
+
+
+def _remove_readonly_tree(path: Path) -> None:
+    def retry_with_write_access(function, blocked_path, _error) -> None:
+        os.chmod(blocked_path, stat.S_IWRITE)
+        function(blocked_path)
+
+    shutil.rmtree(path, onerror=retry_with_write_access)
+
+
+def copy_durable_octx(source: Path, destination: Path, *, replace: bool = False) -> None:
+    """Copy persistent OCTX state without transient transfer workspaces or file metadata."""
+    if not source.is_dir():
+        return
+    if replace and destination.exists():
+        _remove_readonly_tree(destination)
+    shutil.copytree(
+        source,
+        destination,
+        ignore=_ignore_transient_staging(source),
+        copy_function=shutil.copyfile,
+    )

--- a/apps/api/sag_api/upgrades/swap.py
+++ b/apps/api/sag_api/upgrades/swap.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
-import shutil
 from pathlib import Path
 
+from sag_api.upgrades.octx_files import copy_durable_octx
 from sag_api.upgrades.types import StorageUpgradeError
 
 
@@ -36,12 +36,7 @@ def swap_engine(engine: Path, staging: Path, rollback: Path) -> None:
 
     preserved_octx = engine / "octx"
     if preserved_octx.is_dir():
-        shutil.copytree(
-            preserved_octx,
-            staging / "octx",
-            dirs_exist_ok=True,
-            copy_function=shutil.copyfile,
-        )
+        copy_durable_octx(preserved_octx, staging / "octx", replace=True)
 
     os.replace(engine, rollback)
     try:

--- a/apps/api/tests/test_storage_upgrade_recovery.py
+++ b/apps/api/tests/test_storage_upgrade_recovery.py
@@ -45,6 +45,44 @@ def test_backup_copies_octx_payload_without_windows_restricted_metadata(
     assert (backup.engine_path / artifact.relative_to(engine)).read_bytes() == b"existing-package"
 
 
+def test_backup_skips_transient_octx_staging_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = tmp_path / "engine"
+    release = engine / "octx" / "releases" / "asset" / "1.0.0" / "package.octx"
+    workspace = engine / "octx" / "workspaces" / "source" / ".octx" / "state.json"
+    transient = engine / "octx" / "staging" / "transfer" / "export-1" / "workspace" / "document.md"
+    for path, payload in (
+        (release, b"existing-package"),
+        (workspace, b"persistent-state"),
+        (transient, b"temporary-export"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+    layout = StorageLayout(
+        root=tmp_path,
+        engine=engine,
+        sag_db=None,
+        upgrades=tmp_path / ".storage-upgrades",
+        backups=tmp_path / ".storage-upgrades" / "backups",
+        staging=tmp_path / ".storage-upgrades" / "staging",
+    )
+    original_copyfile = shutil.copyfile
+
+    def reject_transient_staging(source, destination, *, follow_symlinks=True):
+        if Path(source).is_relative_to(engine / "octx" / "staging"):
+            raise FileNotFoundError(2, "No such file or directory", destination)
+        return original_copyfile(source, destination, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(shutil, "copyfile", reject_transient_staging)
+
+    backup = create_backup(layout, "migration", source_version="0.7.1")
+
+    assert (backup.engine_path / release.relative_to(engine)).read_bytes() == b"existing-package"
+    assert (backup.engine_path / workspace.relative_to(engine)).read_bytes() == b"persistent-state"
+    assert not (backup.engine_path / "octx" / "staging").exists()
+
+
 def test_swap_restores_original_when_second_rename_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     engine = tmp_path / "engine"
     staging = tmp_path / "staging"
@@ -100,6 +138,34 @@ def test_swap_preserves_octx_artifacts_in_current_engine(
 
     assert (engine / "octx" / artifact.relative_to(engine / "octx")).read_bytes() == b"existing-package"
     assert (rollback / "octx" / artifact.relative_to(engine / "octx")).read_bytes() == b"existing-package"
+
+
+def test_swap_replaces_octx_left_by_an_interrupted_windows_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = tmp_path / "engine"
+    staging = tmp_path / "staging"
+    rollback = tmp_path / "rollback"
+    artifact = engine / "octx" / "releases" / "asset" / "1.0.0" / "package.octx"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"existing-package")
+    stale = staging / artifact.relative_to(engine)
+    stale.parent.mkdir(parents=True)
+    stale.write_bytes(b"partial-package")
+    (staging / "marker").write_text("current", encoding="utf-8")
+    original_copyfile = shutil.copyfile
+
+    def reject_existing_destination(source, destination, *, follow_symlinks=True):
+        if Path(destination).exists():
+            raise PermissionError(5, "Access is denied", destination)
+        return original_copyfile(source, destination, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(shutil, "copyfile", reject_existing_destination)
+
+    swap_engine(engine, staging, rollback)
+
+    assert artifact.read_bytes() == b"existing-package"
+    assert (engine / "marker").read_text(encoding="utf-8") == "current"
 
 
 @pytest.mark.asyncio

--- a/apps/web/components/features/storage-bootstrap-gate.test.tsx
+++ b/apps/web/components/features/storage-bootstrap-gate.test.tsx
@@ -301,7 +301,9 @@ describe("StorageBootstrapGate interactions", () => {
 
   it("keeps the accepted choice locked when the submit response times out", async () => {
     setToken("owner-token");
-    vi.spyOn(api, "storageBootstrap").mockResolvedValue(status("choice_required"));
+    vi.spyOn(api, "storageBootstrap")
+      .mockResolvedValueOnce(status("choice_required"))
+      .mockRejectedValueOnce(new ApiError(0, "timeout", "请求超时，请检查网络后重试"));
     vi.spyOn(api, "chooseStorageBootstrap").mockRejectedValue(
       new ApiError(0, "timeout", "请求超时，请检查网络后重试"),
     );
@@ -312,6 +314,30 @@ describe("StorageBootstrapGate interactions", () => {
 
     expect(mounted.container.textContent).toContain("正在准备新的知识库存储");
     expect(mounted.container.textContent).not.toContain("请求超时");
+    expect([...mounted.container.querySelectorAll("button")]).toHaveLength(0);
+    await unmount(mounted.root, mounted.container);
+  });
+
+  it("uses authoritative processing state after a gateway timeout", async () => {
+    setToken("owner-token");
+    const load = vi
+      .spyOn(api, "storageBootstrap")
+      .mockResolvedValueOnce(status("choice_required"))
+      .mockResolvedValueOnce(status("processing", {
+        stage: "backup",
+        accepted_choice: "migrate",
+      }));
+    vi.spyOn(api, "chooseStorageBootstrap").mockRejectedValue(
+      new ApiError(504, "gateway_timeout", "Gateway Timeout"),
+    );
+    const mounted = await mountGate();
+
+    await click(button(mounted.container, "迁移旧知识库"));
+    await click(button(mounted.container, "确认并开始"));
+
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(mounted.container.textContent).toContain("正在备份业务数据");
+    expect(mounted.container.textContent).not.toContain("Gateway Timeout");
     expect([...mounted.container.querySelectorAll("button")]).toHaveLength(0);
     await unmount(mounted.root, mounted.container);
   });

--- a/apps/web/components/features/storage-bootstrap-gate.tsx
+++ b/apps/web/components/features/storage-bootstrap-gate.tsx
@@ -378,13 +378,18 @@ export function StorageBootstrapGate({ children }: { children: React.ReactNode }
         setStatus(previousStatus);
         return;
       }
-      const acceptedButResponseLost =
-        error instanceof ApiError &&
-        (error.status === 409 ||
-          (error.status === 0 && ["timeout", "network", "aborted"].includes(error.code)));
-      if (!acceptedButResponseLost) {
+      try {
+        const authoritativeStatus = await loadStatus(api.storageBootstrap);
+        if (!mountedRef.current) return;
+        if (authoritativeStatus.phase !== "choice_required") {
+          setStatus(authoritativeStatus);
+          return;
+        }
         setStatus(previousStatus);
         setErrorMessage(errorText(error, t("submitFailed")));
+      } catch {
+        // The POST and reconciliation result are both unknown. Keep the gate
+        // locked in processing so the status poller can converge safely.
       }
     } finally {
       submittingRef.current = false;


### PR DESCRIPTION
## 改动范围
- 存储升级备份：不再复制 `octx/staging` 临时导入导出工作目录，避免 Windows 备份路径变深后触发文件不存在或路径访问失败；正式 OCTX release 和持久化 workspace 仍完整备份。
- 存储切换续跑：清理 1.8.0 中断迁移留下的只读 OCTX 半成品后重新生成持久化快照，避免 1.8.1 重试再次触发拒绝访问。
- Web 迁移选择：提交“迁移/不迁移”后无论遇到冲突、网络错误还是 408/5xx 网关错误，都会先查询服务端权威状态；服务端已经受理时保持迁移页面锁定，避免重复选择触发并发迁移冲突。
- 回归测试：覆盖现场 `Errno 2` 临时 staging 失败、`WinError 5` 元数据失败、中断 swap 后目标文件不可覆盖，以及网关超时后服务端已受理的状态收敛。

## 影响功能范围
- Windows 桌面端：修复 1.7.0/1.8.0 存量数据升级在 OCTX 备份和存储切换阶段阻塞、导致 SAG 无法进入主界面的问题。
- macOS 桌面端：共用同一迁移逻辑；正式 OCTX 数据保持不变，临时 transfer staging 可由业务状态恢复，不参与灾备或引擎切换。
- Web：防止迁移选择请求经过代理超时后重复开放选择；不改变服务端实际迁移流程。
- 兼容性：不修改关系库、向量迁移、模型配置和 OCTX 正式产物格式。

## 测试覆盖情况
- 通过：`pytest` 存储引导与迁移测试组，46 passed，覆盖选择、备份、迁移、恢复、swap 和运行时安装。
- 通过：定向 Ruff，所有后端变更文件无问题。
- 通过：桌面端单元测试，6 passed。
- 通过：Web 存储迁移门禁单元测试，19 passed；Web TypeScript 类型检查和定向 ESLint 通过。
- CI：最新提交已通过后端 Ruff + 全套 pytest、PostgreSQL E2E、前端 typecheck/lint/unit/build 和发布安全回归。

## 发布验收边界
- 当前自动化验证覆盖默认 SQLite + LanceDB 升级路径，但不能替代 Windows/macOS 真实安装包从存量 1.7.0 升级的人工验收。
- Elasticsearch、pgvector、OceanBase 等 Web 自定义存储未包含在本 PR 的数据迁移支持范围内，发布前需单独确认现网使用情况和引擎兼容策略。
