### PR TITLE
fix(api): preserve unset embedding dimensions

### DIFF
--- a/apps/api/sag_api/sag/config_builder.py
+++ b/apps/api/sag_api/sag/config_builder.py
@@ -104,9 +104,9 @@ def build_engine_config(settings: Settings, *, overrides: dict[str, Any] | None 
         model=settings.embedding_model,
         base_url=settings.effective_embedding_base_url,
         api_key=settings.effective_embedding_api_key or _PLACEHOLDER,
-        # 0.8.2:pgvector/oceanbase 建向量模式对象必须显式维度;SAG 默认模型
-        # bge-large-en-v1.5 为 1024 维,未配置 SAG_EMBEDDING_DIMENSIONS 时按此兜底。
-        dimensions=settings.embedding_dimensions or 1024,
+        # 未配置时保持 None：引擎会从首批真实向量推断存储 schema，
+        # 同时避免向不支持 dimensions 参数的 Embedding API 发送该字段。
+        dimensions=settings.embedding_dimensions,
     )
 
     return EngineConfig(

--- a/apps/api/sag_api/sag/config_builder.py
+++ b/apps/api/sag_api/sag/config_builder.py
@@ -104,9 +104,8 @@ def build_engine_config(settings: Settings, *, overrides: dict[str, Any] | None 
         model=settings.embedding_model,
         base_url=settings.effective_embedding_base_url,
         api_key=settings.effective_embedding_api_key or _PLACEHOLDER,
-        # 未配置时保持 None：引擎会从首批真实向量推断存储 schema，
-        # 同时避免向不支持 dimensions 参数的 Embedding API 发送该字段。
-        dimensions=settings.embedding_dimensions,
+        # 当前引擎以该值预建向量 schema；未显式配置时保持既有 1024 维默认值。
+        dimensions=settings.embedding_dimensions or 1024,
     )
 
     return EngineConfig(

--- a/apps/api/sag_api/sag/engine_manager.py
+++ b/apps/api/sag_api/sag/engine_manager.py
@@ -21,6 +21,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from zleap.sag import DataEngine
 from zleap.sag.pipeline import SearchOptions, SearchRequest, SearchScope
@@ -485,6 +486,23 @@ class EngineManager:
             overrides = source.config.get("engine")
         return build_engine_config(self._settings, overrides=overrides)
 
+    def _configure_embedding_request_dimensions(self, engine: DataEngine) -> None:
+        """Apply the narrow provider workaround after schema initialization.
+
+        zleap-sag 0.12.0 shares ``EmbeddingConfig.dimensions`` between vector
+        schema creation and the OpenAI-compatible request body. SiliconFlow's
+        BAAI/bge-m3 returns a fixed 1024-dimensional vector but rejects the
+        optional request parameter. Keep the configured 1024 for schema setup,
+        then omit it from only this verified incompatible request path.
+        """
+        if self._settings.embedding_dimensions is not None:
+            return
+        hostname = (urlparse(self._settings.effective_embedding_base_url or "").hostname or "").lower()
+        model = self._settings.embedding_model.strip().lower()
+        if hostname != "api.siliconflow.cn" or model != "baai/bge-m3":
+            return
+        engine.resources.embedding.dimensions = None
+
     async def _ensure_engine_schema(self, engine: DataEngine) -> None:
         if self._schema_ready:
             return
@@ -590,6 +608,7 @@ class EngineManager:
                         # init_schema() 显式创建关系表与向量模式对象,否则 start()
                         # 抛 StorageInitializationRequiredError。
                         await self._ensure_engine_schema(engine)
+                        self._configure_embedding_request_dimensions(engine)
                         await engine.start()
                         await self._configure_sqlite_document_store(engine)
                     try:

--- a/apps/api/tests/test_octx_vector_protocol.py
+++ b/apps/api/tests/test_octx_vector_protocol.py
@@ -305,7 +305,15 @@ def _compatible_identity(dimensions: int) -> dict:
     )
 
 
-async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_mismatch(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("configured_dimensions", "generated_vector"),
+    [(None, [0.4, 0.5, 0.6]), (2, [0.4, 0.5])],
+)
+async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_are_unknown_or_mismatched(
+    tmp_path: Path,
+    configured_dimensions: int | None,
+    generated_vector: list[float],
+) -> None:
     from sag_api.sag.octx_importer import build_structured_plan
     from sag_api.sag.octx_vector_protocol import vector_profile_from_identity
 
@@ -321,20 +329,20 @@ async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_mismatch(tmp_p
     plan_path = tmp_path / "dim-mismatch-plan.sqlite3"
     build_structured_plan(package, plan_path, str(uuid.uuid4()))
 
-    class TwoDimEmbedding:
+    class Embedding:
         model = "test/embedding"
         base_url = "https://embedding.invalid/v1"
-        dimensions = 2
+        dimensions = configured_dimensions
 
         def __init__(self) -> None:
             self.calls: list[list[str]] = []
 
         async def batch_generate(self, texts):
             self.calls.append(list(texts))
-            return [[0.4, 0.5] for _ in texts]
+            return [generated_vector for _ in texts]
 
-    embedding = TwoDimEmbedding()
-    # A dimension mismatch must disable reuse without crashing the import.
+    embedding = Embedding()
+    # An unknown or mismatched dimension must disable reuse without crashing the import.
     assert prepare_vector_reuse(package, plan_path, embedding) == set()
 
     from sag_api.sag.octx_vector_rebuilder import _vectors_for_role
@@ -346,7 +354,7 @@ async def test_prepare_vector_reuse_rebuilds_role_when_dimensions_mismatch(tmp_p
         embedding,
         plan_path=plan_path,
     )
-    assert regenerated == [[0.4, 0.5]]
+    assert regenerated == [generated_vector]
     assert embedding.calls == [["Head\n\nBody"]]
 
 

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -55,6 +55,88 @@ def test_build_engine_config_zero_infra():
     assert cfg.data_dir == settings.data_dir
 
 
+@pytest.mark.parametrize(
+    ("configured_dimensions", "expected_dimensions"),
+    [(None, None), (1024, 1024)],
+)
+def test_engine_config_preserves_embedding_dimensions(configured_dimensions, expected_dimensions):
+    configured = Settings(_env_file=None, embedding_dimensions=configured_dimensions)
+
+    assert build_engine_config(configured).embedding.dimensions == expected_dimensions
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_dimensions", "expected_request_dimensions"),
+    [(None, None), (1024, 1024)],
+)
+async def test_embedding_request_respects_configured_dimensions(
+    configured_dimensions,
+    expected_request_dimensions,
+    monkeypatch,
+):
+    from zleap.sag.core.ai.embedding import EmbeddingClient
+
+    config = build_engine_config(Settings(_env_file=None, embedding_dimensions=configured_dimensions))
+    embedding = EmbeddingClient(
+        model=config.embedding.model,
+        api_key=config.embedding.api_key,
+        base_url=config.embedding.base_url,
+        dimensions=config.embedding.dimensions,
+        max_retries=0,
+    )
+    requests: list[dict] = []
+
+    async def create(**request):
+        requests.append(request)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(embedding.client.embeddings, "create", create)
+
+    await embedding._create_embeddings("test input", label="test")
+
+    assert requests == [
+        {
+            "input": "test input",
+            "model": config.embedding.model,
+            **({"dimensions": expected_request_dimensions} if expected_request_dimensions is not None else {}),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["lancedb", "es", "pgvector", "oceanbase"])
+async def test_unconfigured_embedding_defers_vector_schema_creation_to_first_real_vector(provider):
+    from zleap.sag.core.storage.schema import prepare_vector_schema
+
+    class VectorAdapter:
+        def __init__(self) -> None:
+            self.provider = provider
+            self.created: list[tuple[str, int]] = []
+
+        async def schema_object_names(self):
+            return frozenset()
+
+        async def validate_schema_object(self, _name, _dimensions):
+            raise AssertionError("no schema object exists before the first vector")
+
+        async def create_schema_object(self, name, dimensions):
+            self.created.append((name, dimensions))
+
+    config = build_engine_config(Settings(_env_file=None, embedding_dimensions=None))
+    adapter = VectorAdapter()
+
+    scan = await prepare_vector_schema(
+        adapter,
+        storage_mode="normal",
+        dimensions=config.embedding.dimensions,
+        create_missing=True,
+    )
+
+    assert adapter.created == []
+    assert scan.missing_objects
+
+
 def test_engine_config_presets_structured_output_mode_by_model():
     from zleap.sag.core.ai.structured import StructuredOutputMode
 

--- a/apps/api/tests/test_units.py
+++ b/apps/api/tests/test_units.py
@@ -57,7 +57,7 @@ def test_build_engine_config_zero_infra():
 
 @pytest.mark.parametrize(
     ("configured_dimensions", "expected_dimensions"),
-    [(None, None), (1024, 1024)],
+    [(None, 1024), (1024, 1024)],
 )
 def test_engine_config_preserves_embedding_dimensions(configured_dimensions, expected_dimensions):
     configured = Settings(_env_file=None, embedding_dimensions=configured_dimensions)
@@ -67,17 +67,31 @@ def test_engine_config_preserves_embedding_dimensions(configured_dimensions, exp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("configured_dimensions", "expected_request_dimensions"),
-    [(None, None), (1024, 1024)],
+    ("base_url", "model", "configured_dimensions", "expected_request_dimensions"),
+    [
+        ("https://api.siliconflow.cn/v1", "BAAI/bge-m3", None, None),
+        ("https://api.openai.com/v1", "text-embedding-3-large", None, 1024),
+        ("https://api.siliconflow.cn/v1", "BAAI/bge-m3", 1024, 1024),
+    ],
 )
 async def test_embedding_request_respects_configured_dimensions(
+    base_url,
+    model,
     configured_dimensions,
     expected_request_dimensions,
     monkeypatch,
 ):
     from zleap.sag.core.ai.embedding import EmbeddingClient
 
-    config = build_engine_config(Settings(_env_file=None, embedding_dimensions=configured_dimensions))
+    from sag_api.sag.engine_manager import EngineManager
+
+    settings = Settings(
+        _env_file=None,
+        embedding_base_url=base_url,
+        embedding_model=model,
+        embedding_dimensions=configured_dimensions,
+    )
+    config = build_engine_config(settings)
     embedding = EmbeddingClient(
         model=config.embedding.model,
         api_key=config.embedding.api_key,
@@ -85,6 +99,8 @@ async def test_embedding_request_respects_configured_dimensions(
         dimensions=config.embedding.dimensions,
         max_retries=0,
     )
+    engine = SimpleNamespace(resources=SimpleNamespace(embedding=embedding))
+    EngineManager(settings)._configure_embedding_request_dimensions(engine)
     requests: list[dict] = []
 
     async def create(**request):
@@ -106,22 +122,24 @@ async def test_embedding_request_respects_configured_dimensions(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ["lancedb", "es", "pgvector", "oceanbase"])
-async def test_unconfigured_embedding_defers_vector_schema_creation_to_first_real_vector(provider):
+async def test_unconfigured_embedding_prebuilds_vector_schema_with_legacy_default(provider):
     from zleap.sag.core.storage.schema import prepare_vector_schema
 
     class VectorAdapter:
         def __init__(self) -> None:
             self.provider = provider
             self.created: list[tuple[str, int]] = []
+            self.names: set[str] = set()
 
         async def schema_object_names(self):
-            return frozenset()
+            return frozenset(self.names)
 
-        async def validate_schema_object(self, _name, _dimensions):
-            raise AssertionError("no schema object exists before the first vector")
+        async def validate_schema_object(self, _name, dimensions):
+            assert dimensions == 1024
 
         async def create_schema_object(self, name, dimensions):
             self.created.append((name, dimensions))
+            self.names.add(name)
 
     config = build_engine_config(Settings(_env_file=None, embedding_dimensions=None))
     adapter = VectorAdapter()
@@ -133,8 +151,9 @@ async def test_unconfigured_embedding_defers_vector_schema_creation_to_first_rea
         create_missing=True,
     )
 
-    assert adapter.created == []
-    assert scan.missing_objects
+    assert adapter.created
+    assert {dimensions for _, dimensions in adapter.created} == {1024}
+    assert not scan.missing_objects
 
 
 def test_engine_config_presets_structured_output_mode_by_model():


### PR DESCRIPTION
## 改动范围
- `apps/api/sag_api/sag/config_builder.py`：未配置 `embedding_dimensions` 时保持既有 1024 维 schema 默认值，确保 pgvector 等后端可在启动阶段完成初始化。
- `apps/api/sag_api/sag/engine_manager.py`：仅对 SiliconFlow `BAAI/bge-m3` 的未显式维度配置，在 schema 初始化后移除 Embedding 请求中的 `dimensions` 参数。
- `apps/api/tests/test_units.py`：覆盖 schema 默认值、SiliconFlow 请求兼容性、显式维度与其他服务商的既有行为，以及四类向量后端的 schema 初始化合同。
- `apps/api/tests/test_octx_vector_protocol.py`：覆盖 OCTX 在维度未知或不匹配时禁用向量复用并重建向量。

## 影响功能范围
- 修复 #159：SiliconFlow `BAAI/bge-m3` 在未配置维度时可完成向量库初始化，并向 Embedding API 发起不含 `dimensions` 的请求。
- OCTX 导入导出格式不变；未显式配置维度时导入会安全降级为全量重建向量，可能增加该次导入的耗时与 Embedding 成本。
- 用户显式配置的维度值、其他模型及服务商请求行为保持不变；未发现额外的数据迁移、导出协议或其他仓库影响。

## 测试覆盖情况
- 通过：`uv run --project . --extra dev ruff check sag_api/sag/config_builder.py sag_api/sag/engine_manager.py tests/test_units.py tests/test_octx_vector_protocol.py`，覆盖本次变更的静态检查。
- 通过：`uv run --project . --extra dev pytest -q tests/test_units.py tests/test_octx_vector_protocol.py tests/test_storage_bootstrap_contract.py tests/test_storage_bootstrap_fresh.py tests/test_storage_upgrade_vectors.py tests/test_postgres_schema_e2e.py`，77 项通过、1 项跳过，覆盖配置请求、OCTX 降级与存储 schema 启动合同。
- 未执行：真实 SiliconFlow、PostgreSQL、Elasticsearch、OceanBase 环境联调；原因是本地 CI 无相应服务与凭据。
- CI：待远程 CI 执行。
