### PR TITLE
fix(api): align extraction guidance with configured language

### DIFF
--- a/apps/api/sag_api/sag/incremental_processor.py
+++ b/apps/api/sag_api/sag/incremental_processor.py
@@ -58,15 +58,30 @@ StageCallback = Callable[[str], Awaitable[None]]
 
 log = get_logger("sag.incremental")
 
-_KNOWLEDGE_EVENT_REQUIREMENTS = """
-对于书籍、报告、论文等非新闻文档，"事项"也包括可独立理解的观点、事实、定义、
-机制、因果关系、论证和结论，不要求必须包含日期、人物动作或新闻事件。
-只有目录、页眉页脚、广告、乱码、纯链接，或确实与文档主题无关的片段才可返回空结果；
-正文只要包含可复用的知识，就至少保留一个有效的顶级事项。
-每个实体必须严格使用 {"type":"实体类型","name":"实体名称","description":"作用说明"}；
-禁止把实体类型写成字段名，例如不能输出
-{"location":"中东","name":"中东","description":"地区"}。
-""".strip()
+_KNOWLEDGE_EVENT_REQUIREMENTS = {
+    "zh": (
+        '对于书籍、报告、论文等非新闻文档，"事项"也包括可独立理解的观点、事实、定义、\n'
+        "机制、因果关系、论证和结论，不要求必须包含日期、人物动作或新闻事件。\n"
+        "只有目录、页眉页脚、广告、乱码、纯链接，或确实与文档主题无关的片段才可返回空结果；\n"
+        "正文只要包含可复用的知识，就至少保留一个有效的顶级事项。\n"
+        '每个实体必须严格使用 {"type":"实体类型","name":"实体名称","description":"作用说明"}；\n'
+        "禁止把实体类型写成字段名，例如不能输出\n"
+        '{"location":"中东","name":"中东","description":"地区"}。'
+    ),
+    "en": (
+        'For books, reports, papers, and other non-news documents, an "event" also includes\n'
+        "independently understandable viewpoints, facts, definitions, mechanisms, causal\n"
+        "relationships, arguments, and conclusions. It does not need to include a date, a person's\n"
+        "action, or a news event.\n"
+        "Only tables of contents, headers, footers, advertisements, corrupted text, standalone links,\n"
+        "or fragments genuinely unrelated to the document topic may return an empty result. Retain at\n"
+        "least one valid top-level event whenever the main text contains reusable knowledge.\n"
+        "Every entity must strictly use\n"
+        '{"type":"entity type","name":"entity name","description":"role description"}.\n'
+        "Do not use an entity type as a field name. For example, do not output\n"
+        '{"location":"Middle East","name":"Middle East","description":"region"}.'
+    ),
+}
 
 # 进度观察节流:避免把 zleap 的每个 progress 事件都转换成一次 DB 断点写入。
 _PROGRESS_COMMIT_EVERY = 5
@@ -213,12 +228,17 @@ class IncrementalDocumentProcessor:
         on_checkpoint: CheckpointCallback,
     ) -> tuple[bool, Any]:
         """整批抽取;暂停由 CancellationToken + 后台轮询驱动,进度经 observer 透出。"""
+        prompt_language = getattr(getattr(self._engine.resources, "prompts", None), "language", None)
+        requirements = _KNOWLEDGE_EVENT_REQUIREMENTS.get(prompt_language)
+        if requirements is None:
+            raise RuntimeError(f"不支持的抽取提示词语言: {prompt_language!r}")
+
         options = ExtractionOptions(
             source_type="article",
             contract="rich",
             limits=ExtractionLimits(min_entities_per_event=1),
             execution=ExtractionExecutionOptions(max_concurrency=self._max_concurrency),
-            guidance_rules=(_KNOWLEDGE_EVENT_REQUIREMENTS,),
+            guidance_rules=(requirements,),
         )
         cancellation = CancellationToken()
 

--- a/apps/api/tests/test_document_resume.py
+++ b/apps/api/tests/test_document_resume.py
@@ -55,10 +55,15 @@ async def _processor_with_fake_engine(
     max_concurrency=30,
     chunk_mode="standard",
     document_title="doc",
+    language="zh",
 ):
     from sag_api.sag.incremental_processor import IncrementalDocumentProcessor
 
-    engine = SimpleNamespace(ingest=ingest, extract=extract)
+    engine = SimpleNamespace(
+        ingest=ingest,
+        extract=extract,
+        resources=SimpleNamespace(prompts=SimpleNamespace(language=language)),
+    )
     processor = IncrementalDocumentProcessor(
         engine,
         "source-config",
@@ -175,7 +180,38 @@ async def test_extract_receives_contract_limits_and_concurrency():
     assert options.source_type == "article"
     assert options.limits.min_entities_per_event == 1
     assert options.execution.max_concurrency == 30
-    assert options.guidance_rules  # 知识型事项要求仍然透传
+    assert "观点、事实、定义" in options.guidance_rules[0]  # 默认中文知识型事项要求仍然透传
+
+
+@pytest.mark.asyncio
+async def test_extract_guidance_matches_english_engine_prompt_language():
+    """英文引擎不能继续收到中文的 SAG 业务规则。"""
+    from sag_api.sag.dto import ProcessCheckpoint
+
+    captured: dict = {}
+
+    async def extract(chunk_set, options, *, observer, cancellation):
+        captured["options"] = options
+        return _event_ref()
+
+    processor = await _processor_with_fake_engine(extract=extract, language="en")
+
+    await processor.process(
+        None,
+        checkpoint=ProcessCheckpoint(
+            source_id="article-1",
+            chunk_ids=["c1", "c2"],
+            generation_id="gen-1",
+            chunk_version="cv-1",
+            source_version="sv-1",
+        ),
+        on_checkpoint=_noop_checkpoint,
+        should_pause=_return_false,
+    )
+
+    (guidance,) = captured["options"].guidance_rules
+    assert "For books, reports, papers" in guidance
+    assert "观点、事实、定义" not in guidance
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 改动范围
- API 文档抽取：按当前 DataEngine 实际加载的 `zh/en` PromptManager 语言选择 SAG 知识事项规则，避免官方提示词与业务规则语言冲突。
- 回归测试：覆盖默认中文规则保持不变，以及英文引擎只接收英文业务规则；Fixes #150。

## 影响功能范围
- 文档抽取：`sag_language=en` 时不再无条件注入中文 `guidance_rules`；默认 `zh` 行为和原中文规则保持不变。
- 兼容性：不修改 zleap-sag、数据库结构、断点、历史数据或文档语言识别逻辑；已有文档需要重新处理后才会生成新的实体结果。

## 测试覆盖情况
- 通过：`ruff check sag_api/ sag_agent/ tests/`，覆盖后端静态检查。
- 通过：`python -m pytest -q tests/test_document_resume.py`，35 项文档抽取与恢复测试通过。
- 通过：`python -m pytest -q`，567 项通过、1 项跳过，覆盖离线后端全套测试。
- CI：GitHub Actions 的发布安全回归、后端全套、PostgreSQL E2E 与前端构建均通过。
